### PR TITLE
Fix android ios text styling issues

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -155,8 +155,8 @@ object MeasurementStore {
     }
 
     val layout = builder.build()
-    // Add small buffer to prevent edge-case clipping
-    val measuredHeight = layout.height.toFloat() + 1f
+    val measuredHeight = layout.height.toFloat()
+
     return YogaMeasureOutput.make(
       PixelUtil.toDIPFromPixel(maxWidth),
       PixelUtil.toDIPFromPixel(measuredHeight),

--- a/android/src/main/java/com/swmansion/enriched/markdown/renderer/TextRenderer.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/renderer/TextRenderer.kt
@@ -17,13 +17,6 @@ class TextRenderer : NodeRenderer {
 
     val blockType = factory.blockStyleContext.currentBlockType
 
-    // Skip TextSpan for paragraph text - it will use TextView's default style
-    // Only apply TextSpan for headings, blockquotes, code blocks, lists where style differs
-    if (blockType == BlockType.PARAGRAPH) {
-      builder.append(content)
-      return
-    }
-
     factory.renderWithSpan(builder, { builder.append(content) }) { start, end, blockStyle ->
       builder.setSpan(
         TextSpan(blockStyle, factory.context),

--- a/android/src/main/java/com/swmansion/enriched/markdown/spans/MarginBottomSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/spans/MarginBottomSpan.kt
@@ -37,6 +37,12 @@ class MarginBottomSpan(
         fm.ascent = 0
         fm.descent = marginPixels
         fm.bottom = marginPixels
+      } else {
+        // No content after - collapse the spacer line to zero height
+        fm.top = 0
+        fm.ascent = 0
+        fm.descent = 0
+        fm.bottom = 0
       }
       return
     }

--- a/ios/utils/ParagraphStyleUtils.m
+++ b/ios/utils/ParagraphStyleUtils.m
@@ -48,15 +48,9 @@ void applyLineHeight(NSMutableAttributedString *output, NSRange range, CGFloat l
   }
 
   NSMutableParagraphStyle *style = getOrCreateParagraphStyle(output, range.location);
-  UIFont *font = [output attribute:NSFontAttributeName atIndex:range.location effectiveRange:NULL];
-  if (!font) {
-    return;
-  }
 
-  style.lineHeightMultiple = lineHeight / font.pointSize;
-  style.minimumLineHeight = 0;
-  style.maximumLineHeight = 0;
-  style.lineSpacing = 0;
+  style.minimumLineHeight = lineHeight;
+  style.maximumLineHeight = lineHeight;
 
   [output addAttribute:NSParagraphStyleAttributeName value:style range:range];
 }

--- a/src/normalizeMarkdownStyle.ts
+++ b/src/normalizeMarkdownStyle.ts
@@ -29,21 +29,13 @@ const getSystemFont = () =>
     default: 'sans-serif',
   });
 
