### PR TITLE
fixed the EnrichedMarkdownText returned an invalid measurement issue

### DIFF
--- a/ios/internals/EnrichedMarkdownShadowNode.mm
+++ b/ios/internals/EnrichedMarkdownShadowNode.mm
@@ -52,7 +52,9 @@ id EnrichedMarkdownShadowNode::setupMockEnrichedMarkdown_(CGFloat width) const
 Size EnrichedMarkdownShadowNode::measureContent(const LayoutContext &layoutContext,
                                                 const LayoutConstraints &layoutConstraints) const
 {
+  CGFloat minWidth = layoutConstraints.minimumSize.width;
   CGFloat maxWidth = layoutConstraints.maximumSize.width;
+  CGFloat minHeight = layoutConstraints.minimumSize.height;
   CGFloat maxHeight = layoutConstraints.maximumSize.height;
 
   const auto &typedProps = *std::static_pointer_cast<const EnrichedMarkdownProps>(this->getProps());
@@ -63,7 +65,7 @@ Size EnrichedMarkdownShadowNode::measureContent(const LayoutContext &layoutConte
     auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::GitHub);
     CachedSize cached;
     if (MeasurementCache::shared().get(cacheKey, cached)) {
-      return {cached.width, std::min(cached.height, (CGFloat)maxHeight)};
+      return {std::max(cached.width, (CGFloat)minWidth), std::max(std::min(cached.height, (CGFloat)maxHeight), (CGFloat)minHeight)};
     }
   }
 
@@ -95,7 +97,9 @@ Size EnrichedMarkdownShadowNode::measureContent(const LayoutContext &layoutConte
     MeasurementCache::shared().set(cacheKey, {size.width, size.height});
   }
 
-  return {size.width, MIN(size.height, maxHeight)};
+  Float resultWidth = std::max(std::min((Float)size.width, (Float)maxWidth), (Float)minWidth);
+  Float resultHeight = std::max(std::min((Float)size.height, (Float)maxHeight), (Float)minHeight);
+  return {resultWidth, resultHeight};
 }
 
 } // namespace facebook::react

--- a/ios/internals/EnrichedMarkdownTextShadowNode.mm
+++ b/ios/internals/EnrichedMarkdownTextShadowNode.mm
@@ -53,7 +53,9 @@ id EnrichedMarkdownTextShadowNode::setupMockEnrichedMarkdownText_(CGFloat width)
 Size EnrichedMarkdownTextShadowNode::measureContent(const LayoutContext &layoutContext,
                                                     const LayoutConstraints &layoutConstraints) const
 {
+  CGFloat minWidth = layoutConstraints.minimumSize.width;
   CGFloat maxWidth = layoutConstraints.maximumSize.width;
+  CGFloat minHeight = layoutConstraints.minimumSize.height;
   CGFloat maxHeight = layoutConstraints.maximumSize.height;
 
   const auto &typedProps = *std::static_pointer_cast<const EnrichedMarkdownTextProps>(this->getProps());
@@ -66,7 +68,7 @@ Size EnrichedMarkdownTextShadowNode::measureContent(const LayoutContext &layoutC
     auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::CommonMark);
     CachedSize cached;
     if (MeasurementCache::shared().get(cacheKey, cached)) {
-      return {cached.width, std::min(cached.height, (CGFloat)maxHeight)};
+      return {std::max(cached.width, (CGFloat)minWidth), std::max(std::min(cached.height, (CGFloat)maxHeight), (CGFloat)minHeight)};
     }
   }
 
@@ -98,7 +100,9 @@ Size EnrichedMarkdownTextShadowNode::measureContent(const LayoutContext &layoutC
     MeasurementCache::shared().set(cacheKey, {size.width, size.height});
   }
 
-  return {size.width, MIN(size.height, maxHeight)};
+  Float resultWidth = std::max(std::min((Float)size.width, (Float)maxWidth), (Float)minWidth);
+  Float resultHeight = std::max(std::min((Float)size.height, (Float)maxHeight), (Float)minHeight);
+  return {resultWidth, resultHeight};
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->

Before

<img width="1315" height="268" alt="image" src="https://github.com/user-attachments/assets/dbe929c0-4722-429d-9ded-8a2d7f83a673" />

After

not seeing the above logs

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

