### PR TITLE
refactor(ios): update paragraph spacing logic to handle marginTop correctly

### DIFF
--- a/ios/renderer/HeadingRenderer.m
+++ b/ios/renderer/HeadingRenderer.m
@@ -72,9 +72,10 @@ static NSString *const kHeadingTypes[] = {nil,          @"heading-1", @"heading-
   applyLineHeight(output, range, style.lineHeight);
   applyTextAlignment(output, range, style.textAlign);
 
-  // Use paragraphSpacingBefore for internal elements; applyBlockSpacingBefore handles index 0
+  // Skip marginTop for the first block — already handled by applyBlockSpacingBefore above
   if (contentStart != 1) {
-    applyParagraphSpacingBefore(output, range, style.marginTop);
+    NSUInteger inserted = applyParagraphSpacingBefore(output, range, style.marginTop);
+    start += inserted;
   }
   applyParagraphSpacingAfter(output, start, style.marginBottom);
 }

--- a/ios/renderer/ParagraphRenderer.m
+++ b/ios/renderer/ParagraphRenderer.m
@@ -65,9 +65,10 @@
 
   applyTextAlignment(output, range, _config.paragraphTextAlign);
 
-  // Apply marginTop for non-index-0 elements using paragraphSpacingBefore
+  // Skip marginTop for the first block — already handled by applyBlockSpacingBefore above
   if (shouldApplyMargin && contentStart != 1) {
-    applyParagraphSpacingBefore(output, range, marginTop);
+    NSUInteger inserted = applyParagraphSpacingBefore(output, range, marginTop);
+    start += inserted;
   }
 
   CGFloat marginBottom = 0;

--- a/ios/utils/ParagraphStyleUtils.h
+++ b/ios/utils/ParagraphStyleUtils.h
@@ -10,7 +10,7 @@ extern NSAttributedString *kNewlineAttributedString;
 NSWritingDirection currentWritingDirection(void);
 NSMutableParagraphStyle *getOrCreateParagraphStyle(NSMutableAttributedString *output, NSUInteger index);
 void applyParagraphSpacingAfter(NSMutableAttributedString *output, NSUInteger start, CGFloat marginBottom);
-void applyParagraphSpacingBefore(NSMutableAttributedString *output, NSRange range, CGFloat marginTop);
+NSUInteger applyParagraphSpacingBefore(NSMutableAttributedString *output, NSRange range, CGFloat marginTop);
 NSUInteger applyBlockSpacingBefore(NSMutableAttributedString *output, NSUInteger insertionPoint, CGFloat marginTop);
 void applyBlockSpacingAfter(NSMutableAttributedString *output, CGFloat marginBottom);
 void applyLineHeight(NSMutableAttributedString *output, NSRange range, CGFloat lineHeight);


### PR DESCRIPTION
### What/Why?
Fix marginTop not being applied to non-first paragraphs and headings on iOS. TextKit ignores paragraphSpacingBefore in a single attributed string, so a spacer with the correct spacing is inserted instead.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

