### PR TITLE
chore: remove internal export for EnrichedMarkdownTextNativeComponent

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
 export { default as EnrichedMarkdownText } from './EnrichedMarkdownText';
-export { default as EnrichedMarkdownTextNativeComponent } from './EnrichedMarkdownTextNativeComponent';
 export type {
   EnrichedMarkdownTextProps,
   MarkdownStyle,


### PR DESCRIPTION
### What/Why?
This PR removes the internal export of EnrichedMarkdownTextNativeComponent.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

