### PR TITLE
fix: github flavor always expanding to full width

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -349,6 +349,7 @@ object MeasurementStore {
       val widthPx = width.toInt().coerceAtLeast(1)
       val lastIndex = segments.lastIndex
       var totalHeightPx = 0f
+      var maxContentWidthPx = 0f
 
       for ((index, segment) in segments.withIndex()) {
         val isLastSegment = index == lastIndex
@@ -364,6 +365,9 @@ object MeasurementStore {
             val layout = createStaticLayout(styledText, fontSize, widthPx)
             totalHeightPx += layout.height
 
+            val segmentMaxLineWidth = (0 until layout.lineCount).maxOfOrNull { layout.getLineWidth(it) } ?: 0f
+            maxContentWidthPx = maxOf(maxContentWidthPx, ceil(segmentMaxLineWidth))
+
             if (includeBottomMargin) {
               totalHeightPx += segmentRenderer.getLastElementMarginBottom()
             }
@@ -372,6 +376,7 @@ object MeasurementStore {
           is MarkdownSegment.Table -> {
             totalHeightPx += style.tableStyle.marginTop
             totalHeightPx += TableContainerView.measureTableNodeHeight(segment.node, style, context)
+            maxContentWidthPx = width
             if (includeBottomMargin) {
               totalHeightPx += style.tableStyle.marginBottom
             }
@@ -380,6 +385,7 @@ object MeasurementStore {
           is MarkdownSegment.Math -> {
             totalHeightPx += style.mathStyle.marginTop
             totalHeightPx += mathHeightByIndex[index] ?: 0f
+            maxContentWidthPx = width
             if (includeBottomMargin) {
               totalHeightPx += style.mathStyle.marginBottom
             }
@@ -388,7 +394,8 @@ object MeasurementStore {
       }
 
       val totalHeightDip = PixelUtil.toDIPFromPixel(totalHeightPx)
-      val result = YogaMeasureOutput.make(PixelUtil.toDIPFromPixel(width), totalHeightDip)
+      val measuredWidthDip = PixelUtil.toDIPFromPixel(maxContentWidthPx).coerceAtMost(PixelUtil.toDIPFromPixel(width))
+      val result = YogaMeasureOutput.make(measuredWidthDip, totalHeightDip)
 
       if (id != null) {
         data[id] = MeasurementParams(width, result, null, PaintParams(Typeface.DEFAULT, fontSize), propsHash)

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -180,12 +180,13 @@ using namespace facebook::react;
   return self;
 }
 
-- (CGFloat)computeSegmentLayoutForWidth:(CGFloat)width applyFrames:(BOOL)applyFrames
+- (CGSize)computeSegmentLayoutForWidth:(CGFloat)width applyFrames:(BOOL)applyFrames
 {
   if (_segmentViews.count == 0)
-    return 0.0;
+    return CGSizeZero;
 
   __block CGFloat yOffset = 0.0;
+  __block CGFloat maxContentWidth = 0.0;
   const NSUInteger lastIndex = _segmentViews.count - 1;
 
   [_segmentViews enumerateObjectsUsingBlock:^(RCTUIView *segment, NSUInteger i, BOOL *stop) {
@@ -197,16 +198,20 @@ using namespace facebook::react;
     if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
       EnrichedMarkdownInternalText *textView = (EnrichedMarkdownInternalText *)segment;
       textView.allowTrailingMargin = shouldAddBottomMargin;
-      segmentHeight = [textView measureHeight:width];
+      CGSize textSize = [textView measureSize:width];
+      segmentHeight = textSize.height;
+      maxContentWidth = MAX(maxContentWidth, textSize.width);
 
     } else if ([segment isKindOfClass:[TableContainerView class]]) {
       yOffset += _config.tableMarginTop;
       segmentHeight = [(TableContainerView *)segment measureHeight:width];
+      maxContentWidth = width;
     }
 #if ENRICHED_MARKDOWN_MATH
     else if ([segment isKindOfClass:[ENRMMathContainerView class]]) {
       yOffset += _config.mathMarginTop;
       segmentHeight = [(ENRMMathContainerView *)segment measureHeight:width];
+      maxContentWidth = width;
     }
 #endif
 
@@ -236,19 +241,20 @@ using namespace facebook::react;
 #endif
   }];
 
-  return yOffset;
+  return CGSizeMake(maxContentWidth, yOffset);
 }
 
 - (CGSize)measureSize:(CGFloat)maxWidth
 {
   CGFloat defaultHeight = UIFontLineHeight([UIFont systemFontOfSize:16.0]);
-  CGFloat totalHeight = [self computeSegmentLayoutForWidth:maxWidth applyFrames:NO];
-  if (totalHeight == 0)
+  CGSize contentSize = [self computeSegmentLayoutForWidth:maxWidth applyFrames:NO];
+  if (contentSize.height == 0)
     return CGSizeMake(maxWidth, defaultHeight);
 
-  // Round to pixel boundaries to match React Native's <Text> measurement
   CGFloat scale = RCTScreenScale();
-  return CGSizeMake(maxWidth, ceil(totalHeight * scale) / scale);
+  CGFloat measuredWidth = MIN(ceil(contentSize.width * scale) / scale, maxWidth);
+  CGFloat measuredHeight = ceil(contentSize.height * scale) / scale;
+  return CGSizeMake(measuredWidth, measuredHeight);
 }
 
 - (BOOL)hasRenderedMarkdown:(NSString *)markdown

--- a/ios/views/EnrichedMarkdownInternalText.h
+++ b/ios/views/EnrichedMarkdownInternalText.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)applyAttributedText:(NSMutableAttributedString *)text context:(RenderContext *)context;
 
 - (CGFloat)measureHeight:(CGFloat)maxWidth;
+- (CGSize)measureSize:(CGFloat)maxWidth;
 
 @property (nonatomic, readonly) ENRMPlatformTextView *textView;
 

--- a/ios/views/EnrichedMarkdownInternalText.m
+++ b/ios/views/EnrichedMarkdownInternalText.m
@@ -88,20 +88,25 @@
 
 - (CGFloat)measureHeight:(CGFloat)maxWidth
 {
+  return [self measureSize:maxWidth].height;
+}
+
+- (CGSize)measureSize:(CGFloat)maxWidth
+{
   NSAttributedString *text = ENRMGetAttributedText(_textView);
   if (text.length == 0) {
-    return 0;
+    return CGSizeZero;
   }
 
   ENRMTextLayoutResult layout = ENRMMeasureTextLayout(_textView, maxWidth);
 
   CGFloat measuredHeight = layout.usedRect.size.height;
+  CGFloat measuredWidth = layout.usedRect.size.width;
 
   if (!CGRectIsEmpty(layout.extraLineFragmentRect)) {
     measuredHeight -= layout.extraLineFragmentRect.size.height;
   }
 
-  // Code block bottom padding compensation (same as EnrichedMarkdownText)
   if (isLastElementCodeBlock(text)) {
     measuredHeight += [_config codeBlockPadding];
   }
@@ -110,9 +115,8 @@
     measuredHeight += _lastElementMarginBottom;
   }
 
-  // Round to pixel boundaries to match React Native's <Text> measurement
   CGFloat scale = RCTScreenScale();
-  return ceil(measuredHeight * scale) / scale;
+  return CGSizeMake(ceil(measuredWidth * scale) / scale, ceil(measuredHeight * scale) / scale);
 }
 
 - (void)layoutSubviews


### PR DESCRIPTION
### What/Why?
Fixes: #172 

flavor="github" always expanded to full available width, even for short content like a single word. This differed from flavor="commonmark" which correctly sized to its content.

The measurement paths on both iOS and Android always reported the parent constraint width instead of the actual content width. The fix reports the widest text line width to Yoga instead. Tables and math still use full width as expected.

#### Screenshots

| Android Before | Android After |
| - | - |
| <img src="https://github.com/user-attachments/assets/f7dd5544-50c6-4987-8366-998f9fa36717" width=300 /> | <img src="https://github.com/user-attachments/assets/5f28fdce-3625-4fcb-88de-958474dd5532" width=300 /> |


| iOS Before | iOS After |
| - | - |
| <img src="https://github.com/user-attachments/assets/17e05b45-c8ce-4158-8c77-e88aa0ea6578" width=300 /> | <img src="https://github.com/user-attachments/assets/9531273e-9ed4-4cc5-8250-c1de50fe5098" width=300 /> |


### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [x] Ran example app to verify changes

