### PR TITLE
fix(ci): drop --immutable from publish workflow yarn install

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           package-name: 'react-native-enriched-markdown'
           package-json-path: 'package.json'
-          install-dependencies-command: 'yarn install --immutable'
+          install-dependencies-command: 'yarn install'
           release-type: ${{ inputs.release-type }}
           version: ${{ inputs.version }}
           dry-run: ${{ inputs.dry-run }}
@@ -66,6 +66,6 @@ jobs:
         with:
           package-name: 'react-native-enriched-markdown'
           package-json-path: 'package.json'
-          install-dependencies-command: 'yarn install --immutable'
+          install-dependencies-command: 'yarn install'
           release-type: 'nightly'
           dry-run: false


### PR DESCRIPTION
The npm-package-publish action bumps the version before installing, which causes the lockfile to become stale in Yarn 4. Using plain yarn install allows the lockfile update after the version bump.

Made-with: Cursor

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

