### PR TITLE
Add link press event type

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ The library provides sensible default styles for all Markdown elements out of th
 | `markdown` | `string` | Required | The Markdown content to render |
 | `markdownStyle` | `MarkdownStyle` | `{}` | Style configuration for Markdown elements |
 | `containerStyle` | `ViewStyle` | - | Style for the container view |
-| `onLinkPress` | `(event) => void` | - | Callback when a link is pressed |
+| `onLinkPress` | `(event: LinkPressEvent) => void` | - | Callback when a link is pressed. Access URL via `event.url` |
 | `isSelectable` | `boolean` | `true` | Whether text can be selected |
 
 ## Contributing

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,8 @@
 import { StyleSheet, ScrollView, Alert, Linking } from 'react-native';
-import { EnrichedMarkdownText } from 'react-native-enriched-markdown';
+import {
+  EnrichedMarkdownText,
+  type LinkPressEvent,
+} from 'react-native-enriched-markdown';
 
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -171,8 +174,8 @@ Built with ❤️ using **React Native Fabric Architecture**
 // `;
 
 export default function App() {
-  const handleLinkPress = (event: { nativeEvent: { url: string } }) => {
-    const { url } = event.nativeEvent;
+  const handleLinkPress = (event: LinkPressEvent) => {
+    const { url } = event;
     Alert.alert('Link Pressed!', `You tapped on: ${url}`, [
       {
         text: 'Open in Browser',

--- a/src/EnrichedMarkdownText.tsx
+++ b/src/EnrichedMarkdownText.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import EnrichedMarkdownTextNativeComponent, {
   type NativeProps,
+  type LinkPressEvent,
 } from './EnrichedMarkdownTextNativeComponent';
 import { normalizeMarkdownStyle } from './normalizeMarkdownStyle';
-import type { ViewStyle, TextStyle } from 'react-native';
+import type { ViewStyle, TextStyle, NativeSyntheticEvent } from 'react-native';
 
 interface BaseBlockStyle {
   fontSize?: number;
@@ -99,7 +100,7 @@ export interface MarkdownStyle {
 }
 
 export interface EnrichedMarkdownTextProps
-  extends Omit<NativeProps, 'markdownStyle' | 'style'> {
+  extends Omit<NativeProps, 'markdownStyle' | 'style' | 'onLinkPress'> {
   /**
    * Style configuration for markdown elements
    */
@@ -108,6 +109,11 @@ export interface EnrichedMarkdownTextProps
    * Style for the container view.
    */
   containerStyle?: ViewStyle | TextStyle;
+  /**
+   * Callback fired when a link is pressed.
+   * Receives the link URL directly.
+   */
+  onLinkPress?: (event: LinkPressEvent) => void;
 }
 
 export const EnrichedMarkdownText = ({
@@ -123,11 +129,19 @@ export const EnrichedMarkdownText = ({
     [markdownStyle]
   );
 
+  const handleLinkPress = useCallback(
+    (e: NativeSyntheticEvent<LinkPressEvent>) => {
+      const { url } = e.nativeEvent;
+      onLinkPress?.({ url });
+    },
+    [onLinkPress]
+  );
+
   return (
     <EnrichedMarkdownTextNativeComponent
       markdown={markdown}
       markdownStyle={normalizedStyle}
-      onLinkPress={onLinkPress}
+      onLinkPress={handleLinkPress}
       isSelectable={isSelectable}
       style={containerStyle}
       {...rest}

--- a/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/src/EnrichedMarkdownTextNativeComponent.ts
@@ -99,6 +99,10 @@ export interface MarkdownStyleInternal {
   thematicBreak: ThematicBreakStyleInternal;
 }
 
+export interface LinkPressEvent {
+  url: string;
+}
+
 export interface NativeProps extends ViewProps {
   /**
    * Markdown content to render.
@@ -114,7 +118,7 @@ export interface NativeProps extends ViewProps {
    * Callback fired when a link is pressed.
    * Receives the URL that was tapped.
    */
-  onLinkPress?: CodegenTypes.BubblingEventHandler<{ url: string }>;
+  onLinkPress?: CodegenTypes.BubblingEventHandler<LinkPressEvent>;
   /**
    * - iOS: Controls text selection and link previews on long press.
    * - Android: Controls text selection.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,3 +4,4 @@ export type {
   EnrichedMarkdownTextProps,
   MarkdownStyle,
 } from './EnrichedMarkdownText';
+export type { LinkPressEvent } from './EnrichedMarkdownTextNativeComponent';


### PR DESCRIPTION
### What/Why?
Export `LinkPressEvent` type and improve `onLinkPress` callback API for better developer experience.

**Changes:**
- Export `LinkPressEvent` interface from package
- Unwrap `nativeEvent` internally so users get clean payload: `({ url }) => ...` instead of `(e) => e.nativeEvent.url`
- Update README with proper type documentation

### Testing
- Verified `LinkPressEvent` type is importable from `react-native-enriched-markdown`
- Tested `onLinkPress` callback receives `{ url }` directly
- Example app updated and works on iOS/Android

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Updated documentation/README if applicable
- [x] Code compiles and runs on Android
- [x] Ran example app to verify changes

