### PR TITLE
fix(ios): update _lastSelectedRange in replaceSelectedTextWith to prevent formatting range shift

### DIFF
--- a/ios/input/EnrichedMarkdownInput.mm
+++ b/ios/input/EnrichedMarkdownInput.mm
@@ -451,6 +451,7 @@ using namespace facebook::react;
   }
 
   _lastTextLength = ENRMGetPlainText(_textView).length;
+  _lastSelectedRange = _textView.selectedRange;
 
   [self applyFormatting];
   [self updatePlaceholderVisibility];


### PR DESCRIPTION
After text replacement (e.g. insertLink), _lastSelectedRange was stale, causing the next keystroke to pass a wrong editLocation to adjustForEditAtLocation and shift formatting ranges by one character.

### What/Why?

`replaceSelectedTextWith:formattingRanges:` updates `_lastTextLength` after replacing text, but does **not** update `_lastSelectedRange`. This causes the next keystroke to use a stale cursor position:

1. `shouldChangeTextInRange` sets `_preEditSelectedRange = _lastSelectedRange` (stale)
2. `handleTextChanged` computes `editLocation = _preEditSelectedRange.location` (wrong)
3. `adjustForEditAtLocation:deletedLength:insertedLength:` shifts formatting ranges incorrectly

All other text mutation paths (`textViewDidChange`, `setValue:`, `textViewDidChangeSelection:`) already update `_lastSelectedRange` — this method was the only one missing.

**Fix:** Add `_lastSelectedRange = _textView.selectedRange;` right after the existing `_lastTextLength` update.

### Testing

1. Call `insertLink("example", "https://example.com")`
2. Type a space immediately after
3. **Before:** link range shifts by 1 char — `[example]` becomes `e[xample]`
4. **After:** link range stays correct

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android (iOS-only change, Android not affected)
- [ ] Updated documentation/README if applicable (N/A)
- [x] Ran example app to verify changes
