### PR TITLE
fix(ios): apply paragraph marginBottom for document-level paragraphs

### DIFF
--- a/ios/renderer/ParagraphRenderer.m
+++ b/ios/renderer/ParagraphRenderer.m
@@ -57,9 +57,11 @@
   }
 
   // 3. Margin Application
-  // Only top-level paragraphs apply bottom margins; nested paragraphs defer to their parents.
+  // Apply margins for document-level paragraphs (None or Paragraph block type).
+  // Nested paragraphs inside blockquotes/lists defer to their parents.
+  BOOL shouldApplyMargin = (context.currentBlockType == BlockTypeNone || context.currentBlockType == BlockTypeParagraph);
   CGFloat marginBottom = 0;
-  if (isTopLevel) {
+  if (shouldApplyMargin) {
     marginBottom = isBlockImage ? _config.imageMarginBottom : _config.paragraphMarginBottom;
   }
 


### PR DESCRIPTION
### What/Why?

Fixes `paragraph.marginBottom` style having no effect on iOS.

**Root cause:** The renderer checks `isTopLevel` (`currentBlockType == BlockTypeNone`) before applying margins.
However, `AttributedRenderer.renderRoot` sets `BlockTypeParagraph` as the baseline context *before* rendering children.
This means `isTopLevel` is always `false` for document-level paragraphs, so margins are never applied.

**Fix:** Check for both `BlockTypeNone` and `BlockTypeParagraph` to correctly identify document-level paragraphs. Nested paragraphs inside blockquotes/lists still correctly defer to their parents since they have different block types.

Android is unaffected as it uses a different approach (`blockquoteDepth > 0 || listDepth > 0`).

### Testing

1. Create a component with custom `markdownStyle`:
```tsx
const markdownStyle = {
  paragraph: {
    marginBottom: 24,
  },
}

<EnrichedMarkdownText
  markdown={"First paragraph.\n\nSecond paragraph."}
  markdownStyle={markdownStyle}
/>
```
2. Run on iOS
3. Verify paragraphs now have visible spacing between them

**PR Checklist**

- Code compiles and runs on iOS
- Code compiles and runs on Android

Close #60 