### PR TITLE
fix: prevent table edge clipping by adding internal horizontal inset

### DIFF
--- a/ios/views/TableContainerView.m
+++ b/ios/views/TableContainerView.m
@@ -34,6 +34,7 @@
   CGFloat _totalTableWidth;
   CGFloat _totalTableHeight;
   CGFloat _borderWidth;
+  CGFloat _horizontalContentInset;
 
   NSString *_cachedMarkdown;
 }
@@ -44,6 +45,7 @@
   if (self) {
     _config = config;
     _borderWidth = config.tableBorderWidth;
+    _horizontalContentInset = config.tableCellPaddingHorizontal;
     _allowFontScaling = YES;
     _maxFontSizeMultiplier = 0;
     _enableLinkPreview = YES;
@@ -232,7 +234,7 @@
 
 - (void)renderGrid
 {
-  _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
+  _gridContainer.frame = CGRectMake(_horizontalContentInset, 0, _totalTableWidth, _totalTableHeight);
   _gridContainer.layer.cornerRadius = self.config.tableBorderRadius;
   _gridContainer.layer.masksToBounds = YES;
 
@@ -490,9 +492,14 @@
 {
   [super layoutSubviews];
   _scrollView.frame = self.bounds;
-  _scrollView.contentSize = CGSizeMake(MAX(_totalTableWidth, self.bounds.size.width), _totalTableHeight);
-  _scrollView.scrollEnabled = (_totalTableWidth > self.bounds.size.width);
-  _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
+
+  _horizontalContentInset = self.config.tableCellPaddingHorizontal;
+  CGFloat availableWidth = MAX(self.bounds.size.width - (_horizontalContentInset * 2), 0);
+  CGFloat contentWidth = MAX(_totalTableWidth + (_horizontalContentInset * 2), self.bounds.size.width);
+
+  _scrollView.contentSize = CGSizeMake(contentWidth, _totalTableHeight);
+  _scrollView.scrollEnabled = (_totalTableWidth > availableWidth);
+  _gridContainer.frame = CGRectMake(_horizontalContentInset, 0, _totalTableWidth, _totalTableHeight);
 }
 
 - (BOOL)isAccessibilityElement


### PR DESCRIPTION
### What/Why?
- Fixes table edge clipping reported in #130 when markdown is rendered inside a padded parent `ScrollView`.
- Adds an internal horizontal inset to `TableContainerView` based on `tableCellPaddingHorizontal`, so table content no longer sits flush against the scroll container edge.
- Updates table content width/scroll calculations to account for this inset, preserving horizontal scrolling when table content exceeds available width.

Fixes #130

### Testing
- Ran `yarn lint` from repo root (passes with existing warnings in release scripts; no new errors introduced).
- iOS/Android example app builds were not run in this environment (no simulator/device attached); validation here is static + lint-level.

### PR Checklist
- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
