### PR TITLE
fix(android): exclude link color from preserve list when it matches paragraph color

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/renderer/SpanStyleCache.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/renderer/SpanStyleCache.kt
@@ -24,8 +24,9 @@ class SpanStyleCache(
   val codeFontSize: Float = style.codeStyle.fontSize
   val codeColor: Int = style.codeStyle.color
 
-  private fun buildColorsToPreserve(style: StyleConfig): IntArray =
-    buildList {
+  private fun buildColorsToPreserve(style: StyleConfig): IntArray {
+    val paragraphColor = style.paragraphStyle.color
+    return buildList {
       style.strongStyle.color
         ?.takeIf { it != 0 }
         ?.let { add(it) }
@@ -33,7 +34,7 @@ class SpanStyleCache(
         ?.takeIf { it != 0 }
         ?.let { add(it) }
       style.linkStyle.color
-        .takeIf { it != 0 }
+        .takeIf { it != 0 && it != paragraphColor }
         ?.let { add(it) }
       style
         .codeStyle
@@ -44,6 +45,7 @@ class SpanStyleCache(
         .takeIf { it != 0 }
         ?.let { add(it) }
     }.toIntArray()
+  }
 
   fun getStrongColorFor(blockColor: Int): Int = strongColor ?: blockColor
 


### PR DESCRIPTION
### What/Why?
When linkStyle.color matches paragraphStyle.color, the link color was incorrectly added to the colorsToPreserve list in SpanStyleCache. This caused block-level spans (blockquotes, lists, code blocks) to skip applying their own color to all text — because every piece of normal paragraph text matched the "preserved" link color value, applyColorPreserving treated it as a link color that shouldn't be overwritten.



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

