### PR TITLE
fix(android): prevent crash when rendering LaTeX in tables on background thread

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.text.StaticLayout
 import android.text.TextPaint
 import android.util.Log
+import com.agog.mathdisplay.MTMathView
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.yoga.YogaMeasureMode
@@ -15,11 +16,13 @@ import com.swmansion.enriched.markdown.parser.MarkdownASTNode
 import com.swmansion.enriched.markdown.parser.Md4cFlags
 import com.swmansion.enriched.markdown.parser.Parser
 import com.swmansion.enriched.markdown.renderer.Renderer
+import com.swmansion.enriched.markdown.spans.MathMeasureHelper
+import com.swmansion.enriched.markdown.spans.MathMeasureRequest
 import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.getBooleanOrDefault
 import com.swmansion.enriched.markdown.utils.common.getMapOrNull
 import com.swmansion.enriched.markdown.utils.common.getStringOrDefault
-import com.swmansion.enriched.markdown.views.MathContainerView
+import com.swmansion.enriched.markdown.utils.text.extensions.replaceMathSpansWithPlaceholders
 import com.swmansion.enriched.markdown.views.TableContainerView
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.ceil
@@ -308,6 +311,29 @@ object MeasurementStore {
       val style = StyleConfig(styleMap, context, allowFontScaling, maxFontSizeMultiplier)
       val segments = splitASTIntoSegments(ast)
 
+      // Pre-scan: batch all block-math measurements into a single main-thread post
+      val mathSegmentIndices = mutableListOf<Int>()
+      val mathRequests = mutableListOf<MathMeasureRequest>()
+      for ((i, segment) in segments.withIndex()) {
+        if (segment is MarkdownSegment.Math) {
+          mathSegmentIndices.add(i)
+          mathRequests.add(
+            MathMeasureRequest(
+              fontSize = style.mathStyle.fontSize,
+              latex = segment.latex,
+              mode = MTMathView.MTMathViewMode.KMTMathViewModeDisplay,
+            ),
+          )
+        }
+      }
+      val mathResults = MathMeasureHelper.measureOnMainThread(context, mathRequests)
+      val mathHeightByIndex = HashMap<Int, Float>(mathSegmentIndices.size)
+      for (i in mathSegmentIndices.indices) {
+        val metrics = mathResults[i]
+        mathHeightByIndex[mathSegmentIndices[i]] =
+          (metrics.ascent + metrics.descent).toInt() + (style.mathStyle.padding * 2)
+      }
+
       val widthPx = width.toInt().coerceAtLeast(1)
       val lastIndex = segments.lastIndex
       var totalHeightPx = 0f
@@ -321,6 +347,7 @@ object MeasurementStore {
             val segmentRenderer = Renderer().apply { configure(style, context) }
             val tempDoc = MarkdownASTNode(type = MarkdownASTNode.NodeType.Document, children = segment.nodes)
             val styledText = segmentRenderer.renderDocument(tempDoc, null)
+            styledText.replaceMathSpansWithPlaceholders(context)
 
             val layout = createStaticLayout(styledText, fontSize, widthPx)
             totalHeightPx += layout.height
@@ -340,7 +367,7 @@ object MeasurementStore {
 
           is MarkdownSegment.Math -> {
             totalHeightPx += style.mathStyle.marginTop
-            totalHeightPx += MathContainerView.measureMathHeight(segment.latex, style.mathStyle, context)
+            totalHeightPx += mathHeightByIndex[index] ?: 0f
             if (includeBottomMargin) {
               totalHeightPx += style.mathStyle.marginBottom
             }

--- a/android/src/main/java/com/swmansion/enriched/markdown/spans/MathInlinePlaceholderSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/spans/MathInlinePlaceholderSpan.kt
@@ -1,0 +1,41 @@
+package com.swmansion.enriched.markdown.spans
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.text.style.ReplacementSpan
+import kotlin.math.roundToInt
+
+/** Holds pre-computed math metrics for background-thread measurement. */
+class MathInlinePlaceholderSpan(
+  private val metrics: MathMetrics,
+) : ReplacementSpan() {
+  override fun getSize(
+    paint: Paint,
+    text: CharSequence?,
+    start: Int,
+    end: Int,
+    fm: Paint.FontMetricsInt?,
+  ): Int {
+    fm?.apply {
+      ascent = -metrics.ascent.roundToInt()
+      top = ascent
+      descent = metrics.descent.roundToInt()
+      bottom = descent
+    }
+    return metrics.width
+  }
+
+  override fun draw(
+    canvas: Canvas,
+    text: CharSequence?,
+    start: Int,
+    end: Int,
+    x: Float,
+    top: Int,
+    y: Int,
+    bottom: Int,
+    paint: Paint,
+  ) {
+    // Never displayed — measurement only.
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/spans/MathInlineSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/spans/MathInlineSpan.kt
@@ -12,40 +12,50 @@ import kotlin.math.roundToInt
 class MathInlineSpan(
   private val context: Context,
   internal val latex: String,
-  private val fontSize: Float,
+  internal val fontSize: Float,
   private val textColor: Int,
 ) : ReplacementSpan() {
   private var cachedBitmap: Bitmap? = null
   private var cachedWidth = 0
   private var mathAscent = 0f
   private var mathDescent = 0f
+  private var renderFailed = false
 
   private fun prepareResources() {
     if (cachedBitmap != null && !cachedBitmap!!.isRecycled) return
+    if (renderFailed) return
 
-    val mathView =
-      MTMathView(context).apply {
-        labelMode = MTMathView.MTMathViewMode.KMTMathViewModeText
-        textAlignment = MTMathView.MTTextAlignment.KMTTextAlignmentLeft
-        this.fontSize = this@MathInlineSpan.fontSize
-        this.textColor = this@MathInlineSpan.textColor
-        this.latex = this@MathInlineSpan.latex
-      }
+    try {
+      val mathView =
+        MTMathView(context).apply {
+          labelMode = MTMathView.MTMathViewMode.KMTMathViewModeText
+          textAlignment = MTMathView.MTTextAlignment.KMTTextAlignmentLeft
+          this.fontSize = this@MathInlineSpan.fontSize
+          this.textColor = this@MathInlineSpan.textColor
+          this.latex = this@MathInlineSpan.latex
+        }
 
-    val spec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
-    mathView.measure(spec, spec)
+      val spec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+      mathView.measure(spec, spec)
 
-    val width = mathView.measuredWidth.coerceAtLeast(1)
-    val height = mathView.measuredHeight.coerceAtLeast(1)
+      val width = mathView.measuredWidth.coerceAtLeast(1)
+      val height = mathView.measuredHeight.coerceAtLeast(1)
 
-    cachedWidth = width
-    calculateMetrics(mathView, height)
+      cachedWidth = width
+      calculateMetrics(mathView, height)
 
-    mathView.layout(0, 0, width, height)
+      mathView.layout(0, 0, width, height)
 
-    val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-    mathView.draw(Canvas(bitmap))
-    cachedBitmap = bitmap
+      val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+      mathView.draw(Canvas(bitmap))
+      cachedBitmap = bitmap
+    } catch (_: Exception) {
+      renderFailed = true
+      val estimatedHeight = fontSize * 1.2f
+      cachedWidth = (fontSize * latex.length * 0.6f).toInt().coerceAtLeast(1)
+      mathAscent = estimatedHeight * 0.7f
+      mathDescent = estimatedHeight * 0.3f
+    }
   }
 
   private fun calculateMetrics(

--- a/android/src/main/java/com/swmansion/enriched/markdown/spans/MathMeasureHelper.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/spans/MathMeasureHelper.kt
@@ -1,0 +1,110 @@
+package com.swmansion.enriched.markdown.spans
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.view.View.MeasureSpec
+import com.agog.mathdisplay.MTMathView
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+data class MathMeasureRequest(
+  val fontSize: Float,
+  val latex: String,
+  val mode: MTMathView.MTMathViewMode = MTMathView.MTMathViewMode.KMTMathViewModeText,
+)
+
+data class MathMetrics(
+  val width: Int,
+  val ascent: Float,
+  val descent: Float,
+)
+
+object MathMeasureHelper {
+  private const val BASE_TIMEOUT_MS = 500L
+  private const val PER_ITEM_TIMEOUT_MS = 50L
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private var sharedMathView: MTMathView? = null
+
+  fun measureOnMainThread(
+    context: Context,
+    requests: List<MathMeasureRequest>,
+  ): List<MathMetrics> {
+    if (requests.isEmpty()) return emptyList()
+
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      return requests.map { measureSingle(context, it) }
+    }
+
+    val results = mutableListOf<MathMetrics?>()
+    val latch = CountDownLatch(1)
+    val timeout = BASE_TIMEOUT_MS + (PER_ITEM_TIMEOUT_MS * requests.size)
+
+    mainHandler.post {
+      requests.mapTo(results) { request ->
+        runCatching { measureSingle(context, request) }.getOrNull()
+      }
+      latch.countDown()
+    }
+
+    val completed = latch.await(timeout, TimeUnit.MILLISECONDS)
+
+    return requests.mapIndexed { i, req ->
+      if (completed) {
+        results.getOrNull(i) ?: estimateFallback(req)
+      } else {
+        estimateFallback(req)
+      }
+    }
+  }
+
+  private fun measureSingle(
+    context: Context,
+    request: MathMeasureRequest,
+  ): MathMetrics {
+    val mathView =
+      (
+        sharedMathView ?: MTMathView(context.applicationContext).also {
+          sharedMathView = it
+        }
+      ).apply {
+        labelMode = request.mode
+        textAlignment = MTMathView.MTTextAlignment.KMTTextAlignmentLeft
+        fontSize = request.fontSize
+        latex = request.latex
+      }
+
+    val spec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+    mathView.measure(spec, spec)
+
+    val width = mathView.measuredWidth.coerceAtLeast(1)
+    val height = mathView.measuredHeight.coerceAtLeast(1).toFloat()
+
+    return runCatching {
+      val dl = displayListField?.get(mathView) ?: throw Exception()
+      val ascent = getAscentMethod?.invoke(dl) as Float
+      val descent = getDescentMethod?.invoke(dl) as Float
+      MathMetrics(width, ascent, descent)
+    }.getOrDefault(MathMetrics(width, height * 0.7f, height * 0.3f))
+  }
+
+  private fun estimateFallback(request: MathMeasureRequest): MathMetrics {
+    val h = request.fontSize * 1.4f
+    return MathMetrics(
+      width =
+        (request.fontSize * request.latex.length * 0.5f)
+          .coerceIn(request.fontSize, request.fontSize * 20f)
+          .toInt(),
+      ascent = h * 0.7f,
+      descent = h * 0.3f,
+    )
+  }
+
+  private val displayListField =
+    runCatching {
+      MTMathView::class.java.getDeclaredField("displayList").apply { isAccessible = true }
+    }.getOrNull()
+
+  private val getAscentMethod = runCatching { displayListField?.type?.getMethod("getAscent") }.getOrNull()
+  private val getDescentMethod = runCatching { displayListField?.type?.getMethod("getDescent") }.getOrNull()
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/extensions/SpannableExtensions.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/extensions/SpannableExtensions.kt
@@ -1,9 +1,38 @@
 package com.swmansion.enriched.markdown.utils.text.extensions
 
+import android.content.Context
+import android.text.SpannableString
 import android.text.SpannableStringBuilder
+import com.swmansion.enriched.markdown.spans.MathInlinePlaceholderSpan
+import com.swmansion.enriched.markdown.spans.MathInlineSpan
+import com.swmansion.enriched.markdown.spans.MathMeasureHelper
+import com.swmansion.enriched.markdown.spans.MathMeasureRequest
 
 fun SpannableStringBuilder.isInlineImage(): Boolean {
   if (isEmpty()) return false
   val lastChar = last()
   return lastChar != '\n' && lastChar != '\u200B'
+}
+
+/** Swaps MathInlineSpans for MathInlinePlaceholderSpans safe for background-thread measurement. */
+fun SpannableString.replaceMathSpansWithPlaceholders(context: Context) {
+  val mathSpans = getSpans(0, length, MathInlineSpan::class.java)
+  if (mathSpans.isEmpty()) return
+
+  val requests = mathSpans.map { MathMeasureRequest(it.fontSize, it.latex) }
+
+  val results = MathMeasureHelper.measureOnMainThread(context, requests)
+
+  mathSpans.forEachIndexed { i, span ->
+    val metrics = results.getOrNull(i) ?: return@forEachIndexed
+
+    val start = getSpanStart(span)
+    val end = getSpanEnd(span)
+    val flags = getSpanFlags(span)
+
+    if (start >= 0 && end >= 0) {
+      removeSpan(span)
+      setSpan(MathInlinePlaceholderSpan(metrics), start, end, flags)
+    }
+  }
 }

--- a/android/src/main/java/com/swmansion/enriched/markdown/views/MathContainerView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/views/MathContainerView.kt
@@ -5,10 +5,11 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.view.Gravity
 import android.view.View
-import android.view.View.MeasureSpec
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.FrameLayout
 import com.agog.mathdisplay.MTMathView
+import com.swmansion.enriched.markdown.spans.MathMeasureHelper
+import com.swmansion.enriched.markdown.spans.MathMeasureRequest
 import com.swmansion.enriched.markdown.styles.MathStyle
 import com.swmansion.enriched.markdown.styles.StyleConfig
 
@@ -83,17 +84,14 @@ class MathContainerView(
       mathStyle: MathStyle,
       context: Context,
     ): Float {
-      val tempView =
-        MTMathView(context).apply {
-          fontSize = mathStyle.fontSize
-          this.latex = latex
-          labelMode = MTMathView.MTMathViewMode.KMTMathViewModeDisplay
-        }
-
-      val spec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
-      tempView.measure(spec, spec)
-
-      return tempView.measuredHeight + (mathStyle.padding * 2)
+      val request =
+        MathMeasureRequest(
+          fontSize = mathStyle.fontSize,
+          latex = latex,
+          mode = MTMathView.MTMathViewMode.KMTMathViewModeDisplay,
+        )
+      val metrics = MathMeasureHelper.measureOnMainThread(context, listOf(request)).first()
+      return (metrics.ascent + metrics.descent).toInt() + (mathStyle.padding * 2)
     }
   }
 }

--- a/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
@@ -26,6 +26,7 @@ import com.swmansion.enriched.markdown.styles.TableStyle
 import com.swmansion.enriched.markdown.utils.common.layout.isLayoutRTL
 import com.swmansion.enriched.markdown.utils.common.serialization.MarkdownASTSerializer
 import com.swmansion.enriched.markdown.utils.text.conversion.HTMLGenerator
+import com.swmansion.enriched.markdown.utils.text.extensions.replaceMathSpansWithPlaceholders
 import com.swmansion.enriched.markdown.utils.text.view.LinkLongPressMovementMethod
 import com.swmansion.enriched.markdown.views.ContextMenuPopup
 import kotlin.math.ceil
@@ -361,6 +362,7 @@ class TableContainerView(
                 Renderer()
                   .apply { configure(config, context) }
                   .renderDocument(MarkdownASTNode(NodeType.Document, children = listOf(paragraph)), null, null)
+              styledText.replaceMathSpansWithPlaceholders(context)
               if ((section.type == NodeType.TableHead || cell.type == NodeType.TableHeaderCell) && styledText.isNotEmpty()) {
                 styledText.setSpan(HeaderTypefaceSpan(headerTypeface), 0, styledText.length, 33)
               }


### PR DESCRIPTION
### What/Why?
Fixes: #124 

Fix Android crash when rendering LaTeX inside tables.

### Testing
<!-- How to test changed code? What testing has been done? -->

 #### Screenshots 
<img width="922" height="944" alt="Screenshot 2026-03-04 at 11 48 39" src="https://github.com/user-attachments/assets/ba868748-f8cb-42f4-a677-6d425d4d7b0a" />

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

