### PR TITLE
fix(ios): don't include kUTIRTFD in the copy (#164)

### DIFF
--- a/ios/utils/PasteboardUtils.m
+++ b/ios/utils/PasteboardUtils.m
@@ -37,7 +37,6 @@ static void addRTFDData(NSMutableDictionary *items, NSAttributedString *attribut
   if (wrapper && !error) {
     NSData *data = [wrapper serializedRepresentation];
     if (data) {
-      items[kUTIRTFD] = data;
       items[kUTIFlatRTFD] = data;
     }
   }


### PR DESCRIPTION
### What/Why?
Removes the non-flat kUTIRTFD version of data in ios pastboard copy. That was causing pasting into Notes and Messages to fail.

### Testing
Copy data from the example app, try to paste it into Notes/Messages. Should work now.

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes

