### PR TITLE
fix(ios): restore view layout on remount and clamp measurement to layout constraints

### DIFF
--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -605,6 +605,31 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+
+  if (self.window && _renderedMarkdown != nil) {
+    for (UIView *segment in _segmentViews) {
+      if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
+        EnrichedMarkdownInternalText *textSegment = (EnrichedMarkdownInternalText *)segment;
+        UITextView *textView = textSegment.textView;
+        textView.contentOffset = CGPointZero;
+        if (textView.attributedText.length > 0) {
+          [textView.layoutManager invalidateLayoutForCharacterRange:NSMakeRange(0, textView.attributedText.length)
+                                               actualCharacterRange:NULL];
+          textView.textContainer.size = CGSizeMake(textView.bounds.size.width, CGFLOAT_MAX);
+          [textView setNeedsLayout];
+          [textView layoutIfNeeded];
+          [textView setNeedsDisplay];
+        }
+      }
+    }
+
+    [self requestHeightUpdate];
+  }
+}
+
 Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
 {
   return EnrichedMarkdown.class;

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -463,6 +463,29 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+
+  if (self.window && _renderedMarkdown != nil) {
+    _textView.hidden = NO;
+    _textView.contentOffset = CGPointZero;
+
+    NSAttributedString *text = _textView.attributedText;
+    if (text.length > 0) {
+      [_textView.layoutManager invalidateLayoutForCharacterRange:NSMakeRange(0, text.length) actualCharacterRange:NULL];
+    }
+
+    _textView.frame = self.bounds;
+    _textView.textContainer.size = CGSizeMake(self.bounds.size.width, CGFLOAT_MAX);
+    [_textView setNeedsLayout];
+    [_textView layoutIfNeeded];
+    [_textView setNeedsDisplay];
+
+    [self requestHeightUpdate];
+  }
+}
+
 Class<RCTComponentViewProtocol> EnrichedMarkdownTextCls(void)
 {
   return EnrichedMarkdownText.class;

--- a/ios/internals/EnrichedMarkdownShadowNode.mm
+++ b/ios/internals/EnrichedMarkdownShadowNode.mm
@@ -63,7 +63,13 @@ Size EnrichedMarkdownShadowNode::measureContent(const LayoutContext &layoutConte
     auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::GitHub);
     CachedSize cached;
     if (MeasurementCache::shared().get(cacheKey, cached)) {
-      return {cached.width, std::min(cached.height, (CGFloat)maxHeight)};
+      Float cachedWidth = std::max(cached.width, layoutConstraints.minimumSize.width);
+      cachedWidth = std::min(cachedWidth, layoutConstraints.maximumSize.width);
+      Float cachedHeight = std::max(cached.height, layoutConstraints.minimumSize.height);
+      if (std::isfinite(layoutConstraints.maximumSize.height)) {
+        cachedHeight = std::min(cachedHeight, layoutConstraints.maximumSize.height);
+      }
+      return {cachedWidth, cachedHeight};
     }
   }
 
@@ -95,7 +101,15 @@ Size EnrichedMarkdownShadowNode::measureContent(const LayoutContext &layoutConte
     MeasurementCache::shared().set(cacheKey, {size.width, size.height});
   }
 
-  return {size.width, MIN(size.height, maxHeight)};
+  Float clampedWidth = size.width;
+  Float clampedHeight = size.height;
+  clampedWidth = std::max(clampedWidth, layoutConstraints.minimumSize.width);
+  clampedWidth = std::min(clampedWidth, layoutConstraints.maximumSize.width);
+  clampedHeight = std::max(clampedHeight, layoutConstraints.minimumSize.height);
+  if (std::isfinite(layoutConstraints.maximumSize.height)) {
+    clampedHeight = std::min(clampedHeight, layoutConstraints.maximumSize.height);
+  }
+  return {clampedWidth, clampedHeight};
 }
 
 } // namespace facebook::react

--- a/ios/internals/EnrichedMarkdownTextShadowNode.mm
+++ b/ios/internals/EnrichedMarkdownTextShadowNode.mm
@@ -66,7 +66,13 @@ Size EnrichedMarkdownTextShadowNode::measureContent(const LayoutContext &layoutC
     auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::CommonMark);
     CachedSize cached;
     if (MeasurementCache::shared().get(cacheKey, cached)) {
-      return {cached.width, std::min(cached.height, (CGFloat)maxHeight)};
+      Float cachedWidth = std::max(cached.width, layoutConstraints.minimumSize.width);
+      cachedWidth = std::min(cachedWidth, layoutConstraints.maximumSize.width);
+      Float cachedHeight = std::max(cached.height, layoutConstraints.minimumSize.height);
+      if (std::isfinite(layoutConstraints.maximumSize.height)) {
+        cachedHeight = std::min(cachedHeight, layoutConstraints.maximumSize.height);
+      }
+      return {cachedWidth, cachedHeight};
     }
   }
 
@@ -98,7 +104,15 @@ Size EnrichedMarkdownTextShadowNode::measureContent(const LayoutContext &layoutC
     MeasurementCache::shared().set(cacheKey, {size.width, size.height});
   }
 
-  return {size.width, MIN(size.height, maxHeight)};
+  Float clampedWidth = size.width;
+  Float clampedHeight = size.height;
+  clampedWidth = std::max(clampedWidth, layoutConstraints.minimumSize.width);
+  clampedWidth = std::min(clampedWidth, layoutConstraints.maximumSize.width);
+  clampedHeight = std::max(clampedHeight, layoutConstraints.minimumSize.height);
+  if (std::isfinite(layoutConstraints.maximumSize.height)) {
+    clampedHeight = std::min(clampedHeight, layoutConstraints.maximumSize.height);
+  }
+  return {clampedWidth, clampedHeight};
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
### What/Why?
Fix two iOS layout issues: (1) views losing their rendered content when removed and re-added to a window (e.g. bottom sheets, tab switches), and (2) shadow node measurements ignoring Yoga's min/max layout constraints, causing incorrect sizing.



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

