### PR TITLE
fix(android): render table correctly when lineHeight is not specified

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
@@ -196,7 +196,6 @@ class TableContainerView(
         textSize = tableStyle.fontSize / resources.displayMetrics.scaledDensity
         typeface = if (data.isHeader) styleConfig.tableHeaderTypeface else styleConfig.tableTypeface
         setTextColor(if (data.isHeader) tableStyle.headerTextColor else tableStyle.color)
-        if (tableStyle.lineHeight > 0f) setLineSpacing(tableStyle.lineHeight - (textSize * resources.displayMetrics.scaledDensity), 1f)
         gravity =
           when (data.alignment) {
             Layout.Alignment.ALIGN_CENTER -> Gravity.CENTER_HORIZONTAL

--- a/src/normalizeMarkdownStyle.ts
+++ b/src/normalizeMarkdownStyle.ts
@@ -158,7 +158,7 @@ const DEFAULT_NORMALIZED_STYLE: MarkdownStyleInternal = Object.freeze({
     color: defaultTextColor,
     marginTop: 0,
     marginBottom: 16,
-    lineHeight: 0,
+    lineHeight: Platform.select({ ios: 20, android: 22, default: 22 }),
     headerFontFamily: '',
     headerBackgroundColor: normalizeColor('#F3F4F6')!,
     headerTextColor: normalizeColor('#111827')!,


### PR DESCRIPTION
### What/Why?
Fixes: #133 

Table didn't render when lineHeight wasn't specified. The default was 0, causing Android's LineHeightSpan(0) to collapse cell text to zero height. Fixed by providing a sensible default and removing a redundant setLineSpacing call that caused text clipping.

### Testing
<!-- How to test changed code? What testing has been done? -->

#### Screenshots

<img width="300" height="700" alt="Screenshot 2026-03-06 at 11 37 12" src="https://github.com/user-attachments/assets/9b552c86-3193-48e0-8b62-4ef08bf59f55" />

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

