### PR TITLE
fix(ios): respect link.underline: false on initial mount

### DIFF
--- a/ios/utils/StylePropsUtils.h
+++ b/ios/utils/StylePropsUtils.h
@@ -497,9 +497,12 @@ BOOL applyMarkdownStyleToConfig(StyleConfig *config, const MarkdownStyle &newSty
     changed = YES;
   }
 
-  if (newStyle.link.underline != oldStyle.link.underline) {
-    [config setLinkUnderline:newStyle.link.underline];
-    changed = YES;
+  {
+    BOOL newUnderline = newStyle.link.underline ? YES : NO;
+    if (newStyle.link.underline != oldStyle.link.underline || [config linkUnderline] != newUnderline) {
+      [config setLinkUnderline:newUnderline];
+      changed = YES;
+    }
   }
 
   // ── Strong ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### What/Why?
`link.underline: false` is ignored on iOS. StyleConfig defaults _linkUnderline = YES, but the C++ codegen struct defaults it to false. On initial mount, old and new props are both false, so the diff check never fires and the config keeps YES — links always render underlined.

The fix compares against the config's actual value so the initial sync isn't skipped.

Fixes: #149 

### Testing
<!-- How to test changed code? What testing has been done? -->

#### Screenshots

https://github.com/user-attachments/assets/e0fb581e-b997-4602-973b-5863794446bd

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

