### PR TITLE
feat: add auto-link detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - 🕹️ Imperative API for toggling styles and managing links
 - 📋 Native format bar and context menu with formatting options
 - 🔍 Real-time style state detection
+- 🔗 Auto-link detection with customizable regex
 - 🔄 Smart copy/paste with Markdown preservation
 - 🎨 Customizable bold, italic, and link colors
 
@@ -52,6 +53,7 @@ We can help you build your next dream product –
   - [Usage](docs/INPUT.md#usage)
   - [Inline Styles](docs/INPUT.md#inline-styles)
   - [Links](docs/INPUT.md#links)
+  - [Auto-Link Detection](docs/INPUT.md#auto-link-detection)
   - [Style Detection](docs/INPUT.md#style-detection)
   - [Other Events](docs/INPUT.md#other-events)
   - [Customizing Styles](docs/INPUT.md#customizing-enrichedmarkdowninput--styles)

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputManager.kt
@@ -14,6 +14,7 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.EnrichedMarkdownInputManagerDelegate
 import com.facebook.react.viewmanagers.EnrichedMarkdownInputManagerInterface
 import com.facebook.yoga.YogaMeasureMode
+import com.swmansion.enriched.markdown.input.autolink.LinkRegexConfig
 import com.swmansion.enriched.markdown.input.events.OnChangeMarkdownEvent
 import com.swmansion.enriched.markdown.input.events.OnChangeSelectionEvent
 import com.swmansion.enriched.markdown.input.events.OnChangeStateEvent
@@ -21,6 +22,7 @@ import com.swmansion.enriched.markdown.input.events.OnChangeTextEvent
 import com.swmansion.enriched.markdown.input.events.OnContextMenuItemPressEvent
 import com.swmansion.enriched.markdown.input.events.OnInputBlurEvent
 import com.swmansion.enriched.markdown.input.events.OnInputFocusEvent
+import com.swmansion.enriched.markdown.input.events.OnLinkDetectedEvent
 import com.swmansion.enriched.markdown.input.events.OnRequestMarkdownResultEvent
 import com.swmansion.enriched.markdown.input.layout.InputMeasurementStore
 import com.swmansion.enriched.markdown.input.model.StyleType
@@ -84,6 +86,7 @@ class EnrichedMarkdownInputManager :
       OnInputFocusEvent.EVENT_NAME,
       OnInputBlurEvent.EVENT_NAME,
       OnContextMenuItemPressEvent.EVENT_NAME,
+      OnLinkDetectedEvent.EVENT_NAME,
     ).associateWithTo(mutableMapOf()) { name -> mapOf("registrationName" to name) }
 
   // Props
@@ -181,6 +184,7 @@ class EnrichedMarkdownInputManager :
     if (view == null || value == null) return
 
     val style = MarkdownStyleParser.parse(value)
+    view.setAutoLinkStyle(style)
     val changed = view.formatter.updateStyle(style)
     if (changed) {
       view.applyFormatting()
@@ -245,6 +249,27 @@ class EnrichedMarkdownInputManager :
     if (view == null) return
     val items = (0 until (value?.size() ?: 0)).mapNotNull { value?.getMap(it)?.getString("text") }
     view.setContextMenuItems(items)
+  }
+
+  @ReactProp(name = "linkRegex")
+  override fun setLinkRegex(
+    view: EnrichedMarkdownInputView?,
+    value: ReadableMap?,
+  ) {
+    if (view == null) return
+    val config =
+      if (value != null) {
+        LinkRegexConfig(
+          pattern = value.getString("pattern") ?: "",
+          caseInsensitive = value.getBoolean("caseInsensitive"),
+          dotAll = value.getBoolean("dotAll"),
+          isDisabled = value.getBoolean("isDisabled"),
+          isDefault = value.getBoolean("isDefault"),
+        )
+      } else {
+        LinkRegexConfig("", caseInsensitive = false, dotAll = false, isDisabled = false, isDefault = true)
+      }
+    view.setLinkRegex(config)
   }
 
   override fun updateProperties(

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputView.kt
@@ -20,6 +20,9 @@ import com.facebook.react.uimanager.BackgroundStyleApplicator
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.views.text.ReactTypefaceUtils
+import com.swmansion.enriched.markdown.input.autolink.AutoLinkDetector
+import com.swmansion.enriched.markdown.input.autolink.LinkRegexConfig
+import com.swmansion.enriched.markdown.input.detection.DetectorPipeline
 import com.swmansion.enriched.markdown.input.editing.InputConnectionWrapper
 import com.swmansion.enriched.markdown.input.editing.MarkdownEditableFactory
 import com.swmansion.enriched.markdown.input.editing.MarkdownTextWatcher
@@ -29,6 +32,7 @@ import com.swmansion.enriched.markdown.input.formatting.InputParser
 import com.swmansion.enriched.markdown.input.layout.InputEventEmitter
 import com.swmansion.enriched.markdown.input.layout.InputLayoutManager
 import com.swmansion.enriched.markdown.input.model.FormattingRange
+import com.swmansion.enriched.markdown.input.model.InputFormatterStyle
 import com.swmansion.enriched.markdown.input.model.StyleType
 import com.swmansion.enriched.markdown.input.toolbar.FormatBar
 import com.swmansion.enriched.markdown.input.toolbar.InputContextMenu
@@ -70,6 +74,8 @@ class EnrichedMarkdownInputView(
   val contextMenu = InputContextMenu(this)
   val formatBar = FormatBar(this)
   val eventEmitter = InputEventEmitter(this)
+  private val autoLinkDetector = AutoLinkDetector(formattingStore)
+  private val detectorPipeline = DetectorPipeline()
 
   private var textWatcher: MarkdownTextWatcher? = null
   private var inputMethodManager: InputMethodManager? = null
@@ -77,8 +83,16 @@ class EnrichedMarkdownInputView(
   var scrollEnabled: Boolean = true
 
   init {
+    setupDetectorPipeline()
     prepareComponent()
     isComponentReady = true
+  }
+
+  private fun setupDetectorPipeline() {
+    autoLinkDetector.onLinkDetected = { text, url, start, end ->
+      eventEmitter.emitLinkDetected(text, url, start, end)
+    }
+    detectorPipeline.addDetector(autoLinkDetector)
   }
 
   private fun prepareComponent() {
@@ -201,6 +215,12 @@ class EnrichedMarkdownInputView(
       formattingStore.adjustForEdit(editStart, deletedLength, insertedLength)
       applyPendingStyles(editStart, insertedLength)
       applyFormatting()
+
+      val editable = text
+      if (editable != null) {
+        detectorPipeline.processTextChange(editable, currentText, editStart, insertedLength)
+      }
+
       forceScrollToSelection()
       eventEmitter.emitChangeText()
       if (emitMarkdown) eventEmitter.emitChangeMarkdown()
@@ -343,6 +363,10 @@ class EnrichedMarkdownInputView(
     val selEnd = selectionEnd
     if (selStart == selEnd) return
 
+    val editable = text
+    if (editable != null) {
+      autoLinkDetector.clearAutoLinkInRange(editable, selStart, selEnd)
+    }
     formattingStore.addRange(FormattingRange(StyleType.LINK, selStart, selEnd, url))
     applyFormattingAndEmit()
   }
@@ -360,6 +384,7 @@ class EnrichedMarkdownInputView(
     try {
       editable.replace(selStart, selEnd, displayText)
       formattingStore.adjustForEdit(selStart, selEnd - selStart, displayText.length)
+      autoLinkDetector.clearAutoLinkInRange(editable, selStart, linkEnd)
       formattingStore.addRange(FormattingRange(StyleType.LINK, selStart, linkEnd, url))
       lastProcessedText = editable.toString()
 
@@ -380,6 +405,21 @@ class EnrichedMarkdownInputView(
 
   fun setContextMenuItems(items: List<String>) {
     contextMenu.setContextMenuItems(items)
+  }
+
+  fun setLinkRegex(config: LinkRegexConfig) {
+    autoLinkDetector.setRegexConfig(config)
+  }
+
+  fun setAutoLinkStyle(style: InputFormatterStyle) {
+    autoLinkDetector.style = style
+  }
+
+  fun allFormattingRangesForSerialization(): List<FormattingRange> {
+    val editable = text ?: return formattingStore.allRanges
+    val transientRanges = detectorPipeline.allTransientFormattingRanges(editable)
+    if (transientRanges.isEmpty()) return formattingStore.allRanges
+    return formattingStore.allRanges + transientRanges
   }
 
   fun setValueFromJS(markdown: String) {

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/autolink/AutoDetectedLinkSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/autolink/AutoDetectedLinkSpan.kt
@@ -1,0 +1,29 @@
+package com.swmansion.enriched.markdown.input.autolink
+
+import android.text.TextPaint
+import android.text.style.CharacterStyle
+import android.text.style.ForegroundColorSpan
+import android.text.style.UnderlineSpan
+
+/**
+ * Visual spans for auto-detected links. These intentionally do NOT implement
+ * MarkdownSpan so they survive the diff-based removal in InputFormatter.applyFormatting.
+ */
+class AutoDetectedLinkColorSpan(
+  color: Int,
+) : ForegroundColorSpan(color)
+
+class AutoDetectedLinkUnderlineSpan : UnderlineSpan()
+
+/**
+ * Zero-width marker span that carries the matched URL and marks a range as
+ * auto-detected. Used to enumerate existing auto-link ranges without confusing
+ * them with manual MarkdownSpan link spans.
+ */
+class AutoDetectedLinkMarkerSpan(
+  val url: String,
+) : CharacterStyle() {
+  override fun updateDrawState(tp: TextPaint) {
+    // no-op — styling is handled by the color/underline spans
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/autolink/AutoLinkDetector.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/autolink/AutoLinkDetector.kt
@@ -1,0 +1,188 @@
+package com.swmansion.enriched.markdown.input.autolink
+
+import android.text.Spannable
+import com.swmansion.enriched.markdown.input.detection.TextDetector
+import com.swmansion.enriched.markdown.input.detection.WordResult
+import com.swmansion.enriched.markdown.input.formatting.FormattingStore
+import com.swmansion.enriched.markdown.input.model.FormattingRange
+import com.swmansion.enriched.markdown.input.model.InputFormatterStyle
+import com.swmansion.enriched.markdown.input.model.StyleType
+import java.util.regex.Pattern
+
+typealias OnLinkDetectedCallback = (text: String, url: String, start: Int, end: Int) -> Unit
+
+class AutoLinkDetector(
+  private val formattingStore: FormattingStore,
+) : TextDetector {
+  private var config: LinkRegexConfig? = null
+  private var compiledPattern: Pattern? = null
+  var style: InputFormatterStyle? = null
+  var onLinkDetected: OnLinkDetectedCallback? = null
+
+  fun setRegexConfig(newConfig: LinkRegexConfig) {
+    if (newConfig == config) return
+    config = newConfig
+    compiledPattern = null
+
+    if (!newConfig.isDefault && !newConfig.isDisabled && newConfig.pattern.isNotEmpty()) {
+      var flags = 0
+      if (newConfig.caseInsensitive) flags = flags or Pattern.CASE_INSENSITIVE
+      if (newConfig.dotAll) flags = flags or Pattern.DOTALL
+      compiledPattern =
+        try {
+          Pattern.compile(newConfig.pattern, flags)
+        } catch (_: Exception) {
+          null
+        }
+    }
+  }
+
+  override fun processWord(
+    spannable: Spannable,
+    wordResult: WordResult,
+  ) {
+    val detectedUrl = detectNewLinkInWord(spannable, wordResult)
+    if (detectedUrl != null) {
+      onLinkDetected?.invoke(wordResult.word, detectedUrl, wordResult.start, wordResult.end)
+    }
+  }
+
+  override fun refreshStyling(spannable: Spannable) {
+    val currentStyle = style ?: return
+    val markers = spannable.getSpans(0, spannable.length, AutoDetectedLinkMarkerSpan::class.java)
+    for (marker in markers) {
+      val start = spannable.getSpanStart(marker)
+      val end = spannable.getSpanEnd(marker)
+      applyVisualStyling(spannable, start, end, currentStyle)
+    }
+  }
+
+  override fun transientFormattingRanges(spannable: Spannable): List<FormattingRange> {
+    val markers = spannable.getSpans(0, spannable.length, AutoDetectedLinkMarkerSpan::class.java)
+    return markers.map { marker ->
+      FormattingRange(
+        StyleType.LINK,
+        spannable.getSpanStart(marker),
+        spannable.getSpanEnd(marker),
+        marker.url,
+      )
+    }
+  }
+
+  fun clearAutoLinkInRange(
+    spannable: Spannable,
+    start: Int,
+    end: Int,
+  ) {
+    removeAutoLinkSpans(spannable, start, end)
+  }
+
+  private fun detectNewLinkInWord(
+    spannable: Spannable,
+    wordResult: WordResult,
+  ): String? {
+    if (config?.isDisabled == true) return null
+
+    val (word, wordStart, wordEnd) = wordResult
+
+    val hasManualLink = formattingStore.rangeOfType(StyleType.LINK, wordStart) != null
+    if (hasManualLink) {
+      removeAutoLinkSpans(spannable, wordStart, wordEnd)
+      return null
+    }
+
+    val matchedUrl = matchWord(word)
+    val existingMarker =
+      spannable
+        .getSpans(wordStart, wordEnd, AutoDetectedLinkMarkerSpan::class.java)
+        .firstOrNull { spannable.getSpanStart(it) == wordStart && spannable.getSpanEnd(it) == wordEnd }
+
+    if (matchedUrl != null) {
+      if (existingMarker?.url == matchedUrl) return null
+
+      removeAutoLinkSpans(spannable, wordStart, wordEnd)
+      spannable.setSpan(
+        AutoDetectedLinkMarkerSpan(matchedUrl),
+        wordStart,
+        wordEnd,
+        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+      )
+      val currentStyle = style
+      if (currentStyle != null) {
+        applyVisualStyling(spannable, wordStart, wordEnd, currentStyle)
+      }
+      return matchedUrl
+    } else {
+      if (existingMarker != null) {
+        removeAutoLinkSpans(spannable, wordStart, wordEnd)
+      }
+      return null
+    }
+  }
+
+  private fun matchWord(word: String): String? {
+    if (word.isEmpty()) return null
+
+    val custom = compiledPattern
+    if (custom != null) {
+      return if (custom.matcher(word).matches()) normalizeUrl(word) else null
+    }
+
+    if (DEFAULT_PATTERN.matcher(word).matches()) return normalizeUrl(word)
+
+    return null
+  }
+
+  private fun removeAutoLinkSpans(
+    spannable: Spannable,
+    start: Int,
+    end: Int,
+  ) {
+    for (span in spannable.getSpans(start, end, AutoDetectedLinkMarkerSpan::class.java)) {
+      spannable.removeSpan(span)
+    }
+    for (span in spannable.getSpans(start, end, AutoDetectedLinkColorSpan::class.java)) {
+      spannable.removeSpan(span)
+    }
+    for (span in spannable.getSpans(start, end, AutoDetectedLinkUnderlineSpan::class.java)) {
+      spannable.removeSpan(span)
+    }
+  }
+
+  private fun applyVisualStyling(
+    spannable: Spannable,
+    start: Int,
+    end: Int,
+    style: InputFormatterStyle,
+  ) {
+    spannable.setSpan(
+      AutoDetectedLinkColorSpan(style.linkColor),
+      start,
+      end,
+      Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+    )
+    if (style.linkUnderline) {
+      spannable.setSpan(
+        AutoDetectedLinkUnderlineSpan(),
+        start,
+        end,
+        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+      )
+    }
+  }
+
+  companion object {
+    private val DEFAULT_PATTERN: Pattern =
+      Pattern.compile(
+        "(?:https?://[-a-zA-Z0-9@:%._+~#=]{1,256}\\.[a-z]{2,6}\\b[-a-zA-Z0-9@:%_+.~#?&//=]*" +
+          "|www\\.[-a-zA-Z0-9@:%._+~#=]{1,256}\\.[a-z]{2,6}\\b[-a-zA-Z0-9@:%_+.~#?&//=]*" +
+          "|[-a-zA-Z0-9@:%._+~#=]{1,256}\\.[a-z]{2,6}\\b[-a-zA-Z0-9@:%_+.~#?&//=]*)",
+        Pattern.CASE_INSENSITIVE,
+      )
+
+    private fun normalizeUrl(url: String): String {
+      if (url.startsWith("http://") || url.startsWith("https://")) return url
+      return "https://$url"
+    }
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/autolink/LinkRegexConfig.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/autolink/LinkRegexConfig.kt
@@ -1,0 +1,9 @@
+package com.swmansion.enriched.markdown.input.autolink
+
+data class LinkRegexConfig(
+  val pattern: String,
+  val caseInsensitive: Boolean,
+  val dotAll: Boolean,
+  val isDisabled: Boolean,
+  val isDefault: Boolean,
+)

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/detection/DetectorPipeline.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/detection/DetectorPipeline.kt
@@ -1,0 +1,40 @@
+package com.swmansion.enriched.markdown.input.detection
+
+import android.text.Spannable
+import com.swmansion.enriched.markdown.input.model.FormattingRange
+
+/**
+ * Coordinates a set of [TextDetector] instances. The input view calls
+ * this pipeline instead of individual detectors.
+ */
+class DetectorPipeline {
+  private val detectors = mutableListOf<TextDetector>()
+
+  fun addDetector(detector: TextDetector) {
+    detectors.add(detector)
+  }
+
+  fun processTextChange(
+    spannable: Spannable,
+    text: String,
+    editStart: Int,
+    editLength: Int,
+  ) {
+    val words = WordsUtils.getAffectedWords(text, editStart, editLength)
+
+    for (wordResult in words) {
+      for (detector in detectors) {
+        detector.processWord(spannable, wordResult)
+      }
+    }
+  }
+
+  fun refreshAllStyling(spannable: Spannable) {
+    for (detector in detectors) {
+      detector.refreshStyling(spannable)
+    }
+  }
+
+  fun allTransientFormattingRanges(spannable: Spannable): List<FormattingRange> =
+    detectors.flatMap { it.transientFormattingRanges(spannable) }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/detection/TextDetector.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/detection/TextDetector.kt
@@ -1,0 +1,27 @@
+package com.swmansion.enriched.markdown.input.detection
+
+import android.text.Spannable
+import com.swmansion.enriched.markdown.input.model.FormattingRange
+
+/**
+ * Interface for pluggable text detectors that run after each text edit.
+ * Each detector processes affected words, can refresh its own visual styling
+ * after the formatter resets spans, and contributes transient formatting ranges
+ * for markdown serialization.
+ */
+interface TextDetector {
+  /** Process a single word at the given range after a text edit. */
+  fun processWord(
+    spannable: Spannable,
+    wordResult: WordResult,
+  )
+
+  /** Re-apply any visual styling owned by this detector. */
+  fun refreshStyling(spannable: Spannable)
+
+  /**
+   * Return transient formatting ranges that should be merged
+   * with the FormattingStore ranges during markdown serialization.
+   */
+  fun transientFormattingRanges(spannable: Spannable): List<FormattingRange>
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/detection/WordResult.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/detection/WordResult.kt
@@ -1,0 +1,7 @@
+package com.swmansion.enriched.markdown.input.detection
+
+data class WordResult(
+  val word: String,
+  val start: Int,
+  val end: Int,
+)

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/detection/WordsUtils.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/detection/WordsUtils.kt
@@ -1,0 +1,50 @@
+package com.swmansion.enriched.markdown.input.detection
+
+object WordsUtils {
+  fun getAffectedWords(
+    text: String,
+    editStart: Int,
+    editLength: Int,
+  ): List<WordResult> {
+    val textLength = text.length
+    if (textLength == 0) return emptyList()
+
+    var left = editStart.coerceIn(0, textLength)
+    if (left > 0) {
+      left--
+      while (left > 0 && !text[left].isWhitespace()) {
+        left--
+      }
+      if (text[left].isWhitespace()) left++
+    }
+
+    var right = (editStart + editLength).coerceIn(0, textLength)
+    if (right < textLength) {
+      while (right < textLength && !text[right].isWhitespace()) {
+        right++
+      }
+    }
+
+    if (left >= right) return emptyList()
+
+    val results = mutableListOf<WordResult>()
+    var wordStart = left
+    var i = left
+
+    while (i < right) {
+      if (text[i].isWhitespace()) {
+        if (i > wordStart) {
+          results.add(WordResult(text.substring(wordStart, i), wordStart, i))
+        }
+        wordStart = i + 1
+      }
+      i++
+    }
+
+    if (wordStart < right) {
+      results.add(WordResult(text.substring(wordStart, right), wordStart, right))
+    }
+
+    return results
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnLinkDetectedEvent.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnLinkDetectedEvent.kt
@@ -1,0 +1,28 @@
+package com.swmansion.enriched.markdown.input.events
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class OnLinkDetectedEvent(
+  surfaceId: Int,
+  viewId: Int,
+  private val text: String,
+  private val url: String,
+  private val start: Int,
+  private val end: Int,
+) : Event<OnLinkDetectedEvent>(surfaceId, viewId) {
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap =
+    Arguments.createMap().apply {
+      putString("text", text)
+      putString("url", url)
+      putInt("start", start)
+      putInt("end", end)
+    }
+
+  companion object {
+    const val EVENT_NAME = "onLinkDetected"
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
@@ -11,6 +11,7 @@ import com.swmansion.enriched.markdown.input.events.OnChangeTextEvent
 import com.swmansion.enriched.markdown.input.events.OnContextMenuItemPressEvent
 import com.swmansion.enriched.markdown.input.events.OnInputBlurEvent
 import com.swmansion.enriched.markdown.input.events.OnInputFocusEvent
+import com.swmansion.enriched.markdown.input.events.OnLinkDetectedEvent
 import com.swmansion.enriched.markdown.input.events.OnRequestMarkdownResultEvent
 import com.swmansion.enriched.markdown.input.formatting.MarkdownSerializer
 import com.swmansion.enriched.markdown.input.model.StyleType
@@ -67,6 +68,15 @@ class InputEventEmitter(
     dispatch(OnInputBlurEvent(surfaceId(), view.id))
   }
 
+  fun emitLinkDetected(
+    text: String,
+    url: String,
+    start: Int,
+    end: Int,
+  ) {
+    dispatch(OnLinkDetectedEvent(surfaceId(), view.id, text, url, start, end))
+  }
+
   fun emitRequestMarkdownResult(requestId: Int) {
     dispatch(OnRequestMarkdownResultEvent(surfaceId(), view.id, requestId, serializeToMarkdown()))
   }
@@ -116,7 +126,7 @@ class InputEventEmitter(
 
   private fun serializeToMarkdown(): String {
     val plainText = view.text?.toString() ?: ""
-    return MarkdownSerializer.serialize(plainText, view.formattingStore.allRanges)
+    return MarkdownSerializer.serialize(plainText, view.allFormattingRangesForSerialization())
   }
 
   private fun surfaceId(): Int {

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -77,6 +77,50 @@ The built-in native format bar also includes a link option that presents a URL p
 
 A complete example of a setup that supports both setting links on the selected text, as well as inserting them at the cursor position can be found in the example app code.
 
+## Auto-Link Detection
+
+`EnrichedMarkdownInput` can automatically detect URLs as the user types and convert them into Markdown links. Detected links are visually styled in the input and serialized as `[text](url)` in the Markdown output.
+
+### Basic usage
+
+Auto-link detection is enabled by default. URLs like `google.com`, `www.google.com`, and `https://google.com` are detected when followed by a space or newline.
+
+Bare domains and `www.` prefixes are automatically normalized with `https://` (e.g., `google.com` becomes `[google.com](https://google.com)`).
+
+### Custom regex
+
+You can provide a custom regex pattern to control which text is detected as a link:
+
+```tsx
+<EnrichedMarkdownInput
+  linkRegex={/https?:\/\/[^\s]+/i}
+/>
+```
+
+Pass `null` to disable auto-link detection entirely:
+
+```tsx
+<EnrichedMarkdownInput linkRegex={null} />
+```
+
+### Listening for detections
+
+Use the `onLinkDetected` callback to be notified when a new link is detected:
+
+```tsx
+<EnrichedMarkdownInput
+  onLinkDetected={({ text, url, start, end }) => {
+    console.log(`Detected link: ${text} -> ${url} at [${start}, ${end}]`);
+  }}
+/>
+```
+
+The callback fires only for newly detected links — not for links that were already detected and remain unchanged.
+
+### Interaction with manual links
+
+When a manual link is applied (via `setLink` or `insertLink`) over an auto-detected link, the auto-detected link is replaced by the manual one. Auto-link detection skips ranges that already contain a manual link.
+
 ## Style Detection
 
 All of the above styles can be detected with the use of [onChangeState](API_REFERENCE.md#onchangestate) callback payload.

--- a/ios/input/ENRMAutoLinkDetector.h
+++ b/ios/input/ENRMAutoLinkDetector.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#import "ENRMFormattingStore.h"
+#import "ENRMLinkRegexConfig.h"
+#import "ENRMTextDetector.h"
+#import <Foundation/Foundation.h>
+
+@class ENRMInputFormatterStyle;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^ENRMAutoLinkCallback)(NSString *text, NSString *url, NSRange range);
+
+@interface ENRMAutoLinkDetector : NSObject <ENRMTextDetector>
+
+- (instancetype)initWithTextStorage:(NSTextStorage *)textStorage
+                    formattingStore:(ENRMFormattingStore *)store
+                              style:(ENRMInputFormatterStyle *)style;
+
+- (void)setRegexConfig:(ENRMLinkRegexConfig *)config;
+
+/// Callback invoked when a new auto-link is detected.
+/// Set by the input view to bridge detections to JS event emission.
+@property (nonatomic, copy, nullable) ENRMAutoLinkCallback onLinkDetected;
+
+/// Remove any auto-link marker attribute in the given range.
+/// Call when a manual link is applied over an auto-detected one.
+- (void)clearAutoLinkInRange:(NSRange)range;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/input/ENRMAutoLinkDetector.mm
+++ b/ios/input/ENRMAutoLinkDetector.mm
@@ -1,0 +1,209 @@
+#import "ENRMAutoLinkDetector.h"
+
+#import "ENRMFormattingRange.h"
+#import "InputStylePropsUtils.h"
+
+static NSAttributedStringKey const ENRMAutomaticLinkAttributeName = @"ENRMAutomaticLink";
+
+@implementation ENRMAutoLinkDetector {
+  __weak NSTextStorage *_textStorage;
+  __weak ENRMFormattingStore *_formattingStore;
+  __weak ENRMInputFormatterStyle *_style;
+  ENRMLinkRegexConfig *_regexConfig;
+}
+
+- (instancetype)initWithTextStorage:(NSTextStorage *)textStorage
+                    formattingStore:(ENRMFormattingStore *)store
+                              style:(ENRMInputFormatterStyle *)style
+{
+  self = [super init];
+  if (self) {
+    _textStorage = textStorage;
+    _formattingStore = store;
+    _style = style;
+  }
+  return self;
+}
+
+- (void)setRegexConfig:(ENRMLinkRegexConfig *)config
+{
+  _regexConfig = config;
+}
+
+#pragma mark - ENRMTextDetector
+
+- (void)processWord:(ENRMWordResult *)wordResult
+{
+  NSString *detectedUrl = [self detectNewLinkAtRange:wordResult.range inText:wordResult.word];
+  if (detectedUrl != nil && _onLinkDetected != nil) {
+    _onLinkDetected(wordResult.word, detectedUrl, wordResult.range);
+  }
+}
+
+- (void)refreshStyling
+{
+  NSTextStorage *textStorage = _textStorage;
+  if (textStorage == nil || textStorage.length == 0) {
+    return;
+  }
+
+  [textStorage beginEditing];
+  [textStorage enumerateAttribute:ENRMAutomaticLinkAttributeName
+                          inRange:NSMakeRange(0, textStorage.length)
+                          options:0
+                       usingBlock:^(id value, NSRange range, BOOL *stop) {
+                         if (value != nil) {
+                           [self applyVisualStylingToRange:range];
+                         }
+                       }];
+  [textStorage endEditing];
+}
+
+- (NSArray<ENRMFormattingRange *> *)transientFormattingRanges
+{
+  NSTextStorage *textStorage = _textStorage;
+  if (textStorage == nil || textStorage.length == 0) {
+    return @[];
+  }
+
+  NSMutableArray<ENRMFormattingRange *> *ranges = [NSMutableArray array];
+  [textStorage enumerateAttribute:ENRMAutomaticLinkAttributeName
+                          inRange:NSMakeRange(0, textStorage.length)
+                          options:0
+                       usingBlock:^(id value, NSRange range, BOOL *stop) {
+                         if (value != nil && [value isKindOfClass:[NSString class]]) {
+                           ENRMFormattingRange *fmtRange = [ENRMFormattingRange rangeWithType:ENRMInputStyleTypeLink
+                                                                                        range:range
+                                                                                          url:value];
+                           [ranges addObject:fmtRange];
+                         }
+                       }];
+  return ranges;
+}
+
+- (void)clearAutoLinkInRange:(NSRange)range
+{
+  NSTextStorage *textStorage = _textStorage;
+  if (textStorage == nil || NSMaxRange(range) > textStorage.length) {
+    return;
+  }
+  [textStorage removeAttribute:ENRMAutomaticLinkAttributeName range:range];
+}
+
+#pragma mark - Link matching
+
+- (nullable NSString *)detectNewLinkAtRange:(NSRange)wordRange inText:(NSString *)word
+{
+  if (_regexConfig != nil && _regexConfig.isDisabled) {
+    return nil;
+  }
+
+  NSTextStorage *textStorage = _textStorage;
+  if (textStorage == nil) {
+    return nil;
+  }
+
+  if (NSMaxRange(wordRange) > textStorage.length) {
+    return nil;
+  }
+
+  ENRMFormattingStore *store = _formattingStore;
+  if (store != nil) {
+    ENRMFormattingRange *manualLink = [store rangeOfType:ENRMInputStyleTypeLink containingPosition:wordRange.location];
+    if (manualLink != nil) {
+      return nil;
+    }
+  }
+
+  NSString *matchedUrl = [self tryMatchWord:word];
+
+  if (matchedUrl != nil) {
+    NSRange effectiveRange;
+    id existing = [textStorage attribute:ENRMAutomaticLinkAttributeName
+                                 atIndex:wordRange.location
+                          effectiveRange:&effectiveRange];
+    BOOL alreadyApplied = [matchedUrl isEqual:existing] && NSEqualRanges(effectiveRange, wordRange);
+
+    if (!alreadyApplied) {
+      [textStorage beginEditing];
+      [textStorage addAttribute:ENRMAutomaticLinkAttributeName value:matchedUrl range:wordRange];
+      [self applyVisualStylingToRange:wordRange];
+      [textStorage endEditing];
+    }
+  } else {
+    id existing = [textStorage attribute:ENRMAutomaticLinkAttributeName atIndex:wordRange.location effectiveRange:nil];
+    if (existing != nil) {
+      [textStorage beginEditing];
+      [textStorage removeAttribute:ENRMAutomaticLinkAttributeName range:wordRange];
+      [textStorage endEditing];
+    }
+  }
+
+  return matchedUrl;
+}
+
+- (nullable NSString *)tryMatchWord:(NSString *)word
+{
+  if (word.length == 0) {
+    return nil;
+  }
+
+  NSRange matchRange = NSMakeRange(0, word.length);
+
+  if (_regexConfig != nil && !_regexConfig.isDefault && _regexConfig.parsedRegex != nil) {
+    if ([_regexConfig.parsedRegex numberOfMatchesInString:word options:0 range:matchRange]) {
+      return [ENRMAutoLinkDetector normalizeUrl:word];
+    }
+    return nil;
+  }
+
+  if ([[ENRMAutoLinkDetector defaultRegex] numberOfMatchesInString:word options:0 range:matchRange]) {
+    return [ENRMAutoLinkDetector normalizeUrl:word];
+  }
+
+  return nil;
+}
+
++ (NSString *)normalizeUrl:(NSString *)url
+{
+  if ([url hasPrefix:@"http://"] || [url hasPrefix:@"https://"]) {
+    return url;
+  }
+  return [@"https://" stringByAppendingString:url];
+}
+
+#pragma mark - Visual styling
+
+- (void)applyVisualStylingToRange:(NSRange)range
+{
+  NSTextStorage *textStorage = _textStorage;
+  ENRMInputFormatterStyle *style = _style;
+  if (textStorage == nil || style == nil) {
+    return;
+  }
+
+  [textStorage addAttribute:NSForegroundColorAttributeName value:style.linkColor range:range];
+  if (style.linkUnderline) {
+    [textStorage addAttribute:NSUnderlineStyleAttributeName value:@(NSUnderlineStyleSingle) range:range];
+  }
+}
+
+#pragma mark - Default regex
+
++ (NSRegularExpression *)defaultRegex
+{
+  static NSRegularExpression *regex;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    regex = [NSRegularExpression
+        regularExpressionWithPattern:
+            @"(?:https?://[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,6}\\b[-a-zA-Z0-9@:%_\\+.~#?&//=]*"
+            @"|www\\.[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,6}\\b[-a-zA-Z0-9@:%_\\+.~#?&//=]*"
+            @"|[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,6}\\b[-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
+                             options:NSRegularExpressionCaseInsensitive
+                               error:nil];
+  });
+  return regex;
+}
+
+@end

--- a/ios/input/ENRMDetectorPipeline.h
+++ b/ios/input/ENRMDetectorPipeline.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#import "ENRMFormattingRange.h"
+#import "ENRMTextDetector.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Coordinates a set of ENRMTextDetector instances. The input view calls
+/// this pipeline instead of individual detectors.
+@interface ENRMDetectorPipeline : NSObject
+
+- (void)addDetector:(id<ENRMTextDetector>)detector;
+
+/// Run all detectors over the affected words for a given modification range.
+- (void)processTextChange:(NSString *)text modificationRange:(NSRange)range;
+
+/// Re-apply visual styling for all detectors after the formatter
+/// resets base attributes. Call right after applyFormattingRanges.
+- (void)refreshAllStyling;
+
+/// Collect transient formatting ranges from every detector,
+/// suitable for merging with FormattingStore ranges before serialization.
+- (NSArray<ENRMFormattingRange *> *)allTransientFormattingRanges;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/input/ENRMDetectorPipeline.mm
+++ b/ios/input/ENRMDetectorPipeline.mm
@@ -1,0 +1,53 @@
+#import "ENRMDetectorPipeline.h"
+
+#import "ENRMWordsUtils.h"
+
+@implementation ENRMDetectorPipeline {
+  NSMutableArray<id<ENRMTextDetector>> *_detectors;
+}
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _detectors = [NSMutableArray array];
+  }
+  return self;
+}
+
+- (void)addDetector:(id<ENRMTextDetector>)detector
+{
+  [_detectors addObject:detector];
+}
+
+- (void)processTextChange:(NSString *)text modificationRange:(NSRange)range
+{
+  NSArray<ENRMWordResult *> *words = [ENRMWordsUtils getAffectedWordsFromText:text modificationRange:range];
+
+  for (ENRMWordResult *wordResult in words) {
+    for (id<ENRMTextDetector> detector in _detectors) {
+      [detector processWord:wordResult];
+    }
+  }
+}
+
+- (void)refreshAllStyling
+{
+  for (id<ENRMTextDetector> detector in _detectors) {
+    [detector refreshStyling];
+  }
+}
+
+- (NSArray<ENRMFormattingRange *> *)allTransientFormattingRanges
+{
+  NSMutableArray<ENRMFormattingRange *> *all = [NSMutableArray array];
+  for (id<ENRMTextDetector> detector in _detectors) {
+    NSArray<ENRMFormattingRange *> *ranges = [detector transientFormattingRanges];
+    if (ranges.count > 0) {
+      [all addObjectsFromArray:ranges];
+    }
+  }
+  return all;
+}
+
+@end

--- a/ios/input/ENRMInputFormatter.mm
+++ b/ios/input/ENRMInputFormatter.mm
@@ -113,11 +113,10 @@
 
   [textStorage beginEditing];
 
-  NSDictionary *baseAttributes = @{
-    NSFontAttributeName : style.baseFont,
-    NSForegroundColorAttributeName : style.baseTextColor,
-  };
-  [textStorage setAttributes:baseAttributes range:fullTextRange];
+  [textStorage addAttribute:NSFontAttributeName value:style.baseFont range:fullTextRange];
+  [textStorage addAttribute:NSForegroundColorAttributeName value:style.baseTextColor range:fullTextRange];
+  [textStorage removeAttribute:NSUnderlineStyleAttributeName range:fullTextRange];
+  [textStorage removeAttribute:NSStrikethroughStyleAttributeName range:fullTextRange];
 
   UIFontDescriptorSymbolicTraits *traitMap =
       (UIFontDescriptorSymbolicTraits *)calloc(textLength, sizeof(UIFontDescriptorSymbolicTraits));

--- a/ios/input/ENRMLinkRegexConfig.h
+++ b/ios/input/ENRMLinkRegexConfig.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ENRMLinkRegexConfig : NSObject
+
+@property (nonatomic, copy, readonly) NSString *pattern;
+@property (nonatomic, assign, readonly) BOOL caseInsensitive;
+@property (nonatomic, assign, readonly) BOOL dotAll;
+@property (nonatomic, assign, readonly) BOOL isDisabled;
+@property (nonatomic, assign, readonly) BOOL isDefault;
+@property (nonatomic, strong, readonly, nullable) NSRegularExpression *parsedRegex;
+
+- (instancetype)initWithPattern:(NSString *)pattern
+                caseInsensitive:(BOOL)caseInsensitive
+                         dotAll:(BOOL)dotAll
+                     isDisabled:(BOOL)isDisabled
+                      isDefault:(BOOL)isDefault;
+
+- (BOOL)isEqualToConfig:(ENRMLinkRegexConfig *)other;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/input/ENRMLinkRegexConfig.mm
+++ b/ios/input/ENRMLinkRegexConfig.mm
@@ -1,0 +1,60 @@
+#import "ENRMLinkRegexConfig.h"
+
+#import <React/RCTLog.h>
+
+@implementation ENRMLinkRegexConfig
+
+- (instancetype)initWithPattern:(NSString *)pattern
+                caseInsensitive:(BOOL)caseInsensitive
+                         dotAll:(BOOL)dotAll
+                     isDisabled:(BOOL)isDisabled
+                      isDefault:(BOOL)isDefault
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _pattern = [pattern copy];
+  _caseInsensitive = caseInsensitive;
+  _dotAll = dotAll;
+  _isDisabled = isDisabled;
+  _isDefault = isDefault;
+  _parsedRegex = nil;
+
+  if (!_isDefault && !_isDisabled && _pattern.length > 0) {
+    NSRegularExpressionOptions options = 0;
+    if (_caseInsensitive) {
+      options |= NSRegularExpressionCaseInsensitive;
+    }
+    if (_dotAll) {
+      options |= NSRegularExpressionDotMatchesLineSeparators;
+    }
+
+    NSError *error = nil;
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:_pattern
+                                                                           options:options
+                                                                             error:&error];
+    if (error) {
+      RCTLogWarn(
+          @"[EnrichedMarkdownInput]: Couldn't parse the user-defined link regex '%@', "
+           "falling back to default regex.",
+          _pattern);
+    } else {
+      _parsedRegex = regex;
+    }
+  }
+
+  return self;
+}
+
+- (BOOL)isEqualToConfig:(ENRMLinkRegexConfig *)other
+{
+  if (other == nil) {
+    return NO;
+  }
+  return [_pattern isEqualToString:other.pattern] && _caseInsensitive == other.caseInsensitive &&
+         _dotAll == other.dotAll && _isDefault == other.isDefault && _isDisabled == other.isDisabled;
+}
+
+@end

--- a/ios/input/ENRMTextDetector.h
+++ b/ios/input/ENRMTextDetector.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#import "ENRMWordsUtils.h"
+#import <Foundation/Foundation.h>
+
+@class ENRMFormattingRange;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Protocol for pluggable text detectors that run after each text edit.
+/// Each detector scans affected words, can refresh its own visual styling
+/// after the formatter resets base attributes, and contributes transient
+/// formatting ranges for markdown serialization.
+@protocol ENRMTextDetector <NSObject>
+
+/// Process a single word at the given range after a text edit.
+/// Called once per affected word in the modification range.
+- (void)processWord:(ENRMWordResult *)wordResult;
+
+/// Re-apply any visual styling owned by this detector.
+/// Called after the formatter resets base text attributes.
+- (void)refreshStyling;
+
+/// Return transient formatting ranges that should be merged
+/// with the FormattingStore ranges during markdown serialization.
+- (NSArray<ENRMFormattingRange *> *)transientFormattingRanges;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/input/ENRMWordsUtils.h
+++ b/ios/input/ENRMWordsUtils.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ENRMWordResult : NSObject
+
+@property (nonatomic, copy, readonly) NSString *word;
+@property (nonatomic, assign, readonly) NSRange range;
+
++ (instancetype)resultWithWord:(NSString *)word range:(NSRange)range;
+
+@end
+
+@interface ENRMWordsUtils : NSObject
+
+/// Expands the modification range to word boundaries, then splits into
+/// individual ENRMWordResult objects.
++ (NSArray<ENRMWordResult *> *)getAffectedWordsFromText:(NSString *)text modificationRange:(NSRange)range;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/input/ENRMWordsUtils.mm
+++ b/ios/input/ENRMWordsUtils.mm
@@ -1,0 +1,74 @@
+#import "ENRMWordsUtils.h"
+
+@implementation ENRMWordResult
+
++ (instancetype)resultWithWord:(NSString *)word range:(NSRange)range
+{
+  ENRMWordResult *result = [[ENRMWordResult alloc] init];
+  result->_word = [word copy];
+  result->_range = range;
+  return result;
+}
+
+@end
+
+@implementation ENRMWordsUtils
+
++ (NSArray<ENRMWordResult *> *)getAffectedWordsFromText:(NSString *)text modificationRange:(NSRange)range
+{
+  NSUInteger textLength = text.length;
+  if (textLength == 0) {
+    return @[];
+  }
+
+  NSCharacterSet *whitespace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+  NSCharacterSet *nonWhitespace = [whitespace invertedSet];
+
+  NSUInteger left = range.location;
+  if (left > 0) {
+    NSRange searchRange = NSMakeRange(0, left);
+    NSRange whitespaceHit = [text rangeOfCharacterFromSet:whitespace options:NSBackwardsSearch range:searchRange];
+    left = (whitespaceHit.location != NSNotFound) ? NSMaxRange(whitespaceHit) : 0;
+  }
+
+  NSUInteger right = MIN(range.location + range.length, textLength);
+  if (right < textLength) {
+    NSRange searchRange = NSMakeRange(right, textLength - right);
+    NSRange whitespaceHit = [text rangeOfCharacterFromSet:whitespace options:0 range:searchRange];
+    right = (whitespaceHit.location != NSNotFound) ? whitespaceHit.location : textLength;
+  }
+
+  if (left >= right) {
+    return @[];
+  }
+
+  NSMutableArray<ENRMWordResult *> *results = [NSMutableArray array];
+
+  NSUInteger scanStart = left;
+  while (scanStart < right) {
+    NSRange scanRange = NSMakeRange(scanStart, right - scanStart);
+    NSRange wordStart = [text rangeOfCharacterFromSet:nonWhitespace options:0 range:scanRange];
+    if (wordStart.location == NSNotFound) {
+      break;
+    }
+
+    NSRange remaining = NSMakeRange(NSMaxRange(wordStart), right - NSMaxRange(wordStart));
+    NSRange wordEnd;
+    if (remaining.length > 0) {
+      wordEnd = [text rangeOfCharacterFromSet:whitespace options:0 range:remaining];
+    } else {
+      wordEnd.location = NSNotFound;
+    }
+
+    NSUInteger wordEndPosition = (wordEnd.location != NSNotFound) ? wordEnd.location : right;
+    NSRange wordRange = NSMakeRange(wordStart.location, wordEndPosition - wordStart.location);
+    NSString *word = [text substringWithRange:wordRange];
+
+    [results addObject:[ENRMWordResult resultWithWord:word range:wordRange]];
+    scanStart = wordEndPosition;
+  }
+
+  return results;
+}
+
+@end

--- a/ios/input/EnrichedMarkdownInput.mm
+++ b/ios/input/EnrichedMarkdownInput.mm
@@ -1,5 +1,7 @@
 #import "EnrichedMarkdownInput.h"
 #import "ContextMenuUtils.h"
+#import "ENRMAutoLinkDetector.h"
+#import "ENRMDetectorPipeline.h"
 #import "ENRMFormattingRange.h"
 #import "ENRMFormattingStore.h"
 #import "ENRMInputFormatter.h"
@@ -7,6 +9,7 @@
 #import "ENRMInputLinkPrompt.h"
 #import "ENRMInputParser.h"
 #import "ENRMInputTextView.h"
+#import "ENRMLinkRegexConfig.h"
 #import "ENRMMarkdownSerializer.h"
 #import "ENRMStyleHandler.h"
 #import "ENRMStyleMergingConfig.h"
@@ -74,6 +77,9 @@ using namespace facebook::react;
 
   NSArray<NSString *> *_contextMenuItemTexts;
   NSArray<NSString *> *_contextMenuItemIcons;
+
+  ENRMAutoLinkDetector *_autoLinkDetector;
+  ENRMDetectorPipeline *_detectorPipeline;
 }
 
 #pragma mark - Fabric lifecycle
@@ -106,8 +112,25 @@ using namespace facebook::react;
     _lastSelectedRange = NSMakeRange(0, 0);
 
     [self setupTextView];
+
+    [self setupDetectorPipeline];
   }
   return self;
+}
+
+- (void)setupDetectorPipeline
+{
+  _autoLinkDetector = [[ENRMAutoLinkDetector alloc] initWithTextStorage:_textView.textStorage
+                                                        formattingStore:_formattingStore
+                                                                  style:_formatterStyle];
+
+  __weak EnrichedMarkdownInput *weakSelf = self;
+  _autoLinkDetector.onLinkDetected = ^(NSString *text, NSString *url, NSRange range) {
+    [weakSelf emitOnLinkDetectedWithText:text url:url range:range];
+  };
+
+  _detectorPipeline = [[ENRMDetectorPipeline alloc] init];
+  [_detectorPipeline addDetector:_autoLinkDetector];
 }
 
 - (void)setupTextView
@@ -275,6 +298,21 @@ using namespace facebook::react;
   }
 
   _emitMarkdown = newViewProps.isOnChangeMarkdownSet;
+
+  {
+    auto configFromProp = [](const auto &prop) {
+      return [[ENRMLinkRegexConfig alloc] initWithPattern:[NSString stringWithUTF8String:prop.pattern.c_str()]
+                                          caseInsensitive:prop.caseInsensitive
+                                                   dotAll:prop.dotAll
+                                               isDisabled:prop.isDisabled
+                                                isDefault:prop.isDefault];
+    };
+    ENRMLinkRegexConfig *oldRegexConfig = configFromProp(oldViewProps.linkRegex);
+    ENRMLinkRegexConfig *newRegexConfig = configFromProp(newViewProps.linkRegex);
+    if (![newRegexConfig isEqualToConfig:oldRegexConfig]) {
+      [_autoLinkDetector setRegexConfig:newRegexConfig];
+    }
+  }
 
   if (ENRMContextMenuItemsChanged(oldViewProps.contextMenuItems, newViewProps.contextMenuItems)) {
     _contextMenuItemTexts = ENRMContextMenuTextsFromItems(newViewProps.contextMenuItems);
@@ -454,6 +492,10 @@ using namespace facebook::react;
   _lastSelectedRange = _textView.selectedRange;
 
   [self applyFormatting];
+
+  [_detectorPipeline processTextChange:ENRMGetPlainText(_textView)
+                     modificationRange:NSMakeRange(editLocation, text.length)];
+
   [self updatePlaceholderVisibility];
   [self emitOnChangeText];
   [self emitOnChangeSelection];
@@ -492,6 +534,7 @@ using namespace facebook::react;
   NSRange savedSelection = _textView.selectedRange;
 
   [_formatter applyFormattingRanges:_formattingStore.allRanges toTextView:_textView style:_formatterStyle];
+  [_detectorPipeline refreshAllStyling];
 
   NSUInteger textLen = ENRMGetPlainText(_textView).length;
   if (savedSelection.location + savedSelection.length <= textLen) {
@@ -628,9 +671,11 @@ using namespace facebook::react;
 
   if (activeLink != nil) {
     activeLink.url = url;
+    [_autoLinkDetector clearAutoLinkInRange:activeLink.range];
   } else if (selection.length > 0) {
     ENRMFormattingRange *linkRange = [ENRMFormattingRange rangeWithType:ENRMInputStyleTypeLink range:selection url:url];
     [_formattingStore addRange:linkRange];
+    [_autoLinkDetector clearAutoLinkInRange:selection];
   } else {
     return;
   }
@@ -682,7 +727,7 @@ using namespace facebook::react;
   NSUInteger selEnd = NSMaxRange(selection);
 
   NSMutableArray<ENRMFormattingRange *> *clippedRanges = [NSMutableArray array];
-  for (ENRMFormattingRange *range in _formattingStore.allRanges) {
+  for (ENRMFormattingRange *range in [self allRangesIncludingTransient]) {
     NSUInteger rangeStart = range.range.location;
     NSUInteger rangeEnd = NSMaxRange(range.range);
 
@@ -707,7 +752,7 @@ using namespace facebook::react;
     return;
   }
   NSString *markdown = [ENRMMarkdownSerializer serializePlainText:ENRMGetPlainText(_textView)
-                                                           ranges:_formattingStore.allRanges];
+                                                           ranges:[self allRangesIncludingTransient]];
   emitter->onRequestMarkdownResult({
       .requestId = static_cast<int>(requestId),
       .markdown = std::string([markdown UTF8String] ?: ""),
@@ -752,6 +797,17 @@ using namespace facebook::react;
   return std::static_pointer_cast<EnrichedMarkdownInputEventEmitter const>(_eventEmitter);
 }
 
+- (NSArray<ENRMFormattingRange *> *)allRangesIncludingTransient
+{
+  NSArray<ENRMFormattingRange *> *transient = [_detectorPipeline allTransientFormattingRanges];
+  if (transient.count == 0) {
+    return _formattingStore.allRanges;
+  }
+  NSMutableArray<ENRMFormattingRange *> *merged = [_formattingStore.allRanges mutableCopy];
+  [merged addObjectsFromArray:transient];
+  return merged;
+}
+
 - (void)emitOnChangeText
 {
   auto emitter = [self getEventEmitter];
@@ -769,7 +825,7 @@ using namespace facebook::react;
     return;
   }
   NSString *markdown = [ENRMMarkdownSerializer serializePlainText:ENRMGetPlainText(_textView)
-                                                           ranges:_formattingStore.allRanges];
+                                                           ranges:[self allRangesIncludingTransient]];
   emitter->onChangeMarkdown({.value = std::string([markdown UTF8String] ?: "")});
 }
 
@@ -890,6 +946,20 @@ using namespace facebook::react;
   emitter->onInputBlur({});
 }
 
+- (void)emitOnLinkDetectedWithText:(NSString *)text url:(NSString *)url range:(NSRange)range
+{
+  auto emitter = [self getEventEmitter];
+  if (emitter == nullptr) {
+    return;
+  }
+  emitter->onLinkDetected({
+      .text = std::string([text UTF8String] ?: ""),
+      .url = std::string([url UTF8String] ?: ""),
+      .start = static_cast<int>(range.location),
+      .end = static_cast<int>(range.location + range.length),
+  });
+}
+
 #pragma mark - Text edit tracking
 
 - (void)handleTextChanged
@@ -951,6 +1021,10 @@ using namespace facebook::react;
 #endif
 
   [self applyFormatting];
+
+  [_detectorPipeline processTextChange:ENRMGetPlainText(_textView)
+                     modificationRange:NSMakeRange(editLocation, insertedLength)];
+
   [self updatePlaceholderVisibility];
   [self emitOnChangeText];
   [self emitOnChangeSelection];

--- a/src/EnrichedMarkdownInput.tsx
+++ b/src/EnrichedMarkdownInput.tsx
@@ -15,7 +15,9 @@ import EnrichedMarkdownInputNativeComponent, {
   type OnChangeStateEvent,
   type OnRequestMarkdownResultEvent,
   type OnContextMenuItemPressEvent,
+  type OnLinkDetected,
 } from './EnrichedMarkdownInputNativeComponent';
+export type { OnLinkDetected } from './EnrichedMarkdownInputNativeComponent';
 import type {
   HostInstance,
   NativeSyntheticEvent,
@@ -24,6 +26,7 @@ import type {
   ColorValue,
 } from 'react-native';
 import { normalizeMarkdownInputStyle } from './normalizeMarkdownInputStyle';
+import { toNativeRegexConfig } from './utils/regexParser';
 import type { RefObject } from 'react';
 
 type NativeRef = HostInstance;
@@ -96,9 +99,11 @@ export interface EnrichedMarkdownInputProps {
   onChangeMarkdown?: (markdown: string) => void;
   onChangeSelection?: (selection: { start: number; end: number }) => void;
   onChangeState?: (state: StyleState) => void;
+  onLinkDetected?: (event: OnLinkDetected) => void;
   onFocus?: () => void;
   onBlur?: () => void;
   contextMenuItems?: ContextMenuItem[];
+  linkRegex?: RegExp | null;
 }
 
 type MarkdownRequest = {
@@ -133,9 +138,11 @@ export const EnrichedMarkdownInput = ({
   onChangeMarkdown,
   onChangeSelection,
   onChangeState,
+  onLinkDetected,
   onFocus,
   onBlur,
   contextMenuItems,
+  linkRegex: _linkRegex,
 }: EnrichedMarkdownInputProps) => {
   const nativeRef = useRef<NativeRef | null>(null);
 
@@ -175,6 +182,19 @@ export const EnrichedMarkdownInput = ({
   }, []);
 
   const normalizedStyle = normalizeMarkdownInputStyle(markdownStyle);
+
+  const linkRegex = useMemo(
+    () => toNativeRegexConfig(_linkRegex),
+    [_linkRegex]
+  );
+
+  const handleLinkDetected = useCallback(
+    (e: NativeSyntheticEvent<OnLinkDetected>) => {
+      const { text, url, start, end } = e.nativeEvent;
+      onLinkDetected?.({ text, url, start, end });
+    },
+    [onLinkDetected]
+  );
 
   const handleChangeText = useCallback(
     (e: NativeSyntheticEvent<OnChangeTextEvent>) => {
@@ -298,6 +318,7 @@ export const EnrichedMarkdownInput = ({
         handleChangeSelection as NativeProps['onChangeSelection']
       }
       onChangeState={handleChangeState as NativeProps['onChangeState']}
+      onLinkDetected={handleLinkDetected as NativeProps['onLinkDetected']}
       onInputFocus={handleFocus as NativeProps['onInputFocus']}
       onInputBlur={handleBlur as NativeProps['onInputBlur']}
       onRequestMarkdownResult={
@@ -307,6 +328,7 @@ export const EnrichedMarkdownInput = ({
       onContextMenuItemPress={
         handleContextMenuItemPress as NativeProps['onContextMenuItemPress']
       }
+      linkRegex={linkRegex}
     />
   );
 };

--- a/src/EnrichedMarkdownInputNativeComponent.ts
+++ b/src/EnrichedMarkdownInputNativeComponent.ts
@@ -51,6 +51,21 @@ export interface OnRequestMarkdownResultEvent {
   markdown: string;
 }
 
+export interface LinkNativeRegex {
+  pattern: string;
+  caseInsensitive: boolean;
+  dotAll: boolean;
+  isDisabled: boolean;
+  isDefault: boolean;
+}
+
+export interface OnLinkDetected {
+  text: string;
+  url: string;
+  start: CodegenTypes.Int32;
+  end: CodegenTypes.Int32;
+}
+
 export interface ContextMenuItemConfig {
   text: string;
   icon?: string;
@@ -140,6 +155,12 @@ export interface NativeProps extends ViewProps {
    */
   contextMenuItems?: ReadonlyArray<Readonly<ContextMenuItemConfig>>;
 
+  /**
+   * Regex configuration for automatic link detection.
+   * Omit or pass undefined to use platform defaults.
+   */
+  linkRegex?: Readonly<LinkNativeRegex>;
+
   // Events
   onChangeText?: CodegenTypes.DirectEventHandler<OnChangeTextEvent>;
   onChangeMarkdown?: CodegenTypes.DirectEventHandler<OnChangeMarkdownEvent>;
@@ -149,6 +170,7 @@ export interface NativeProps extends ViewProps {
   onInputBlur?: CodegenTypes.DirectEventHandler<TargetedEvent>;
   onRequestMarkdownResult?: CodegenTypes.DirectEventHandler<OnRequestMarkdownResultEvent>;
   onContextMenuItemPress?: CodegenTypes.DirectEventHandler<OnContextMenuItemPressEvent>;
+  onLinkDetected?: CodegenTypes.DirectEventHandler<OnLinkDetected>;
 }
 
 type ComponentType = HostComponent<NativeProps>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ export type {
   MarkdownInputStyle,
   StyleState,
   ContextMenuItem,
+  OnLinkDetected,
 } from './EnrichedMarkdownInput';
 
 export type { ContextMenuItem as TextContextMenuItem } from './EnrichedMarkdownText';

--- a/src/utils/regexParser.ts
+++ b/src/utils/regexParser.ts
@@ -1,0 +1,54 @@
+import type { LinkNativeRegex } from '../EnrichedMarkdownInputNativeComponent';
+
+const DISABLED_REGEX: LinkNativeRegex = {
+  pattern: '',
+  caseInsensitive: false,
+  dotAll: false,
+  isDisabled: true,
+  isDefault: false,
+};
+
+const DEFAULT_REGEX: LinkNativeRegex = {
+  pattern: '',
+  caseInsensitive: false,
+  dotAll: false,
+  isDisabled: false,
+  isDefault: true,
+};
+
+export const toNativeRegexConfig = (
+  regex: RegExp | undefined | null
+): LinkNativeRegex => {
+  if (regex === null) {
+    return DISABLED_REGEX;
+  }
+
+  if (regex === undefined) {
+    return DEFAULT_REGEX;
+  }
+
+  const source = regex.source;
+
+  const hasLookbehind = source.includes('(?<=') || source.includes('(?<!');
+
+  if (hasLookbehind) {
+    const lookbehindContent = source.match(/\(\?<[=!](.*?)\)/)?.[1] || '';
+    if (/[*+{]/.test(lookbehindContent)) {
+      if (__DEV__) {
+        console.error(
+          'Variable-width lookbehinds are not supported. Using default link regex.'
+        );
+      }
+
+      return DEFAULT_REGEX;
+    }
+  }
+
+  return {
+    pattern: source,
+    caseInsensitive: regex.ignoreCase,
+    dotAll: regex.dotAll,
+    isDisabled: false,
+    isDefault: false,
+  };
+};


### PR DESCRIPTION
### What/Why?
Adds auto-link detection to EnrichedMarkdownInput. URLs are automatically recognized as the user types (e.g., google.com, www.google.com, https://google.com), visually styled in the input, and serialized as Markdown links in the output. Bare domains are normalized with https://. Detection can be customized via the linkRegex prop or disabled by passing null. A new onLinkDetected callback notifies JS when a link is detected.

Implements: #201 

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