-// Helper to get platform-specific line height multiplier
-const getLineHeightMultiplier = (baseMultiplier: number) =>
-  Platform.select({
-    ios: baseMultiplier * 0.75, // Tighter line height on iOS
-    android: baseMultiplier,
-    default: baseMultiplier,
-  });
-
 const paragraphDefaultStyles: MarkdownStyleInternal['paragraph'] = {
   fontSize: 16,
   fontFamily: getSystemFont(),
   fontWeight: 'normal',
   color: defaultTextColor,
   marginBottom: 20,
-  lineHeight: 16 * getLineHeightMultiplier(1.6),
+  lineHeight: 16,
 };
 
 const defaultH1Style: MarkdownStyleInternal['h1'] = {
@@ -52,7 +44,7 @@ const defaultH1Style: MarkdownStyleInternal['h1'] = {
   fontWeight: 'bold',
   color: defaultHeadingColor,
   marginBottom: 12,
-  lineHeight: 32 * getLineHeightMultiplier(1.2),
+  lineHeight: 32,
 };
 
 const defaultH2Style: MarkdownStyleInternal['h2'] = {
@@ -61,7 +53,7 @@ const defaultH2Style: MarkdownStyleInternal['h2'] = {
   fontWeight: 'bold',
   color: defaultHeadingColor,
   marginBottom: 12,
-  lineHeight: 24 * getLineHeightMultiplier(1.25),
+  lineHeight: 24,
 };
 
 const defaultH3Style: MarkdownStyleInternal['h3'] = {
@@ -70,7 +62,7 @@ const defaultH3Style: MarkdownStyleInternal['h3'] = {
   fontWeight: 'bold',
   color: defaultHeadingColor,
   marginBottom: 12,
-  lineHeight: 20 * getLineHeightMultiplier(1.3),
+  lineHeight: 20,
 };
 
 const defaultH4Style: MarkdownStyleInternal['h4'] = {
@@ -79,7 +71,7 @@ const defaultH4Style: MarkdownStyleInternal['h4'] = {
   fontWeight: 'bold',
   color: defaultHeadingColor,
   marginBottom: 12,
-  lineHeight: 18 * getLineHeightMultiplier(1.35),
+  lineHeight: 18,
 };
 
 const defaultH5Style: MarkdownStyleInternal['h5'] = {
@@ -88,7 +80,7 @@ const defaultH5Style: MarkdownStyleInternal['h5'] = {
   fontWeight: 'bold',
   color: defaultHeadingColor,
   marginBottom: 12,
-  lineHeight: 17 * getLineHeightMultiplier(1.4),
+  lineHeight: 17,
 };
 
 const defaultH6Style: MarkdownStyleInternal['h6'] = {
@@ -97,7 +89,7 @@ const defaultH6Style: MarkdownStyleInternal['h6'] = {
   fontWeight: 'bold',
   color: defaultHeadingColor,
   marginBottom: 12,
-  lineHeight: 16 * getLineHeightMultiplier(1.4),
+  lineHeight: 16,
 };
 
 const defaultLinkColor = processColor('#2563EB') as ColorValue;
@@ -140,7 +132,7 @@ const defaultBlockquoteStyle: MarkdownStyleInternal['blockquote'] = {
   fontWeight: 'normal',
   color: processColor('#374151') as ColorValue,
   marginBottom: 20,
-  lineHeight: 16 * getLineHeightMultiplier(1.6),
+  lineHeight: 16,
   borderColor: defaultBlockquoteBorderColor,
   borderWidth: 4,
   gapWidth: 16,
@@ -156,7 +148,7 @@ const defaultListStyle: MarkdownStyleInternal['list'] = {
   fontWeight: 'normal',
   color: defaultTextColor,
   marginBottom: 16,
-  lineHeight: 17 * getLineHeightMultiplier(1.6),
+  lineHeight: 17,
   bulletColor: defaultListBulletColor,
   bulletSize: 6,
   markerColor: defaultListMarkerColor,
@@ -177,7 +169,7 @@ const defaultCodeBlockStyle: MarkdownStyleInternal['codeBlock'] = {
   fontWeight: 'normal',
   color: defaultCodeBlockTextColor,
   marginBottom: 24,
-  lineHeight: 14 * getLineHeightMultiplier(1.6),
+  lineHeight: 14,
   backgroundColor: defaultCodeBlockBackgroundColor,
   borderColor: defaultCodeBlockBorderColor,
   borderRadius: 8,
@@ -207,7 +199,8 @@ export const normalizeMarkdownStyle = (
       normalizeColor(style.paragraph?.color) ?? paragraphDefaultStyles.color,
     marginBottom:
       style.paragraph?.marginBottom ?? paragraphDefaultStyles.marginBottom,
-    lineHeight: paragraphDefaultStyles.lineHeight,
+    lineHeight:
+      style.paragraph?.lineHeight ?? paragraphDefaultStyles.lineHeight,
   };
 
   const h1: MarkdownStyleInternal['h1'] = {


### PR DESCRIPTION
### What/Why?
iOS: This PR fixes custom paragraph styles not being applied on Android and improves line height consistency across both platforms.

Android: `TextRenderer.kt` had an optimization that skipped applying `TextSpan` for paragraph text, assuming the TextView's default style would be used. However, the paragraph style was never applied to the TextView itself, resulting in unstyled text.


### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes

