### PR TITLE
chore: simplify CMake

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -67,16 +67,4 @@ target_include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
-  target_compile_reactnative_options(${LIB_TARGET_NAME} PRIVATE)
-else()
-  target_compile_options(
-    ${LIB_TARGET_NAME}
-    PRIVATE
-    -DLOG_TAG=\"ReactNative\"
-    -fexceptions
-    -frtti
-    -std=c++20
-    -Wall
-  )
-endif()
+target_compile_reactnative_options(${LIB_TARGET_NAME} PRIVATE)


### PR DESCRIPTION
### What/Why?
Based on the README and extensive usage of `RN_SERIALIZABLE_STATE` this lib is not compatible with RN < 81. Meaning we can avoid additional check inside CMake.

### Testing
Ensure app builds and runs correctly on Android

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Ran example app to verify changes

