### PR TITLE
fix(ios): prevent VoiceOver crash on stale accessibility ranges

### DIFF
--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -368,6 +368,9 @@ using namespace facebook::react;
   }
   _textView.textContainer.size = CGSizeMake(containerWidth, CGFLOAT_MAX);
 
+  _accessibilityElements = nil;
+  _accessibilityNeedsRebuild = YES;
+
   _textView.attributedText = attributedText;
   _renderedMarkdown = [_cachedMarkdown copy];
 
@@ -390,8 +393,6 @@ using namespace facebook::react;
       [self requestHeightUpdate];
     }
   }
-
-  _accessibilityNeedsRebuild = YES;
 
   if (_textView.hidden) {
     dispatch_async(dispatch_get_main_queue(), ^{ self->_textView.hidden = NO; });

--- a/ios/utils/MarkdownAccessibilityElementBuilder.m
+++ b/ios/utils/MarkdownAccessibilityElementBuilder.m
@@ -206,7 +206,13 @@ typedef NS_ENUM(NSInteger, ElementType) { ElementTypeText, ElementTypeLink, Elem
 
 + (CGRect)frameForRange:(NSRange)range inTextView:(UITextView *)textView container:(id)container
 {
-  NSRange glyphRange = [textView.layoutManager glyphRangeForCharacterRange:range actualCharacterRange:NULL];
+  NSUInteger textLength = textView.attributedText.string.length;
+  if (textLength == 0 || range.location >= textLength) {
+    return CGRectZero;
+  }
+  NSRange clamped = NSMakeRange(range.location, MIN(range.length, textLength - range.location));
+
+  NSRange glyphRange = [textView.layoutManager glyphRangeForCharacterRange:clamped actualCharacterRange:NULL];
   CGRect rect = [textView.layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:textView.textContainer];
   rect = CGRectOffset(CGRectInset(rect, -2, -2), textView.textContainerInset.left, textView.textContainerInset.top);
   return [(UIView *)container convertRect:CGRectIntegral(rect) fromView:textView];

--- a/ios/views/EnrichedMarkdownInternalText.m
+++ b/ios/views/EnrichedMarkdownInternalText.m
@@ -74,6 +74,9 @@
 
   objc_setAssociatedObject(_textView.textContainer, kTextViewKey, _textView, OBJC_ASSOCIATION_ASSIGN);
 
+  _accessibilityElements = nil;
+  _accessibilityNeedsRebuild = YES;
+
   ENRMSetAttributedText(_textView, text);
 
   [_textView.layoutManager invalidateLayoutForCharacterRange:NSMakeRange(0, text.length) actualCharacterRange:NULL];
@@ -82,8 +85,6 @@
   [_textView setNeedsLayout];
 #endif
   ENRMSetNeedsDisplay(_textView);
-
-  _accessibilityNeedsRebuild = (_accessibilityInfo != nil);
 }
 
 - (CGFloat)measureHeight:(CGFloat)maxWidth


### PR DESCRIPTION
When rendered markdown content becomes shorter before accessibility elements are rebuilt, VoiceOver can request frame information using character ranges from the previous render. These stale ranges exceed the current text length and crash in NSLayoutManager glyphRangeForCharacterRange:.

Closes #183

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

