### PR TITLE
fix(android): honor emphasisFontStyle normal without custom font family

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/spans/EmphasisSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/spans/EmphasisSpan.kt
@@ -28,6 +28,8 @@ class EmphasisSpan(
       if (styleCache.emphasisFontFamily.isNotEmpty()) {
         val resolvedStyle = if (styleCache.emphasisFontStyle == "normal") Typeface.NORMAL else style
         SpanStyleCache.getTypeface(styleCache.emphasisFontFamily, resolvedStyle)
+      } else if (styleCache.emphasisFontStyle == "normal") {
+        currentTypeface
       } else {
         Typeface.create(currentTypeface, style)
       }


### PR DESCRIPTION
### What/Why?
On Android, setting emphasisFontStyle: "normal" in markdown styles was only honored when a custom emphasisFontFamily was also provided. Without a custom font family, the EmphasisSpan always forced italic regardless of the fontStyle value — the "normal" directive was silently ignored.


### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

