### PR TITLE
fix: improve line break rendering

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/spans/BaseListSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/spans/BaseListSpan.kt
@@ -57,6 +57,11 @@ abstract class BaseListSpan(
   ) {
     if (!first || shouldSkipDrawing(text, start) || !hasContent(text, start, end)) return
 
+    // Only draw the marker on the true first line of this span.
+    // \n inside list item content creates inner paragraphs, each with first=true,
+    // but only the line at the span start should get a bullet/number.
+    if (text is Spanned && text.getSpanStart(this) != start) return
+
     val originalStyle = paint.style
     val originalColor = paint.color
     drawMarker(canvas, paint, x, dir, top, baseline, bottom, layout, start)

--- a/cpp/parser/MD4CParser.cpp
+++ b/cpp/parser/MD4CParser.cpp
@@ -57,6 +57,7 @@ public:
   }
 
   void addInlineNode(std::shared_ptr<MarkdownASTNode> node) {
+    flushText();
     if (node && !nodeStack.empty()) {
       nodeStack.back()->addChild(node);
     }

--- a/ios/renderer/RendererFactory.m
+++ b/ios/renderer/RendererFactory.m
@@ -8,6 +8,7 @@
 #import "LinkRenderer.h"
 #import "ListItemRenderer.h"
 #import "ListRenderer.h"
+#import "MarkdownASTNode.h"
 #import "ParagraphRenderer.h"
 #import "RenderContext.h"
 #import "StrikethroughRenderer.h"
@@ -106,6 +107,12 @@
                      context:(RenderContext *)context
 {
   for (MarkdownASTNode *child in node.children) {
+    if (child.type == MarkdownNodeTypeLineBreak) {
+      NSAttributedString *lineBreak = [[NSAttributedString alloc] initWithString:@"\u2028"
+                                                                      attributes:[context getTextAttributes]];
+      [output appendAttributedString:lineBreak];
+      continue;
+    }
     id<NodeRenderer> renderer = [self rendererForNodeType:child.type];
     if (renderer) {
       [renderer renderNode:child into:output context:context];


### PR DESCRIPTION
### What/Why?
Fixes: #93 
Line breaks within paragraphs were silently ignored - text before and after a break got concatenated together.
Fixed the C++ parser to correctly split text around line break nodes, added line break rendering on iOS using \u2028, and fixed Android list items drawing duplicate bullets when line breaks were present.

### Testing
```
*Emphasis line one*
Plain text line two

Backslash line one\nBackslash line two\nBackslash line three

**Bold first line**
**Bold second line**
*Italic line one*
*Italic line two*
Normal text
then a break
~~Struck line one~~
~~Struck line two~~

> Blockquote line one
> Blockquote line two
> Blockquote line three

- List item line one
  List item line two
  List item line three

- **Bold list**
  *Italic list*
  Normal list

**Bold line one**
**Bold line two**
```


#### Screenshots

| iOS | Android |
| - | - |
| <img src="https://github.com/user-attachments/assets/d6a2fa6d-9706-4fd8-891b-bd26246a1c17" width=300 /> | <img src="https://github.com/user-attachments/assets/45c2f0f0-0c6d-4d9a-8e14-005f2b6293f6" width=300 /> |

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

