### PR TITLE
fix(ios): update line height configuration in ListItemRenderer to use the same approach as paragraph

### DIFF
--- a/ios/renderer/ListItemRenderer.m
+++ b/ios/renderer/ListItemRenderer.m
@@ -110,12 +110,9 @@ NSString *const TaskIndexAttribute = @"TaskIndex";
                     style.firstLineHeadIndent = totalIndent;
                     style.headIndent = totalIndent;
 
-                    // Apply line height if configured
-                    UIFont *currentFont = [output attribute:NSFontAttributeName
-                                                    atIndex:range.location
-                                             effectiveRange:NULL];
-                    if (lineHeightConfig > 0 && currentFont) {
-                      style.lineHeightMultiple = lineHeightConfig / currentFont.pointSize;
+                    if (lineHeightConfig > 0) {
+                      style.minimumLineHeight = lineHeightConfig;
+                      style.maximumLineHeight = lineHeightConfig;
                     }
 
                     NSMutableDictionary *attributesToApply = [metadata mutableCopy];


### PR DESCRIPTION
### What/Why?

Line height was applied inconsistently between paragraphs and list items on iOS. Paragraphs used absolute line height (`minimumLineHeight` / `maximumLineHeight`), while list items used a relative multiplier (`lineHeightMultiple = lineHeight / font.pointSize`). This caused list items to have visibly larger line spacing than paragraphs even when configured with the same `lineHeight` value.

For example, with `lineHeight: 24` and a 16pt font:
- Paragraphs rendered at exactly 24pt (correct)
- List items rendered at ~28.8pt (`1.5 × ~19.2pt` natural line height)

Fixes: #120 

### Testing
<!-- How to test changed code? What testing has been done? -->

#### Screenshots

https://github.com/user-attachments/assets/bbc227b9-e5b6-4d3f-a751-cae8506e61a5

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

