### PR TITLE
Make required markdown prop

### DIFF
--- a/android/src/main/java/com/richtext/RichTextView.kt
+++ b/android/src/main/java/com/richtext/RichTextView.kt
@@ -100,7 +100,7 @@ class RichTextView : AppCompatTextView {
     val newStyle = style?.let { RichTextStyle(it) }
     val styleChanged = richTextStyle != newStyle
     richTextStyle = newStyle
-    if (styleChanged && currentMarkdown.isNotEmpty()) {
+    if (styleChanged) {
       renderMarkdown()
     }
   }

--- a/ios/parser/MarkdownParser.mm
+++ b/ios/parser/MarkdownParser.mm
@@ -169,7 +169,7 @@ static int md4c_text_callback(MD_TEXTTYPE type, const MD_CHAR *text, MD_SIZE siz
 @implementation MarkdownParser
 
 - (MarkdownASTNode *)parseMarkdown:(NSString *)markdown {
-    if (!markdown || markdown.length == 0) {
+    if (markdown.length == 0) {
         return [[MarkdownASTNode alloc] initWithType:MarkdownNodeTypeDocument];
     }
     

--- a/src/RichTextViewNativeComponent.ts
+++ b/src/RichTextViewNativeComponent.ts
@@ -46,7 +46,7 @@ export interface NativeProps extends ViewProps {
   /**
    * Markdown content to render.
    */
-  markdown?: string;
+  markdown: string;
   /**
    * Base font size for all text elements.
    */


### PR DESCRIPTION
## Why?

Makes the `markdown` prop required instead of optional, and removes unnecessary empty/null checks in native code since markdown is always provided from the TypeScript side.