### PR TITLE
fix(android): apply table fontSize to cell content instead of paragraph fontSize

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/styles/StyleConfig.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/styles/StyleConfig.kt
@@ -22,13 +22,45 @@ class StyleConfig(
   private val styleParser = StyleParser(context, allowFontScaling, maxFontSizeMultiplier)
   private val assets: AssetManager = context.assets
 
-  val paragraphStyle: ParagraphStyle by lazy {
+  private var paragraphStyleOverride: ParagraphStyle? = null
+
+  val paragraphStyle: ParagraphStyle
+    get() = paragraphStyleOverride ?: paragraphStyleDefault
+
+  private val paragraphStyleDefault: ParagraphStyle by lazy {
     val map =
       requireNotNull(style.getMap("paragraph")) {
         "Paragraph style not found. JS should always provide defaults."
       }
     ParagraphStyle.fromReadableMap(map, styleParser)
   }
+
+  /** Runs block with a temporary paragraph style override for table cell rendering. */
+  fun <T> withParagraphOverride(
+    override: ParagraphStyle,
+    block: () -> T,
+  ): T {
+    paragraphStyleOverride = override
+    try {
+      return block()
+    } finally {
+      paragraphStyleOverride = null
+    }
+  }
+
+  fun tableCellParagraphStyle(
+    tableStyle: TableStyle,
+    isHeader: Boolean,
+  ): ParagraphStyle =
+    paragraphStyleDefault.copy(
+      fontSize = tableStyle.fontSize,
+      fontFamily = if (isHeader && tableStyle.headerFontFamily.isNotEmpty()) tableStyle.headerFontFamily else tableStyle.fontFamily,
+      fontWeight = if (isHeader) "bold" else tableStyle.fontWeight,
+      color = if (isHeader) tableStyle.headerTextColor else tableStyle.color,
+      lineHeight = tableStyle.lineHeight,
+      marginTop = 0f,
+      marginBottom = 0f,
+    )
 
   val headingStyles: Array<HeadingStyle?> by lazy {
     Array(7) { index ->

--- a/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
@@ -107,12 +107,16 @@ class TableContainerView(
     alignment: Layout.Alignment,
   ): SpannableString {
     val root = MarkdownASTNode(NodeType.Document, children = listOf(MarkdownASTNode(NodeType.Paragraph, children = node.children)))
-    return (Renderer().apply { configure(styleConfig, context) }.renderDocument(root, onLinkPress, onLinkLongPress)).apply {
-      if (isNotEmpty()) {
-        if (isHeader) setSpan(HeaderTypefaceSpan(styleConfig.tableHeaderTypeface ?: Typeface.DEFAULT_BOLD), 0, length, 33)
-        if (alignment != Layout.Alignment.ALIGN_NORMAL) setSpan(AlignmentSpan.Standard(alignment), 0, length, 33)
+    val cellParagraphStyle = styleConfig.tableCellParagraphStyle(tableStyle, isHeader)
+    return styleConfig
+      .withParagraphOverride(cellParagraphStyle) {
+        Renderer().apply { configure(styleConfig, context) }.renderDocument(root, onLinkPress, onLinkLongPress)
+      }.apply {
+        if (isNotEmpty()) {
+          if (isHeader) setSpan(HeaderTypefaceSpan(styleConfig.tableHeaderTypeface ?: Typeface.DEFAULT_BOLD), 0, length, 33)
+          if (alignment != Layout.Alignment.ALIGN_NORMAL) setSpan(AlignmentSpan.Standard(alignment), 0, length, 33)
+        }
       }
-    }
   }
 
   private fun extractPlainText(node: MarkdownASTNode): String = node.content + node.children.joinToString("") { extractPlainText(it) }
@@ -352,18 +356,23 @@ class TableContainerView(
       config: StyleConfig,
       context: Context,
     ): Float {
+      val tableStyle = config.tableStyle
       val headerTypeface = config.tableHeaderTypeface ?: Typeface.DEFAULT_BOLD
       val texts =
         node.children.flatMap { section ->
           section.children.filter { it.type == NodeType.TableRow }.map { row ->
             row.children.map { cell ->
+              val isHeader = section.type == NodeType.TableHead || cell.type == NodeType.TableHeaderCell
               val paragraph = MarkdownASTNode(NodeType.Paragraph, children = cell.children)
+              val cellParagraphStyle = config.tableCellParagraphStyle(tableStyle, isHeader)
               val styledText =
-                Renderer()
-                  .apply { configure(config, context) }
-                  .renderDocument(MarkdownASTNode(NodeType.Document, children = listOf(paragraph)), null, null)
+                config.withParagraphOverride(cellParagraphStyle) {
+                  Renderer()
+                    .apply { configure(config, context) }
+                    .renderDocument(MarkdownASTNode(NodeType.Document, children = listOf(paragraph)), null, null)
+                }
               styledText.replaceMathSpansWithPlaceholders(context)
-              if ((section.type == NodeType.TableHead || cell.type == NodeType.TableHeaderCell) && styledText.isNotEmpty()) {
+              if (isHeader && styledText.isNotEmpty()) {
                 styledText.setSpan(HeaderTypefaceSpan(headerTypeface), 0, styledText.length, 33)
               }
               styledText
@@ -372,7 +381,7 @@ class TableContainerView(
         }
       if (texts.isEmpty()) return 0f
       val (_, heights) = computeTableDimensions(texts, config, context)
-      return heights.sum() + config.tableStyle.borderWidth
+      return heights.sum() + tableStyle.borderWidth
     }
   }
 


### PR DESCRIPTION
### What/Why?
Fixes table fontSize style not being applied to cell content on Android.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

