### PR TITLE
fix: unwrap consecutive latex/math blocks merged into a single paragraph by md4c

### DIFF
--- a/cpp/parser/MD4CParser.cpp
+++ b/cpp/parser/MD4CParser.cpp
@@ -395,16 +395,43 @@ std::shared_ptr<MarkdownASTNode> MD4CParser::parse(const std::string &markdown, 
 
   impl_->flushText();
 
-  // md4c emits $$...$$ as an inline span inside a Paragraph — promote to block-level
-  // so the segment splitter treats it as a standalone math segment.
+  // md4c wraps certain block-level constructs as inline spans inside a Paragraph.
+  // When they appear on consecutive lines without a blank separator, md4c merges
+  // them into a single Paragraph with LineBreak / whitespace Text nodes between them.
+  // Detect and unwrap these, promoting each block node to a top-level sibling.
+  // Example: consecutive $$...$$ (LatexMathDisplay) on adjacent lines.
   if (impl_->root) {
+    auto shouldPromote = [](const MarkdownASTNode &n) { return n.type == NodeType::LatexMathDisplay; };
+    auto isSeparator = [](const MarkdownASTNode &n) {
+      return n.type == NodeType::LineBreak ||
+             (n.type == NodeType::Text && n.content.find_first_not_of(" \t\n\r") == std::string::npos);
+    };
+
     auto &children = impl_->root->children;
-    for (size_t i = 0; i < children.size(); ++i) {
-      auto &child = children[i];
-      if (child->type == NodeType::Paragraph && child->children.size() == 1 &&
-          child->children[0]->type == NodeType::LatexMathDisplay) {
-        children[i] = child->children[0];
+    for (size_t i = 0; i < children.size();) {
+      auto &para = children[i];
+      if (para->type != NodeType::Paragraph || para->children.empty()) {
+        ++i;
+        continue;
       }
+
+      std::vector<std::shared_ptr<MarkdownASTNode>> promoted;
+      for (auto &pc : para->children) {
+        if (shouldPromote(*pc))
+          promoted.push_back(pc);
+        else if (!isSeparator(*pc)) {
+          promoted.clear();
+          break;
+        }
+      }
+
+      if (promoted.empty()) {
+        ++i;
+        continue;
+      }
+      auto pos = children.erase(children.begin() + static_cast<ptrdiff_t>(i));
+      children.insert(pos, promoted.begin(), promoted.end());
+      i += promoted.size();
     }
   }
 


### PR DESCRIPTION
### What/Why?
Consecutive `$$...$$` blocks on adjacent lines (no blank line between them) were rendered as plain text instead of math. `md4c` merges them into a single paragraph with LineBreak nodes between them, and the existing unwrap logic only handled the single-block case. Extended it to unwrap all display math blocks from such paragraphs.

### Testing
<!-- How to test changed code? What testing has been done? -->

#### Screenshots
<!-- If you attach screenshots, please use <img src="" width=200/> -->

| Before | After |
| - | - |
| <img src="https://github.com/user-attachments/assets/43107a57-3b97-4be6-a6db-1d17b7183218" width=300 /> | <img src="https://github.com/user-attachments/assets/c60fb934-9f23-486c-9fb1-761a807a6ebf" width=300 /> |

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

