### PR TITLE
fix(ios): preserve code block styles inside list items

### DIFF
--- a/ios/renderer/ListItemRenderer.m
+++ b/ios/renderer/ListItemRenderer.m
@@ -169,10 +169,19 @@ NSString *const TaskIndexAttribute = @"TaskIndex";
                      options:0
                   usingBlock:^(NSNumber *depth, NSRange segmentRange, BOOL *stop) {
                     BOOL isNestedSubItem = (depth && [depth integerValue] > nestingLevel);
-
-                    if (!isNestedSubItem) {
-                      [output addAttributes:checkedAttrs range:segmentRange];
+                    if (isNestedSubItem) {
+                      return;
                     }
+
+                    // Skip code block ranges — preserve CodeBlockRenderer styles.
+                    NSNumber *isCodeBlock = [output attribute:CodeBlockAttributeName
+                                                     atIndex:segmentRange.location
+                                              effectiveRange:nil];
+                    if ([isCodeBlock boolValue]) {
+                      return;
+                    }
+
+                    [output addAttributes:checkedAttrs range:segmentRange];
                   }];
 }
 


### PR DESCRIPTION
## Summary

When a fenced code block appears inside a list item (e.g. ` ```text ` inside an ordered list), `ListItemRenderer`'s paragraph style enumeration overwrites the code block's own styles with list item styles. This causes:

- List markers (e.g. "2.") appearing on every line inside the code block
- Code block padding and LTR indentation being replaced by list indentation

**Root cause**: `ListItemRenderer.m` enumerates `ListDepthAttribute` over the entire item range and applies list paragraph styles to all segments that don't belong to a nested sub-list. Code block ranges (which have `CodeBlockAttributeName` set by `CodeBlockRenderer`) were not excluded.

**Fix**: Check for `CodeBlockAttributeName` in the enumeration callback and skip those ranges, preserving the paragraph style already applied by `CodeBlockRenderer`.

## Reproduction

```markdown
1. First item
2. Second item:

\`\`\`text
Line A
Line B
Line C
\`\`\`

3. Third item
```

Before this fix, lines inside the code block render with "2." list markers on iOS.

## Test plan

- [ ] Verify fenced code blocks inside ordered/unordered list items render without list markers
- [ ] Verify code block background, padding, and LTR alignment are preserved
- [ ] Verify nested lists still render correctly (no regression)
- [ ] Verify task list items with code blocks render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)