### PR TITLE
fix(ios): preserve contentView frame on input window attach

### DIFF
--- a/ios/input/EnrichedMarkdownInput.mm
+++ b/ios/input/EnrichedMarkdownInput.mm
@@ -333,7 +333,8 @@ using namespace facebook::react;
   [super didMoveToWindow];
 
   if (self.window) {
-    ENRMRefreshTextViewAfterWindowAttach(_textView, self.bounds);
+    // Don't override the contentView frame set by RCTViewComponentView.
+    ENRMRefreshTextViewLayout(_textView);
 
     [self applyFormatting];
     [self updatePlaceholderVisibility];

--- a/ios/utils/ENRMUIKit.h
+++ b/ios/utils/ENRMUIKit.h
@@ -298,23 +298,31 @@ static inline ENRMTextLayoutResult ENRMMeasureTextLayout(ENRMPlatformTextView *t
 #define ENRMSetNeedsDisplay(view) [(view) setNeedsDisplay:YES]
 #endif
 
-/// Refreshes a text view's layout and display after it is attached to a window.
-/// On iOS, resets contentOffset to zero (NSTextView has no scroll position).
-/// Sets the frame and text container to the given bounds, invalidates layout for
-/// any existing content, then triggers a redraw.
-static inline void ENRMRefreshTextViewAfterWindowAttach(ENRMPlatformTextView *textView, CGRect bounds)
+/// Invalidates the text container, re-lays out any existing content, and
+/// triggers a redraw.  On iOS also resets contentOffset to zero.
+/// Does NOT touch the text view's frame — callers that need to reposition
+/// the view should set the frame themselves before calling this.
+static inline void ENRMRefreshTextViewLayout(ENRMPlatformTextView *textView)
 {
 #if !TARGET_OS_OSX
   textView.contentOffset = CGPointZero;
 #endif
-  textView.frame = bounds;
-  textView.textContainer.size = CGSizeMake(bounds.size.width, CGFLOAT_MAX);
+  textView.textContainer.size = CGSizeMake(textView.bounds.size.width, CGFLOAT_MAX);
   NSUInteger textLength = ENRMGetAttributedText(textView).length;
   if (textLength > 0) {
     [textView.layoutManager invalidateLayoutForCharacterRange:NSMakeRange(0, textLength) actualCharacterRange:NULL];
     [textView.layoutManager ensureLayoutForTextContainer:textView.textContainer];
   }
   ENRMSetNeedsDisplay(textView);
+}
+
+/// Refreshes a text view's layout and display after it is attached to a window.
+/// Sets the frame and text container to the given bounds, invalidates layout for
+/// any existing content, then triggers a redraw.
+static inline void ENRMRefreshTextViewAfterWindowAttach(ENRMPlatformTextView *textView, CGRect bounds)
+{
+  textView.frame = bounds;
+  ENRMRefreshTextViewLayout(textView);
 }
 
 /// Cross-platform text deselection: UITextView uses selectedTextRange (nullable);


### PR DESCRIPTION
### What/Why?
Fixes: #177 

Fixes incorrect layout positioning of `EnrichedMarkdownInput` on the first render when padding styles are applied. The text view's frame was being overwritten in `didMoveToWindow`, ignoring the padding set by Fabric. Extracted a frame-preserving `ENRMRefreshTextViewLayout` helper and use it instead.

#### Screenshots

<video src="https://github.com/user-attachments/assets/d965a7b3-fbf5-4307-8cc1-cbf5d622ee12" width=300 />


<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

