### PR TITLE
fix(android): disable smart text selection to prevent ImageSpan crash

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextViewSetup.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextViewSetup.kt
@@ -1,11 +1,11 @@
 package com.swmansion.enriched.markdown.utils.text.view
 
 import android.graphics.Color
+import android.os.Build
+import android.view.textclassifier.TextClassifier
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.ViewCompat
 import com.swmansion.enriched.markdown.accessibility.MarkdownAccessibilityHelper
-import com.swmansion.enriched.markdown.utils.text.view.LinkLongPressMovementMethod
-import com.swmansion.enriched.markdown.utils.text.view.createSelectionActionModeCallback
 
 fun AppCompatTextView.setupAsMarkdownTextView(accessibilityHelper: MarkdownAccessibilityHelper) {
   setBackgroundColor(Color.TRANSPARENT)
@@ -13,6 +13,20 @@ fun AppCompatTextView.setupAsMarkdownTextView(accessibilityHelper: MarkdownAcces
   movementMethod = LinkLongPressMovementMethod.createInstance()
   setTextIsSelectable(true)
   customSelectionActionModeCallback = createSelectionActionModeCallback(this)
+  // SmartSelectSprite crashes with "Center point is not inside any of the
+  // rectangles!" when Layout.getSelection returns empty rects near an
+  // ImageSpan (ReplacementSpan). NO_OP makes skipTextClassification() return
+  // true, bypassing the entire SmartSelectSprite code path. Regular text
+  // selection (long-press, handles, copy/paste) still works; only automatic
+  // entity detection (phone numbers, addresses) is disabled.
+  //
+  // TODO: Add an Android-only `enableSmartTextSelection` prop that skips this
+  // NO_OP override. This would let users who don't render images opt in to
+  // entity detection. The prop should default to false and its docs should
+  // warn that enabling it with markdown containing images will crash.
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    setTextClassifier(TextClassifier.NO_OP)
+  }
   isVerticalScrollBarEnabled = false
   isHorizontalScrollBarEnabled = false
   ViewCompat.setAccessibilityDelegate(this, accessibilityHelper)


### PR DESCRIPTION
### What/Why?
Disables Android's smart text selection (TextClassifier.NO_OP) to prevent a SmartSelectSprite crash ("Center point is not inside any of the rectangles!") when tapping near an ImageSpan. The crash occurs because Layout.getSelection returns empty rectangles for ReplacementSpans. Regular text selection (long-press, handles, copy/paste) is unaffected — only automatic entity detection (phone numbers, addresses) is disabled.

A future enableSmartTextSelection prop (Android-only) will allow users who don't render images to opt back in to entity detection.

Fixes: #196

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

