### PR TITLE
fix: disable scroll indicators

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -51,6 +51,8 @@ class EnrichedMarkdownText
       movementMethod = LinkMovementMethod.getInstance()
       setTextIsSelectable(true)
       customSelectionActionModeCallback = createSelectionActionModeCallback(this)
+      isVerticalScrollBarEnabled = false
+      isHorizontalScrollBarEnabled = false
     }
 
     fun setMarkdownContent(markdown: String) {

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -145,6 +145,8 @@ using namespace facebook::react;
   _textView.editable = NO;
   _textView.delegate = self;
   _textView.scrollEnabled = NO;
+  _textView.showsVerticalScrollIndicator = NO;
+  _textView.showsHorizontalScrollIndicator = NO;
   _textView.textContainerInset = UIEdgeInsetsZero;
   _textView.textContainer.lineFragmentPadding = 0;
   // Disable UITextView's default link styling - we handle it directly in attributed strings


### PR DESCRIPTION
### What/Why?
Disables scroll indicators on the internal TextView/UITextView to prevent scroll bars.

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes

