### PR TITLE
feat: add ordered and unordered lists to the input

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputManager.kt
@@ -360,6 +360,14 @@ class EnrichedMarkdownInputManager :
     view?.removeLinkAtCursor()
   }
 
+  override fun toggleUnorderedList(view: EnrichedMarkdownInputView?) {
+    view?.toggleUnorderedList()
+  }
+
+  override fun toggleOrderedList(view: EnrichedMarkdownInputView?) {
+    view?.toggleOrderedList()
+  }
+
   override fun requestMarkdown(
     view: EnrichedMarkdownInputView?,
     requestId: Int,

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputView.kt
@@ -209,6 +209,9 @@ class EnrichedMarkdownInputView(
 
     isProcessingTextChange = true
     try {
+      // Auto-continue lists when a newline is added
+      handleAutoListContinuation(currentText, editStart, insertedLength)
+
       formattingStore.adjustForEdit(editStart, deletedLength, insertedLength)
       applyPendingStyles(editStart, insertedLength)
       applyFormatting()
@@ -478,6 +481,78 @@ class EnrichedMarkdownInputView(
     } finally {
       isProcessingTextChange = false
     }
+  }
+
+  private fun handleAutoListContinuation(
+    currentText: String,
+    editStart: Int,
+    insertedLength: Int,
+  ) {
+    val editable = text ?: return
+
+    // Only process if a newline was inserted
+    if (insertedLength == 0 || insertedLength > 1) return
+    if (editStart >= currentText.length || currentText[editStart] != '\n') return
+
+    // Find the previous line
+    var prevLineEnd = editStart - 1
+    if (prevLineEnd < 0) return
+
+    var prevLineStart = prevLineEnd
+    while (prevLineStart > 0 && currentText[prevLineStart - 1] != '\n') {
+      prevLineStart--
+    }
+
+    val prevLineText = currentText.substring(prevLineStart, prevLineEnd + 1)
+    val trimmedPrevLine = prevLineText.trimStart()
+    val indent = prevLineText.length - trimmedPrevLine.length
+    val indentStr = prevLineText.substring(0, indent)
+
+    // Check if previous line is a list item
+    val unorderedPattern = Regex("""^[-*+]\s+""")
+    val orderedPattern = Regex("""^(\d+)\.\s+""")
+
+    val isUnorderedList = unorderedPattern.containsMatchIn(trimmedPrevLine)
+    val isOrderedList = orderedPattern.containsMatchIn(trimmedPrevLine)
+
+    if (!isUnorderedList && !isOrderedList) return
+
+    val currentLineStart = editStart + 1
+    val currentLineEnd =
+      if (currentLineStart < currentText.length) {
+        currentText.indexOf('\n', currentLineStart).let { if (it == -1) currentText.length else it }
+      } else {
+        currentText.length
+      }
+
+    val currentLine =
+      if (currentLineStart < currentText.length) {
+        currentText.substring(currentLineStart, currentLineEnd)
+      } else {
+        ""
+      }
+
+    // Only continue if current line is empty
+    if (currentLine.isNotBlank()) return
+
+    val continuationMarker =
+      when {
+        isUnorderedList -> {
+          indentStr + "- "
+        }
+
+        else -> {
+          val match = orderedPattern.find(trimmedPrevLine)
+          val prevNum = match?.groupValues?.get(1)?.toIntOrNull() ?: 0
+          val nextNum = prevNum + 1
+          indentStr + "$nextNum. "
+        }
+      }
+
+    editable.insert(currentLineStart, continuationMarker)
+    formattingStore.adjustForEdit(currentLineStart, 0, continuationMarker.length)
+    // Move cursor to end of marker
+    setSelection(currentLineStart + continuationMarker.length)
   }
 
   fun setContextMenuItems(items: List<String>) {

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputView.kt
@@ -398,6 +398,88 @@ class EnrichedMarkdownInputView(
     applyFormattingAndEmit()
   }
 
+  fun toggleUnorderedList() {
+    toggleListMarker(unordered = true)
+  }
+
+  fun toggleOrderedList() {
+    toggleListMarker(unordered = false)
+  }
+
+  private fun toggleListMarker(unordered: Boolean) {
+    val editable = text ?: return
+    val pos = selectionStart
+
+    // Find line start and end
+    var lineStart = pos
+    while (lineStart > 0 && editable[lineStart - 1] != '\n') {
+      lineStart--
+    }
+
+    var lineEnd = pos
+    while (lineEnd < editable.length && editable[lineEnd] != '\n') {
+      lineEnd++
+    }
+
+    val lineText = editable.substring(lineStart, lineEnd)
+    val trimmedLine = lineText.trimStart()
+    val indent = lineText.length - trimmedLine.length
+    val indentStr = lineText.substring(0, indent)
+
+    // Check for existing list marker
+    val unorderedPattern = Regex("""^[-*+]\s+""")
+    val orderedPattern = Regex("""^\d+\.\s+""")
+
+    val isUnorderedList = unorderedPattern.containsMatchIn(trimmedLine)
+    val isOrderedList = orderedPattern.containsMatchIn(trimmedLine)
+
+    isProcessingTextChange = true
+    try {
+      when {
+        // Remove marker if same type is active
+        unordered && isUnorderedList -> {
+          val newLine = indentStr + trimmedLine.replaceFirst(unorderedPattern, "")
+          editable.replace(lineStart, lineEnd, newLine)
+          formattingStore.adjustForEdit(lineStart, lineEnd - lineStart, newLine.length)
+        }
+
+        !unordered && isOrderedList -> {
+          val newLine = indentStr + trimmedLine.replaceFirst(orderedPattern, "")
+          editable.replace(lineStart, lineEnd, newLine)
+          formattingStore.adjustForEdit(lineStart, lineEnd - lineStart, newLine.length)
+        }
+
+        // Replace marker if different type is active
+        unordered && isOrderedList -> {
+          val newLine = indentStr + trimmedLine.replaceFirst(orderedPattern, "- ")
+          editable.replace(lineStart, lineEnd, newLine)
+          formattingStore.adjustForEdit(lineStart, lineEnd - lineStart, newLine.length)
+        }
+
+        !unordered && isUnorderedList -> {
+          val newLine = indentStr + trimmedLine.replaceFirst(unorderedPattern, "1. ")
+          editable.replace(lineStart, lineEnd, newLine)
+          formattingStore.adjustForEdit(lineStart, lineEnd - lineStart, newLine.length)
+        }
+
+        // Add marker
+        else -> {
+          val marker = if (unordered) "- " else "1. "
+          val newLine = indentStr + marker + trimmedLine
+          editable.replace(lineStart, lineEnd, newLine)
+          formattingStore.adjustForEdit(lineStart, lineEnd - lineStart, newLine.length)
+        }
+      }
+
+      autoLinkDetector.clearAutoLinkInRange(editable, lineStart, lineEnd)
+      lastProcessedText = editable.toString()
+      applyFormattingAndEmit()
+      eventEmitter.emitChangeText()
+    } finally {
+      isProcessingTextChange = false
+    }
+  }
+
   fun setContextMenuItems(items: List<String>) {
     contextMenu.setContextMenuItems(items)
   }

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnChangeStateEvent.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnChangeStateEvent.kt
@@ -12,6 +12,8 @@ class OnChangeStateEvent(
   private val isUnderline: Boolean,
   private val isStrikethrough: Boolean,
   private val isLink: Boolean,
+  private val isUnorderedList: Boolean,
+  private val isOrderedList: Boolean,
 ) : Event<OnChangeStateEvent>(surfaceId, viewId) {
   override fun getEventName(): String = EVENT_NAME
 
@@ -36,6 +38,14 @@ class OnChangeStateEvent(
       putMap(
         "link",
         Arguments.createMap().apply { putBoolean("isActive", isLink) },
+      )
+      putMap(
+        "unorderedList",
+        Arguments.createMap().apply { putBoolean("isActive", isUnorderedList) },
+      )
+      putMap(
+        "orderedList",
+        Arguments.createMap().apply { putBoolean("isActive", isOrderedList) },
       )
     }
 

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
@@ -20,6 +20,8 @@ class InputEventEmitter(
   private val view: EnrichedMarkdownInputView,
 ) {
   private var prevState: Map<StyleType, Boolean> = emptyMap()
+  private var prevUnorderedListState = false
+  private var prevOrderedListState = false
 
   fun emitChangeText() {
     val plainText = view.text?.toString() ?: ""
@@ -44,8 +46,15 @@ class InputEventEmitter(
         isStyleEffectivelyActive(style, pos)
       }
 
-    if (current == prevState) return
+    // Detect if cursor is in a list
+    val (isUnorderedList, isOrderedList) = detectCurrentListState(pos)
+
+    // Check if state has changed
+    if (current == prevState && isUnorderedList == prevUnorderedListState && isOrderedList == prevOrderedListState) return
+
     prevState = current
+    prevUnorderedListState = isUnorderedList
+    prevOrderedListState = isOrderedList
 
     dispatch(
       OnChangeStateEvent(
@@ -56,6 +65,8 @@ class InputEventEmitter(
         current[StyleType.UNDERLINE] ?: false,
         current[StyleType.STRIKETHROUGH] ?: false,
         current[StyleType.LINK] ?: false,
+        isUnorderedList,
+        isOrderedList,
       ),
     )
   }
@@ -123,6 +134,36 @@ class InputEventEmitter(
         !view.pendingStyleRemovals.contains(style) &&
           view.formattingStore.isStyleActive(style, pos)
       )
+
+  private fun detectCurrentListState(pos: Int): Pair<Boolean, Boolean> {
+    val text = view.text?.toString() ?: return Pair(false, false)
+    if (pos == 0) return Pair(false, false)
+
+    // Find the start of the current line
+    var lineStart = pos - 1
+    while (lineStart >= 0 && text[lineStart] != '\n') {
+      lineStart--
+    }
+    lineStart++ // Move past the newline
+
+    // Find the end of the current line
+    var lineEnd = pos
+    while (lineEnd < text.length && text[lineEnd] != '\n') {
+      lineEnd++
+    }
+
+    val currentLine = text.substring(lineStart, lineEnd)
+
+    // Check for unordered list: ^[-*+]\s+
+    val unorderedPattern = Regex("""^[\s]*[-*+]\s+""")
+    val isUnorderedList = unorderedPattern.containsMatchIn(currentLine)
+
+    // Check for ordered list: ^\d+\.\s+
+    val orderedPattern = Regex("""^[\s]*\d+\.\s+""")
+    val isOrderedList = orderedPattern.containsMatchIn(currentLine)
+
+    return Pair(isUnorderedList, isOrderedList)
+  }
 
   private fun serializeToMarkdown(): String {
     val plainText = view.text?.toString() ?: ""

--- a/apps/example/src/InputScreen.tsx
+++ b/apps/example/src/InputScreen.tsx
@@ -57,7 +57,7 @@ const INITIAL_MESSAGES: Message[] = [
     id: 5,
     markdown:
       'Try using lists:\n- Unordered item 1\n- Unordered item 2\n\n1. Ordered item 1\n2. Ordered item 2',
-    isOwn: false,
+    isOwn: true,
     time: '10:54',
   },
 ];

--- a/apps/example/src/InputScreen.tsx
+++ b/apps/example/src/InputScreen.tsx
@@ -53,13 +53,20 @@ const INITIAL_MESSAGES: Message[] = [
     isOwn: true,
     time: '10:53',
   },
+  {
+    id: 5,
+    markdown:
+      'Try using lists:\n- Unordered item 1\n- Unordered item 2\n\n1. Ordered item 1\n2. Ordered item 2',
+    isOwn: false,
+    time: '10:54',
+  },
 ];
 
 const MARKDOWN_STYLE = {
   link: { color: '#2563EB', underline: true },
 };
 
-let nextId = 5;
+let nextId = 6;
 
 export default function InputScreen() {
   const inputRef = useRef<EnrichedMarkdownInputInstance>(null);
@@ -146,6 +153,8 @@ export default function InputScreen() {
             styleState.underline.isActive && 'underline',
             styleState.strikethrough.isActive && 'strikethrough',
             styleState.link.isActive && 'link',
+            styleState.unorderedList.isActive && 'unordered list',
+            styleState.orderedList.isActive && 'ordered list',
           ]
             .filter(Boolean)
             .join(', ');
@@ -241,6 +250,16 @@ export default function InputScreen() {
                 label: 'S',
                 style: 'strikethrough',
                 action: 'toggleStrikethrough',
+              },
+              {
+                label: '•',
+                style: 'unorderedList',
+                action: 'toggleUnorderedList',
+              },
+              {
+                label: '1.',
+                style: 'orderedList',
+                action: 'toggleOrderedList',
               },
             ] as const
           ).map(({ label, style, action }) => (

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -65,6 +65,14 @@ Each call toggles the style within the current text selection. They are being to
 
 Styles are also available through the built-in native format bar that appears on text selection, and through the system context menu.
 
+## Lists
+
+Supported lists:
+- Ordered lists (numbered)
+- Unordered lists (bullet points)
+
+Each of the lists can be toggled the same way as the inline styles. A `toggle` function is provided for both list types. Toggling a list or having the cursor on a list sets the `isActive` property of the `StyleState` of the list type to `true`, otherwise it is set to `false`.
+
 ## Links
 
 Links are a piece of text with a URL attributed to it. They can be managed by calling methods on the input ref:

--- a/ios/input/EnrichedMarkdownInput+Internal.h
+++ b/ios/input/EnrichedMarkdownInput+Internal.h
@@ -11,6 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)toggleItalic;
 - (void)toggleUnderline;
 - (void)toggleStrikethrough;
+- (void)toggleUnorderedList;
+- (void)toggleOrderedList;
 - (void)toggleInlineStyle:(ENRMInputStyleType)type;
 - (void)showLinkPrompt;
 

--- a/ios/input/EnrichedMarkdownInput.mm
+++ b/ios/input/EnrichedMarkdownInput.mm
@@ -702,6 +702,89 @@ using namespace facebook::react;
   [self emitFormattingChanged];
 }
 
+- (void)toggleUnorderedList
+{
+  [self toggleListMarkerWithUnordered:YES];
+}
+
+- (void)toggleOrderedList
+{
+  [self toggleListMarkerWithUnordered:NO];
+}
+
+- (void)toggleListMarkerWithUnordered:(BOOL)unordered
+{
+  NSString *text = [self plainText];
+  NSUInteger pos = _textView.selectedRange.location;
+
+  // Find line start
+  NSUInteger lineStart = pos;
+  while (lineStart > 0 && [text characterAtIndex:lineStart - 1] != '\n') {
+    lineStart--;
+  }
+
+  // Find line end
+  NSUInteger lineEnd = pos;
+  while (lineEnd < text.length && [text characterAtIndex:lineEnd] != '\n') {
+    lineEnd++;
+  }
+
+  NSString *lineText = [text substringWithRange:NSMakeRange(lineStart, lineEnd - lineStart)];
+  NSString *trimmed = [lineText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+  NSUInteger indentLength = lineText.length - trimmed.length;
+  NSString *indent = [lineText substringToIndex:indentLength];
+
+  // Check for existing markers
+  NSRegularExpression *unorderedRegex = [NSRegularExpression regularExpressionWithPattern:@"^[-*+]\\s+"
+                                                                                  options:0
+                                                                                    error:nil];
+  NSRegularExpression *orderedRegex = [NSRegularExpression regularExpressionWithPattern:@"^\\d+\\.\\s+"
+                                                                                options:0
+                                                                                  error:nil];
+
+  NSRange matchRange = NSMakeRange(0, trimmed.length);
+  BOOL isUnorderedList = [unorderedRegex numberOfMatchesInString:trimmed options:0 range:matchRange] > 0;
+  BOOL isOrderedList = [orderedRegex numberOfMatchesInString:trimmed options:0 range:matchRange] > 0;
+
+  NSString *newLine;
+
+  // Remove marker if same type is active
+  if (unordered && isUnorderedList) {
+    NSString *withoutMarker = [unorderedRegex stringByReplacingMatchesInString:trimmed
+                                                                       options:0
+                                                                         range:matchRange
+                                                                  withTemplate:@""];
+    newLine = [indent stringByAppendingString:withoutMarker];
+  } else if (!unordered && isOrderedList) {
+    NSString *withoutMarker = [orderedRegex stringByReplacingMatchesInString:trimmed
+                                                                     options:0
+                                                                       range:matchRange
+                                                                withTemplate:@""];
+    newLine = [indent stringByAppendingString:withoutMarker];
+  } else if (unordered && isOrderedList) {
+    // Replace ordered with unordered
+    NSString *withoutMarker = [orderedRegex stringByReplacingMatchesInString:trimmed
+                                                                     options:0
+                                                                       range:matchRange
+                                                                withTemplate:@""];
+    newLine = [indent stringByAppendingString:[@"- " stringByAppendingString:withoutMarker]];
+  } else if (!unordered && isUnorderedList) {
+    // Replace unordered with ordered
+    NSString *withoutMarker = [unorderedRegex stringByReplacingMatchesInString:trimmed
+                                                                       options:0
+                                                                         range:matchRange
+                                                                  withTemplate:@""];
+    newLine = [indent stringByAppendingString:[@"1. " stringByAppendingString:withoutMarker]];
+  } else {
+    // Add marker
+    NSString *marker = unordered ? @"- " : @"1. ";
+    newLine = [indent stringByAppendingString:[marker stringByAppendingString:trimmed]];
+  }
+
+  NSRange replaceRange = NSMakeRange(lineStart, lineEnd - lineStart);
+  [_textView replaceCharactersInRange:replaceRange withString:newLine];
+}
+
 - (void)showLinkPrompt
 {
   NSUInteger cursor = _textView.selectedRange.location;

--- a/ios/input/EnrichedMarkdownInput.mm
+++ b/ios/input/EnrichedMarkdownInput.mm
@@ -64,7 +64,7 @@ using namespace facebook::react;
   NSRange _preEditSelectedRange;
 
   struct {
-    BOOL bold, italic, underline, strikethrough, link, initialized;
+    BOOL bold, italic, underline, strikethrough, link, unorderedList, orderedList, initialized;
   } _prevState;
 
 #if TARGET_OS_OSX
@@ -936,9 +936,15 @@ using namespace facebook::react;
   BOOL strikethroughActive = [self isEffectiveStyleActive:ENRMInputStyleTypeStrikethrough atPosition:cursor];
   BOOL linkActive = [self isEffectiveStyleActive:ENRMInputStyleTypeLink atPosition:cursor];
 
+  // Detect list state
+  BOOL unorderedListActive = NO;
+  BOOL orderedListActive = NO;
+  [self detectListStateAtPosition:cursor unorderedList:&unorderedListActive orderedList:&orderedListActive];
+
   if (_prevState.initialized && _prevState.bold == boldActive && _prevState.italic == italicActive &&
       _prevState.underline == underlineActive && _prevState.strikethrough == strikethroughActive &&
-      _prevState.link == linkActive) {
+      _prevState.link == linkActive && _prevState.unorderedList == unorderedListActive &&
+      _prevState.orderedList == orderedListActive) {
     return;
   }
 
@@ -947,6 +953,8 @@ using namespace facebook::react;
   _prevState.underline = underlineActive;
   _prevState.strikethrough = strikethroughActive;
   _prevState.link = linkActive;
+  _prevState.unorderedList = unorderedListActive;
+  _prevState.orderedList = orderedListActive;
   _prevState.initialized = YES;
 
   emitter->onChangeState({
@@ -955,6 +963,8 @@ using namespace facebook::react;
       .underline = {.isActive = underlineActive},
       .strikethrough = {.isActive = strikethroughActive},
       .link = {.isActive = linkActive},
+      .unorderedList = {.isActive = unorderedListActive},
+      .orderedList = {.isActive = orderedListActive},
   });
 }
 
@@ -966,6 +976,57 @@ using namespace facebook::react;
 - (NSArray<NSString *> *)contextMenuItemIcons
 {
   return _contextMenuItemIcons ?: @[];
+}
+
+- (void)detectListStateAtPosition:(NSUInteger)position
+                    unorderedList:(BOOL *)unorderedList
+                      orderedList:(BOOL *)orderedList
+{
+  *unorderedList = NO;
+  *orderedList = NO;
+
+  NSString *text = _textView.textStorage.string;
+  if (position == 0 || text.length == 0) {
+    return;
+  }
+
+  // Find the start of the current line
+  NSUInteger lineStart = position - 1;
+  while (lineStart > 0 && [text characterAtIndex:lineStart - 1] != '\n') {
+    lineStart--;
+  }
+
+  // Find the end of the current line
+  NSUInteger lineEnd = position;
+  while (lineEnd < text.length && [text characterAtIndex:lineEnd] != '\n') {
+    lineEnd++;
+  }
+
+  NSString *currentLine = [text substringWithRange:NSMakeRange(lineStart, lineEnd - lineStart)];
+
+  // Check for unordered list: ^[\s]*[-*+]\s+
+  NSError *unorderedError = nil;
+  NSRegularExpression *unorderedRegex = [NSRegularExpression regularExpressionWithPattern:@"^[\\s]*[-*+]\\s+"
+                                                                                  options:0
+                                                                                    error:&unorderedError];
+  NSArray *unorderedMatches = [unorderedRegex matchesInString:currentLine
+                                                      options:0
+                                                        range:NSMakeRange(0, currentLine.length)];
+  if (unorderedMatches.count > 0) {
+    *unorderedList = YES;
+  }
+
+  // Check for ordered list: ^\d+\.\s+
+  NSError *orderedError = nil;
+  NSRegularExpression *orderedRegex = [NSRegularExpression regularExpressionWithPattern:@"^[\\s]*\\d+\\.\\s+"
+                                                                                options:0
+                                                                                  error:&orderedError];
+  NSArray *orderedMatches = [orderedRegex matchesInString:currentLine
+                                                  options:0
+                                                    range:NSMakeRange(0, currentLine.length)];
+  if (orderedMatches.count > 0) {
+    *orderedList = YES;
+  }
 }
 
 - (void)emitContextMenuItemPress:(NSString *)itemText
@@ -1042,6 +1103,82 @@ using namespace facebook::react;
 
 #pragma mark - Text edit tracking
 
+- (void)handleAutoListContinuationWithText:(NSString *)currentText
+                              editLocation:(NSUInteger)editLocation
+                            insertedLength:(NSUInteger)insertedLength
+{
+  // Only handle single newline insertion
+  if (insertedLength != 1 || editLocation >= currentText.length ||
+      [currentText characterAtIndex:editLocation] != '\n') {
+    return;
+  }
+
+  // Find the previous line
+  NSUInteger prevLineEnd = editLocation; // This is where the newline was inserted
+  if (prevLineEnd == 0) {
+    return;
+  }
+
+  // Move back to find the start of the previous line
+  NSUInteger prevLineStart = prevLineEnd - 1;
+  while (prevLineStart > 0 && [currentText characterAtIndex:prevLineStart - 1] != '\n') {
+    prevLineStart--;
+  }
+
+  // Extract the previous line
+  NSString *prevLine = [currentText substringWithRange:NSMakeRange(prevLineStart, prevLineEnd - prevLineStart)];
+
+  // Check for unordered list marker: ^[-*+]\s+
+  NSError *unorderedError = nil;
+  NSRegularExpression *unorderedRegex = [NSRegularExpression regularExpressionWithPattern:@"^(\\s*)[-*+]\\s+"
+                                                                                  options:0
+                                                                                    error:&unorderedError];
+  NSArray *unorderedMatches = [unorderedRegex matchesInString:prevLine options:0 range:NSMakeRange(0, prevLine.length)];
+
+  if (unorderedMatches.count > 0) {
+    NSTextCheckingResult *match = unorderedMatches[0];
+    NSRange captureRange = [match rangeAtIndex:1]; // Capture group 1 is the indentation
+    NSString *indentStr = [prevLine substringWithRange:captureRange];
+
+    // Insert the list marker
+    NSString *marker = [indentStr stringByAppendingString:@"- "];
+    [_textView.textStorage replaceCharactersInRange:NSMakeRange(editLocation + 1, 0) withString:marker];
+
+    // Move cursor to after the inserted marker
+    _textView.selectedRange = NSMakeRange(editLocation + 1 + marker.length, 0);
+    _lastTextLength = currentText.length + marker.length;
+    [_formattingStore adjustForEditAtLocation:editLocation + 1 deletedLength:0 insertedLength:marker.length];
+
+    return;
+  }
+
+  // Check for ordered list marker: ^\d+\.\s+
+  NSError *orderedError = nil;
+  NSRegularExpression *orderedRegex = [NSRegularExpression regularExpressionWithPattern:@"^(\\s*)(\\d+)\\.\\s+"
+                                                                                options:0
+                                                                                  error:&orderedError];
+  NSArray *orderedMatches = [orderedRegex matchesInString:prevLine options:0 range:NSMakeRange(0, prevLine.length)];
+
+  if (orderedMatches.count > 0) {
+    NSTextCheckingResult *match = orderedMatches[0];
+    NSRange indentRange = [match rangeAtIndex:1]; // Capture group 1 is the indentation
+    NSRange numberRange = [match rangeAtIndex:2]; // Capture group 2 is the number
+
+    NSString *indentStr = [prevLine substringWithRange:indentRange];
+    NSString *numberStr = [prevLine substringWithRange:numberRange];
+    NSInteger nextNumber = numberStr.integerValue + 1;
+
+    // Insert the next list number with marker
+    NSString *marker = [NSString stringWithFormat:@"%@%ld. ", indentStr, (long)nextNumber];
+    [_textView.textStorage replaceCharactersInRange:NSMakeRange(editLocation + 1, 0) withString:marker];
+
+    // Move cursor to after the inserted marker
+    _textView.selectedRange = NSMakeRange(editLocation + 1 + marker.length, 0);
+    _lastTextLength = currentText.length + marker.length;
+    [_formattingStore adjustForEditAtLocation:editLocation + 1 deletedLength:0 insertedLength:marker.length];
+  }
+}
+
 - (void)handleTextChanged
 {
   if (ENRMHasMarkedText(_textView)) {
@@ -1075,6 +1212,11 @@ using namespace facebook::react;
   }
 
   [_formattingStore adjustForEditAtLocation:editLocation deletedLength:deletedLength insertedLength:insertedLength];
+
+  // Auto-continue lists when a newline is added
+  [self handleAutoListContinuationWithText:ENRMGetPlainText(_textView)
+                              editLocation:editLocation
+                            insertedLength:insertedLength];
 
   if (insertedLength > 0) {
     NSRange insertedRange = NSMakeRange(editLocation, insertedLength);

--- a/src/EnrichedMarkdownInput.tsx
+++ b/src/EnrichedMarkdownInput.tsx
@@ -50,6 +50,8 @@ export interface StyleState {
   underline: { isActive: boolean };
   strikethrough: { isActive: boolean };
   link: { isActive: boolean };
+  unorderedList: { isActive: boolean };
+  orderedList: { isActive: boolean };
 }
 
 export interface ContextMenuItem {
@@ -207,7 +209,56 @@ export const EnrichedMarkdownInput = ({
 
   const handleChangeMarkdown = useCallback(
     (e: NativeSyntheticEvent<OnChangeMarkdownEvent>) => {
-      onChangeMarkdown?.(e.nativeEvent.value);
+      const markdown = e.nativeEvent.value;
+
+      // Auto-continue lists: when pressing Enter on a list item, add the next marker
+      const lines = markdown.split('\n');
+      const currentLineIndex = lines.length - 1;
+
+      if (
+        currentLineIndex > 0 &&
+        lines[currentLineIndex] !== undefined &&
+        lines[currentLineIndex - 1] !== undefined
+      ) {
+        const currentLine = lines[currentLineIndex]!;
+        const previousLine = lines[currentLineIndex - 1]!;
+
+        // If current line is empty and previous line is a list item
+        const unorderedMatch = previousLine.match(/^\s*[-*]\s+.+$/);
+        const orderedMatch = previousLine.match(/^\s*\d+\.\s+.+$/);
+
+        if (currentLine.trim() === '' && (unorderedMatch || orderedMatch)) {
+          if (unorderedMatch) {
+            // Continue unordered list
+            const indent = previousLine.match(/^\s*/)?.[0] || '';
+            lines[currentLineIndex] = indent + '- ';
+            if (nativeRef.current) {
+              Commands.setValue(
+                nativeRef.current as Parameters<
+                  (typeof Commands)['setValue']
+                >[0],
+                lines.join('\n')
+              );
+            }
+          } else if (orderedMatch) {
+            // Continue ordered list with incremented number
+            const indent = previousLine.match(/^\s*/)?.[0] || '';
+            const numMatch = previousLine.match(/\d+/);
+            const nextNum = (numMatch ? parseInt(numMatch[0], 10) : 0) + 1;
+            lines[currentLineIndex] = indent + `${nextNum}. `;
+            if (nativeRef.current) {
+              Commands.setValue(
+                nativeRef.current as Parameters<
+                  (typeof Commands)['setValue']
+                >[0],
+                lines.join('\n')
+              );
+            }
+          }
+        }
+      }
+
+      onChangeMarkdown?.(markdown);
     },
     [onChangeMarkdown]
   );
@@ -222,8 +273,24 @@ export const EnrichedMarkdownInput = ({
 
   const handleChangeState = useCallback(
     (e: NativeSyntheticEvent<OnChangeStateEvent>) => {
-      const { bold, italic, underline, strikethrough, link } = e.nativeEvent;
-      onChangeState?.({ bold, italic, underline, strikethrough, link });
+      const {
+        bold,
+        italic,
+        underline,
+        strikethrough,
+        link,
+        unorderedList,
+        orderedList,
+      } = e.nativeEvent;
+      onChangeState?.({
+        bold,
+        italic,
+        underline,
+        strikethrough,
+        link,
+        unorderedList: unorderedList || { isActive: false },
+        orderedList: orderedList || { isActive: false },
+      });
     },
     [onChangeState]
   );

--- a/src/EnrichedMarkdownInput.tsx
+++ b/src/EnrichedMarkdownInput.tsx
@@ -209,56 +209,9 @@ export const EnrichedMarkdownInput = ({
 
   const handleChangeMarkdown = useCallback(
     (e: NativeSyntheticEvent<OnChangeMarkdownEvent>) => {
-      const markdown = e.nativeEvent.value;
-
-      // Auto-continue lists: when pressing Enter on a list item, add the next marker
-      const lines = markdown.split('\n');
-      const currentLineIndex = lines.length - 1;
-
-      if (
-        currentLineIndex > 0 &&
-        lines[currentLineIndex] !== undefined &&
-        lines[currentLineIndex - 1] !== undefined
-      ) {
-        const currentLine = lines[currentLineIndex]!;
-        const previousLine = lines[currentLineIndex - 1]!;
-
-        // If current line is empty and previous line is a list item
-        const unorderedMatch = previousLine.match(/^\s*[-*]\s+.+$/);
-        const orderedMatch = previousLine.match(/^\s*\d+\.\s+.+$/);
-
-        if (currentLine.trim() === '' && (unorderedMatch || orderedMatch)) {
-          if (unorderedMatch) {
-            // Continue unordered list
-            const indent = previousLine.match(/^\s*/)?.[0] || '';
-            lines[currentLineIndex] = indent + '- ';
-            if (nativeRef.current) {
-              Commands.setValue(
-                nativeRef.current as Parameters<
-                  (typeof Commands)['setValue']
-                >[0],
-                lines.join('\n')
-              );
-            }
-          } else if (orderedMatch) {
-            // Continue ordered list with incremented number
-            const indent = previousLine.match(/^\s*/)?.[0] || '';
-            const numMatch = previousLine.match(/\d+/);
-            const nextNum = (numMatch ? parseInt(numMatch[0], 10) : 0) + 1;
-            lines[currentLineIndex] = indent + `${nextNum}. `;
-            if (nativeRef.current) {
-              Commands.setValue(
-                nativeRef.current as Parameters<
-                  (typeof Commands)['setValue']
-                >[0],
-                lines.join('\n')
-              );
-            }
-          }
-        }
-      }
-
-      onChangeMarkdown?.(markdown);
+      // Auto-continue lists is implemented on the native side (iOS/Android)
+      // The native code detects new lines and auto-inserts list markers
+      onChangeMarkdown?.(e.nativeEvent.value);
     },
     [onChangeMarkdown]
   );

--- a/src/EnrichedMarkdownInput.tsx
+++ b/src/EnrichedMarkdownInput.tsx
@@ -75,6 +75,8 @@ export interface EnrichedMarkdownInputInstance {
   toggleItalic: () => void;
   toggleUnderline: () => void;
   toggleStrikethrough: () => void;
+  toggleUnorderedList: () => void;
+  toggleOrderedList: () => void;
   setLink: (url: string) => void;
   insertLink: (text: string, url: string) => void;
   removeLink: () => void;
@@ -284,6 +286,8 @@ export const EnrichedMarkdownInput = ({
       toggleItalic: () => Commands.toggleItalic(commandRef),
       toggleUnderline: () => Commands.toggleUnderline(commandRef),
       toggleStrikethrough: () => Commands.toggleStrikethrough(commandRef),
+      toggleUnorderedList: () => Commands.toggleUnorderedList(commandRef),
+      toggleOrderedList: () => Commands.toggleOrderedList(commandRef),
       setLink: (url) => Commands.setLink(commandRef, url),
       insertLink: (text, url) => Commands.insertLink(commandRef, text, url),
       removeLink: () => Commands.removeLink(commandRef),

--- a/src/EnrichedMarkdownInputNativeComponent.ts
+++ b/src/EnrichedMarkdownInputNativeComponent.ts
@@ -191,6 +191,8 @@ interface NativeCommands {
   toggleItalic: (viewRef: React.ElementRef<ComponentType>) => void;
   toggleUnderline: (viewRef: React.ElementRef<ComponentType>) => void;
   toggleStrikethrough: (viewRef: React.ElementRef<ComponentType>) => void;
+  toggleUnorderedList: (viewRef: React.ElementRef<ComponentType>) => void;
+  toggleOrderedList: (viewRef: React.ElementRef<ComponentType>) => void;
   setLink: (viewRef: React.ElementRef<ComponentType>, url: string) => void;
   insertLink: (
     viewRef: React.ElementRef<ComponentType>,
@@ -214,6 +216,8 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
     'toggleItalic',
     'toggleUnderline',
     'toggleStrikethrough',
+    'toggleUnorderedList',
+    'toggleOrderedList',
     'setLink',
     'insertLink',
     'removeLink',

--- a/src/EnrichedMarkdownInputNativeComponent.ts
+++ b/src/EnrichedMarkdownInputNativeComponent.ts
@@ -44,6 +44,8 @@ export interface OnChangeStateEvent {
   underline: { isActive: boolean };
   strikethrough: { isActive: boolean };
   link: { isActive: boolean };
+  unorderedList: { isActive: boolean };
+  orderedList: { isActive: boolean };
 }
 
 export interface OnRequestMarkdownResultEvent {
@@ -82,6 +84,8 @@ export interface OnContextMenuItemPressEvent {
     underline: { isActive: boolean };
     strikethrough: { isActive: boolean };
     link: { isActive: boolean };
+    unorderedList: { isActive: boolean };
+    orderedList: { isActive: boolean };
   };
 }
 


### PR DESCRIPTION
### What/Why?
Adds the support for ordered (numbered) and unordered (bullet) lists in the input provided. I followed the logic of the inline styles that are currently implemented. I made `toggle` functions along with an `isActive` property in the StyleState. I also handled list continuation when returning to line. This should work for both iOS and Android. I made sure to include the feature in the `InputScreen.tsx` and added a small description in the documentation.



### Testing
I tested thoroughly on Android. It works as expected. I unfortunately can't test on iOS, so I would appreciate it if someone could try the example app on iOS and try to :
- toggle an unordered list 
- return to line and have the list continue
- toggle again to stop the list
- toggle an ordered list
- return to line and have the list continue (with 2.)
- toggle again to stop the list
- verify that states (color on the buttons) are coherent even when returning the cursor later to a list.

https://github.com/user-attachments/assets/893523b7-70bb-4442-9c31-cd9b04f27cc9

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes

