### PR TITLE
fix(android): move ktlint plugin out of shipped build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,10 +15,6 @@ buildscript {
   }
 }
 
-plugins {
-  id "org.jlleitschuh.gradle.ktlint" version "14.0.1"
-}
-
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "com.facebook.react"
@@ -91,20 +87,6 @@ dependencies {
     implementation("com.github.gregcockroft:AndroidMath:v1.1.0") {
       exclude group: 'com.google.guava', module: 'guava'
     }
-  }
-}
-
-ktlint {
-  version = "1.8.0"
-  debug = false
-  verbose = true
-  android = true
-  outputToConsole = true
-  ignoreFailures = false
-  enableExperimentalRules = false
-  filter {
-    exclude("**/build/**")
-    exclude("**/generated/**")
   }
 }
 

--- a/apps/example/android/build.gradle
+++ b/apps/example/android/build.gradle
@@ -18,4 +18,27 @@ buildscript {
     }
 }
 
+plugins {
+    id "org.jlleitschuh.gradle.ktlint" version "14.0.1" apply false
+}
+
 apply plugin: "com.facebook.react.rootproject"
+
+subprojects { subproject ->
+    if (subproject.name == "react-native-enriched-markdown") {
+        subproject.apply plugin: "org.jlleitschuh.gradle.ktlint"
+        subproject.ktlint {
+            version = "1.8.0"
+            debug = false
+            verbose = true
+            android = true
+            outputToConsole = true
+            ignoreFailures = false
+            enableExperimentalRules = false
+            filter {
+                exclude("**/build/**")
+                exclude("**/generated/**")
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What/Why?
Fixes: #224

The `ktlint` Gradle plugin was declared in `android/build.gradle`, which ships to npm. This caused Android build failures for consumers because the plugin couldn't be resolved from their repositories. Moved the plugin to the example app's `build.gradle` so it's only used during development.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

