### PR TITLE
fix: add ProGuard keep rules for AndroidMath and FreeType JNI classes

### DIFF
--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -13,3 +13,8 @@
 -keep class com.swmansion.enriched.markdown.spans.MathMeasureHelper { *; }
 -keep class com.swmansion.enriched.markdown.views.MathContainerView { *; }
 -keep class com.swmansion.enriched.markdown.renderer.MathInlineRenderer { *; }
+
+# AndroidMath and its FreeType dependency use JNI to instantiate Java objects from native code.
+# R8 cannot trace these lookups and will strip or rename the referenced classes.
+-keep class com.agog.mathdisplay.** { *; }
+-keep class com.pvporbit.freetype.** { *; }


### PR DESCRIPTION
### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

