### PR TITLE
fix(ios): handle NSData from pasteboard when pasting copied markdown

### DIFF
--- a/ios/input/ENRMInputTextView.mm
+++ b/ios/input/ENRMInputTextView.mm
@@ -41,7 +41,14 @@ static NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-ma
 {
   UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
 
-  NSString *markdown = [pasteboard valueForPasteboardType:kENRMMarkdownPasteboardType];
+  NSString *markdown = nil;
+  id markdownValue = [pasteboard valueForPasteboardType:kENRMMarkdownPasteboardType];
+  if ([markdownValue isKindOfClass:[NSString class]]) {
+    markdown = markdownValue;
+  } else if ([markdownValue isKindOfClass:[NSData class]]) {
+    markdown = [[NSString alloc] initWithData:markdownValue encoding:NSUTF8StringEncoding];
+  }
+
   if (markdown.length > 0 && self.markdownInput != nil) {
     [self.markdownInput pasteMarkdown:markdown];
     return;


### PR DESCRIPTION
### What/Why?
Fixes a crash when copying and pasting within EnrichedMarkdownInput on iOS. UIPasteboard.valueForPasteboardType: can return NSData instead of NSString, causing an unrecognized selector exception. Added a runtime type check to safely decode the pasteboard value.

Fixes: #205 

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

