### PR TITLE
fix: return actual markdown content width

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -209,8 +209,11 @@ object MeasurementStore {
     val layout = builder.build()
     val measuredHeight = layout.height.toFloat()
 
+    // Calculate actual content width (widest line)
+    val measuredWidth = (0 until layout.lineCount).maxOfOrNull { layout.getLineWidth(it) } ?: 0f
+
     return YogaMeasureOutput.make(
-      PixelUtil.toDIPFromPixel(maxWidth),
+      PixelUtil.toDIPFromPixel(ceil(measuredWidth)),
       PixelUtil.toDIPFromPixel(measuredHeight),
     )
   }

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -85,13 +85,14 @@ using namespace facebook::react;
                                                        context:nil];
 
   CGFloat measuredHeight = boundingRect.size.height;
+  CGFloat measuredWidth = boundingRect.size.width;
 
   // Compensate for iOS not measuring trailing newlines (code block bottom padding)
   if (isLastElementCodeBlock(text)) {
     measuredHeight += [_config codeBlockPadding];
   }
 
-  return CGSizeMake(maxWidth, ceil(measuredHeight));
+  return CGSizeMake(ceil(measuredWidth), ceil(measuredHeight));
 }
 
 - (void)updateState:(const facebook::react::State::Shared &)state


### PR DESCRIPTION
### What/Why?
Fixes: #55

Returns actual measured content width instead of always returning maxWidth during measurement. Previously, the component would expand to fill all available width even for short text like "Hello". Now it properly wraps to content size, matching the behavior of React Native's native `Text` component. This is essential for use cases like chat bubbles where the container should hug the text.

### Testing
In the example app, use this code to check how RN Text and EnrichedMarkdownText fill the width; their behavior should be identical.

```javascript
        <View style={{ alignSelf: 'flex-start', borderWidth: 1, borderColor: 'green' }}>
          <EnrichedMarkdownText
            markdown={"EnrichedMarkdownText"}
            onLinkPress={handleLinkPress}
            markdownStyle={markdownStyle}
            containerStyle={{ borderWidth: 1, borderColor: 'red' }}
          />
          <Text style={{ borderWidth: 1, borderColor: 'blue' }}>
            RN Text Component
          </Text>
        </View>
```

Without alignSelf: 'flex-start', both components should default to filling the full width of the parent View. Please refer to the attached screenshots for comparison.

#### Screenshots

| iOS with alignSelf | iOS without alignSelf |
| - | - |
| <img src="https://github.com/user-attachments/assets/99c82113-9bde-473f-9407-9bc05684e306" width=300 /> | <img src="https://github.com/user-attachments/assets/ad296862-5db9-4384-9f1f-38678de1c80a" width=300 /> |

| Android with alignSelf | Android without alighSelf |
| - | - |
| <img src="https://github.com/user-attachments/assets/b3ececf5-c61d-4c2a-acd2-b40807914478" width=300 /> | <img src="https://github.com/user-attachments/assets/1ae6d4fb-b970-4243-b84b-ceebf2d4f5f7" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes

