### PR TITLE
fix(ios): dismiss text selection when tapping non-interactive area

### DIFF
--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -721,6 +721,12 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
     if (eventEmitter) {
       eventEmitter->onLinkPress({.url = std::string([url UTF8String])});
     }
+    return;
+  }
+
+  // Tapping on non-interactive area: dismiss any active text selection
+  if (textView.selectedTextRange != nil) {
+    textView.selectedTextRange = nil;
   }
 }
 

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -565,6 +565,12 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownTextCls(void)
     if (eventEmitter) {
       eventEmitter->onLinkPress({.url = std::string([url UTF8String])});
     }
+    return;
+  }
+
+  // Tapping on non-interactive area: dismiss any active text selection
+  if (textView.selectedTextRange != nil) {
+    textView.selectedTextRange = nil;
   }
 }
 


### PR DESCRIPTION
### What/Why?

Fixes: #161 

Text selection in EnrichedMarkdownText could not be dismissed by tapping — once text was selected, tapping elsewhere inside the component kept the selection active. This happened because the textTapped: handler only processed link and task list taps, falling through without clearing the selection on plain-area taps. The fix dismisses the active selection when the user taps a non-interactive area within the text view.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

