### PR TITLE
fix(ios): prevent stale measurement when view content is out of sync

### DIFF
--- a/ios/EnrichedMarkdown.h
+++ b/ios/EnrichedMarkdown.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) StyleConfig *config;
 - (CGSize)measureSize:(CGFloat)maxWidth;
 - (void)renderMarkdownSynchronously:(NSString *)markdownString;
+- (BOOL)hasRenderedMarkdown:(NSString *)markdown;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -119,6 +119,7 @@ using namespace facebook::react;
   StyleConfig *_config;
   ENRMMd4cFlags *_md4cFlags;
   NSString *_cachedMarkdown;
+  NSString *_renderedMarkdown;
   NSMutableArray<UIView *> *_segmentViews;
 
   dispatch_queue_t _renderQueue;
@@ -236,6 +237,11 @@ using namespace facebook::react;
   // Round to pixel boundaries to match React Native's <Text> measurement
   CGFloat scale = [UIScreen mainScreen].scale;
   return CGSizeMake(maxWidth, ceil(totalHeight * scale) / scale);
+}
+
+- (BOOL)hasRenderedMarkdown:(NSString *)markdown
+{
+  return _renderedMarkdown != nil && [_renderedMarkdown isEqualToString:markdown];
 }
 
 - (void)updateState:(const facebook::react::State::Shared &)state
@@ -357,6 +363,7 @@ using namespace facebook::react;
 
   _blockAsyncRender = YES;
   _cachedMarkdown = [markdownString copy];
+  _renderedMarkdown = [markdownString copy];
 
   MarkdownASTNode *ast = [_parser parseMarkdown:markdownString flags:_md4cFlags];
   if (!ast) {
@@ -394,6 +401,8 @@ using namespace facebook::react;
 
 - (void)applyRenderedSegments:(NSArray *)renderedSegments
 {
+  _renderedMarkdown = [_cachedMarkdown copy];
+
   for (UIView *view in _segmentViews) {
     [view removeFromSuperview];
   }

--- a/ios/EnrichedMarkdownText.h
+++ b/ios/EnrichedMarkdownText.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) StyleConfig *config;
 - (CGSize)measureSize:(CGFloat)maxWidth;
 - (void)renderMarkdownSynchronously:(NSString *)markdownString;
+- (BOOL)hasRenderedMarkdown:(NSString *)markdown;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -47,6 +47,7 @@ using namespace facebook::react;
   UITextView *_textView;
   ENRMMarkdownParser *_parser;
   NSString *_cachedMarkdown;
+  NSString *_renderedMarkdown;
   StyleConfig *_config;
   ENRMMd4cFlags *_md4cFlags;
 
@@ -114,6 +115,11 @@ using namespace facebook::react;
   // Round to pixel boundaries to match React Native's <Text> measurement
   CGFloat scale = [UIScreen mainScreen].scale;
   return CGSizeMake(ceil(measuredWidth * scale) / scale, ceil(measuredHeight * scale) / scale);
+}
+
+- (BOOL)hasRenderedMarkdown:(NSString *)markdown
+{
+  return _renderedMarkdown != nil && [_renderedMarkdown isEqualToString:markdown];
 }
 
 - (void)updateState:(const facebook::react::State::Shared &)state
@@ -321,6 +327,7 @@ using namespace facebook::react;
   _accessibilityInfo = [AccessibilityInfo infoFromContext:context];
 
   _textView.attributedText = attributedText;
+  _renderedMarkdown = [_cachedMarkdown copy];
 }
 
 - (void)applyRenderedText:(NSMutableAttributedString *)attributedText
@@ -334,6 +341,7 @@ using namespace facebook::react;
   objc_setAssociatedObject(_textView.textContainer, kTextViewKey, _textView, OBJC_ASSOCIATION_ASSIGN);
 
   _textView.attributedText = attributedText;
+  _renderedMarkdown = [_cachedMarkdown copy];
 
   [_textView.layoutManager invalidateLayoutForCharacterRange:NSMakeRange(0, attributedText.length)
                                         actualCharacterRange:NULL];

--- a/ios/internals/EnrichedMarkdownShadowNode.mm
+++ b/ios/internals/EnrichedMarkdownShadowNode.mm
@@ -71,10 +71,12 @@ Size EnrichedMarkdownShadowNode::measureContent(const LayoutContext &layoutConte
       (RCTInternalGenericWeakWrapper *)unwrapManagedObject(getStateData().getComponentViewRef());
   EnrichedMarkdown *view = weakWrapper ? (EnrichedMarkdown *)weakWrapper.object : nil;
 
+  NSString *currentMarkdown = typedProps.markdown.empty() ? nil : @(typedProps.markdown.c_str());
+
   __block CGSize size;
 
   void (^measureBlock)(void) = ^{
-    if (view) {
+    if (view && [view hasRenderedMarkdown:currentMarkdown]) {
       size = [view measureSize:maxWidth];
     } else {
       EnrichedMarkdown *mockView = setupMockEnrichedMarkdown_(maxWidth);

--- a/ios/internals/EnrichedMarkdownTextShadowNode.mm
+++ b/ios/internals/EnrichedMarkdownTextShadowNode.mm
@@ -74,10 +74,12 @@ Size EnrichedMarkdownTextShadowNode::measureContent(const LayoutContext &layoutC
       (RCTInternalGenericWeakWrapper *)unwrapManagedObject(getStateData().getComponentViewRef());
   EnrichedMarkdownText *view = weakWrapper ? (EnrichedMarkdownText *)weakWrapper.object : nil;
 
+  NSString *currentMarkdown = typedProps.markdown.empty() ? nil : @(typedProps.markdown.c_str());
+
   __block CGSize size;
 
   void (^measureBlock)(void) = ^{
-    if (view) {
+    if (view && [view hasRenderedMarkdown:currentMarkdown]) {
       size = [view measureSize:maxWidth];
     } else {
       EnrichedMarkdownText *mockView = setupMockEnrichedMarkdownText_(maxWidth);


### PR DESCRIPTION
### What/Why?
Fixes two iOS measurement bugs: the global MeasurementCache didn't distinguish between CommonMark and GFM flavors (causing cross-flavor stale hits), and the shadow node could measure a view before its async render completed (returning the previous content's height). Adds a flavor discriminator to the cache key and a hasRenderedMarkdown: guard to fall back to synchronous measurement when content is stale.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

