### PR TITLE
 Remove fontStyle prop from RichTextView

### DIFF
--- a/android/src/main/java/com/richtext/RichTextView.kt
+++ b/android/src/main/java/com/richtext/RichTextView.kt
@@ -7,7 +7,6 @@ import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatTextView
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.views.text.ReactTypefaceUtils.applyStyles
-import com.facebook.react.views.text.ReactTypefaceUtils.parseFontStyle
 import com.facebook.react.views.text.ReactTypefaceUtils.parseFontWeight
 import com.facebook.react.bridge.ReadableMap
 import android.graphics.Canvas
@@ -28,7 +27,6 @@ class RichTextView : AppCompatTextView {
 
   var fontSize: Float? = null
   private var fontFamily: String? = null
-  private var fontStyle: Int = ReactConstants.UNSET
   private var fontWeight: Int = ReactConstants.UNSET
 
   var richTextStyle: RichTextStyle? = null
@@ -147,15 +145,6 @@ class RichTextView : AppCompatTextView {
     }
   }
 
-  fun setFontStyle(style: String?) {
-    val parsedStyle = parseFontStyle(style)
-    if (parsedStyle != fontStyle) {
-      fontStyle = parsedStyle
-      typefaceDirty = true
-      updateTypeface()
-    }
-  }
-
   fun setColor(color: Int?) {
     if (color != null) {
       setTextColor(color)
@@ -184,7 +173,7 @@ class RichTextView : AppCompatTextView {
     if (!typefaceDirty) return
     typefaceDirty = false
 
-    val newTypeface = applyStyles(typeface, fontStyle, fontWeight, fontFamily, context.assets)
+    val newTypeface = applyStyles(typeface, ReactConstants.UNSET, fontWeight, fontFamily, context.assets)
     setTypeface(newTypeface)
   }
 

--- a/android/src/main/java/com/richtext/RichTextViewManager.kt
+++ b/android/src/main/java/com/richtext/RichTextViewManager.kt
@@ -66,11 +66,6 @@ class RichTextViewManager : SimpleViewManager<RichTextView>(),
     view?.setFontWeight(weight)
   }
 
-  @ReactProp(name = "fontStyle")
-  override fun setFontStyle(view: RichTextView?, style: String?) {
-    view?.setFontStyle(style)
-  }
-
   @ReactProp(name = "richTextStyle")
   override fun setRichTextStyle(view: RichTextView?, style: com.facebook.react.bridge.ReadableMap?) {
     view?.setRichTextStyle(style)

--- a/ios/RichTextView.mm
+++ b/ios/RichTextView.mm
@@ -27,7 +27,6 @@ static const CGFloat kLabelPadding = 10.0;
 - (void)setupConstraints;
 - (void)renderMarkdownContent:(NSString *)markdownString withProps:(const RichTextViewProps &)props;
 - (void)textTapped:(UITapGestureRecognizer *)recognizer;
-- (UIFont *)createFontWithFamily:(NSString *)fontFamily size:(CGFloat)size weight:(NSString *)weight style:(NSString *)style;
 - (void)setupLayoutManager;
 @end
 
@@ -184,9 +183,6 @@ oldProps:(Props::Shared const &)oldProps {
         _config = [[RichTextConfig alloc] init];
     }
         
-    // Update existing config object's properties
-    // Instead of creating a new config, we update the existing one that the layout manager references
-
     if (newViewProps.color != oldViewProps.color) {
         if (newViewProps.color) {
             UIColor *uiColor = RCTUIColorFromSharedColor(newViewProps.color);
@@ -485,23 +481,5 @@ Class<RCTComponentViewProtocol> RichTextViewCls(void)
     }
 }
 
-- (UIFont *)createFontWithFamily:(NSString *)fontFamily size:(CGFloat)size weight:(NSString *)weight style:(NSString *)style {
-    // Use React Native's RCTFont.updateFont for consistent font handling
-    NSString *fontWeight = weight && weight.length > 0 ? weight : nullptr;
-    NSString *fontStyle = style && style.length > 0 ? style : nullptr;
-    
-    // Handle edge case: weight "0" should be treated as nullptr
-    if ([fontWeight isEqualToString:@"0"]) {
-        fontWeight = nullptr;
-    }
-    
-    return [RCTFont updateFont:nullptr
-                   withFamily:fontFamily
-                          size:@(size)
-                        weight:fontWeight
-                         style:fontStyle
-                      variant:nullptr
-                scaleMultiplier:1];
-}
 
 @end

--- a/src/RichTextView.tsx
+++ b/src/RichTextView.tsx
@@ -65,7 +65,6 @@ export const RichTextView = ({
   fontSize,
   fontFamily,
   fontWeight,
-  fontStyle,
   color,
   style = {},
   containerStyle,
@@ -81,7 +80,6 @@ export const RichTextView = ({
       fontSize={fontSize}
       fontFamily={fontFamily}
       fontWeight={fontWeight}
-      fontStyle={fontStyle}
       color={color}
       richTextStyle={normalizedStyle}
       onLinkPress={onLinkPress}

--- a/src/RichTextViewNativeComponent.ts
+++ b/src/RichTextViewNativeComponent.ts
@@ -61,11 +61,6 @@ export interface NativeProps extends ViewProps {
    */
   fontWeight?: string;
   /**
-   * Font style for all text elements.
-   * @example "normal", "italic"
-   */
-  fontStyle?: string;
-  /**
    * Text color in hex format.
    */
   color?: ColorValue;


### PR DESCRIPTION
## Why?

Removes the unused `fontStyle` prop from the component API. Font styling (italic) is already handled by markdown's emphasis element (`*text*` or `_text_`), making a separate `fontStyle` prop redundant and potentially confusing.