### PR TITLE
refactor(android): unify duplicated AST segment splitting into shared utility

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -19,6 +19,8 @@ import com.swmansion.enriched.markdown.spans.ImageSpan
 import com.swmansion.enriched.markdown.spoiler.SpoilerMode
 import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.FeatureFlags
+import com.swmansion.enriched.markdown.utils.common.MarkdownSegment
+import com.swmansion.enriched.markdown.utils.common.splitASTIntoSegments
 import com.swmansion.enriched.markdown.utils.text.view.emitLinkLongPressEvent
 import com.swmansion.enriched.markdown.utils.text.view.emitLinkPressEvent
 import com.swmansion.enriched.markdown.views.BlockSegmentView
@@ -199,38 +201,11 @@ class EnrichedMarkdown
             }
 
           val processedSegments =
-            splitASTIntoSegments(ast).map { segmentNode ->
-              when (segmentNode) {
-                is MarkdownASTNode -> {
-                  when (segmentNode.type) {
-                    MarkdownASTNode.NodeType.Table -> {
-                      RenderSegment.Table(segmentNode)
-                    }
-
-                    MarkdownASTNode.NodeType.LatexMathDisplay -> {
-                      val latex =
-                        if (segmentNode.children.isNotEmpty()) {
-                          segmentNode.children.first().content
-                        } else {
-                          segmentNode.content
-                        }
-                      RenderSegment.Math(latex)
-                    }
-
-                    else -> {
-                      renderTextSegment(listOf(segmentNode), style)
-                    }
-                  }
-                }
-
-                is List<*> -> {
-                  @Suppress("UNCHECKED_CAST")
-                  renderTextSegment(segmentNode as List<MarkdownASTNode>, style)
-                }
-
-                else -> {
-                  throw IllegalArgumentException("Unknown segment type")
-                }
+            splitASTIntoSegments(ast).map { segment ->
+              when (segment) {
+                is MarkdownSegment.Text -> renderTextSegment(segment.nodes, style)
+                is MarkdownSegment.Table -> RenderSegment.Table(segment.node)
+                is MarkdownSegment.Math -> RenderSegment.Math(segment.latex)
               }
             }
 
@@ -322,32 +297,6 @@ class EnrichedMarkdown
       } catch (_: Exception) {
         android.view.View(context)
       }
-    }
-
-    private fun splitASTIntoSegments(root: MarkdownASTNode): List<Any> {
-      val segments = mutableListOf<Any>()
-      val currentTextBuffer = mutableListOf<MarkdownASTNode>()
-
-      fun flushTextBuffer() {
-        if (currentTextBuffer.isNotEmpty()) {
-          segments.add(currentTextBuffer.toList())
-          currentTextBuffer.clear()
-        }
-      }
-
-      root.children.forEach { child ->
-        if (child.type == MarkdownASTNode.NodeType.Table) {
-          flushTextBuffer()
-          segments.add(child)
-        } else if (child.type == MarkdownASTNode.NodeType.LatexMathDisplay) {
-          flushTextBuffer()
-          segments.add(child)
-        } else {
-          currentTextBuffer.add(child)
-        }
-      }
-      flushTextBuffer()
-      return segments
     }
 
     private fun postToMain(

--- a/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -21,9 +21,11 @@ import com.swmansion.enriched.markdown.spans.MathMetrics
 import com.swmansion.enriched.markdown.spans.MathRenderMode
 import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.FeatureFlags
+import com.swmansion.enriched.markdown.utils.common.MarkdownSegment
 import com.swmansion.enriched.markdown.utils.common.getBooleanOrDefault
 import com.swmansion.enriched.markdown.utils.common.getMapOrNull
 import com.swmansion.enriched.markdown.utils.common.getStringOrDefault
+import com.swmansion.enriched.markdown.utils.common.splitASTIntoSegments
 import com.swmansion.enriched.markdown.utils.text.extensions.replaceMathSpansWithPlaceholders
 import com.swmansion.enriched.markdown.views.TableContainerView
 import java.util.concurrent.ConcurrentHashMap
@@ -275,22 +277,6 @@ object MeasurementStore {
     return adjustedSize
   }
 
-/** Sealed interface for type-safe segment handling */
-  private sealed interface MarkdownSegment {
-    data class Text(
-      val nodes: List<MarkdownASTNode>,
-    ) : MarkdownSegment
-
-    data class Table(
-      val node: MarkdownASTNode,
-    ) : MarkdownSegment
-
-    data class Math(
-      val latex: String,
-      val node: MarkdownASTNode,
-    ) : MarkdownSegment
-  }
-
   private fun measureAndCacheSplit(
     context: Context,
     id: Int?,
@@ -425,44 +411,6 @@ object MeasurementStore {
           setUseLineSpacingFromFallbacks(true)
         }
       }.build()
-  }
-
-  private fun splitASTIntoSegments(root: MarkdownASTNode): List<MarkdownSegment> {
-    val segments = mutableListOf<MarkdownSegment>()
-    val currentTextNodes = mutableListOf<MarkdownASTNode>()
-
-    fun flushTextNodes() {
-      if (currentTextNodes.isNotEmpty()) {
-        segments.add(MarkdownSegment.Text(currentTextNodes.toList()))
-        currentTextNodes.clear()
-      }
-    }
-
-    for (child in root.children) {
-      when (child.type) {
-        MarkdownASTNode.NodeType.Table -> {
-          flushTextNodes()
-          segments.add(MarkdownSegment.Table(child))
-        }
-
-        MarkdownASTNode.NodeType.LatexMathDisplay -> {
-          flushTextNodes()
-          val latex =
-            if (child.children.isNotEmpty()) {
-              child.children.first().content
-            } else {
-              child.content
-            }
-          segments.add(MarkdownSegment.Math(latex, child))
-        }
-
-        else -> {
-          currentTextNodes.add(child)
-        }
-      }
-    }
-    flushTextNodes()
-    return segments
   }
 
   private fun tryRenderMarkdown(

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MarkdownSegment.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MarkdownSegment.kt
@@ -1,0 +1,56 @@
+package com.swmansion.enriched.markdown.utils.common
+
+import com.swmansion.enriched.markdown.parser.MarkdownASTNode
+
+sealed interface MarkdownSegment {
+  data class Text(
+    val nodes: List<MarkdownASTNode>,
+  ) : MarkdownSegment
+
+  data class Table(
+    val node: MarkdownASTNode,
+  ) : MarkdownSegment
+
+  data class Math(
+    val latex: String,
+    val node: MarkdownASTNode,
+  ) : MarkdownSegment
+}
+
+fun splitASTIntoSegments(root: MarkdownASTNode): List<MarkdownSegment> {
+  val segments = mutableListOf<MarkdownSegment>()
+  val currentTextNodes = mutableListOf<MarkdownASTNode>()
+
+  fun flushTextNodes() {
+    if (currentTextNodes.isNotEmpty()) {
+      segments.add(MarkdownSegment.Text(currentTextNodes.toList()))
+      currentTextNodes.clear()
+    }
+  }
+
+  for (child in root.children) {
+    when (child.type) {
+      MarkdownASTNode.NodeType.Table -> {
+        flushTextNodes()
+        segments.add(MarkdownSegment.Table(child))
+      }
+
+      MarkdownASTNode.NodeType.LatexMathDisplay -> {
+        flushTextNodes()
+        val latex =
+          if (child.children.isNotEmpty()) {
+            child.children.first().content
+          } else {
+            child.content
+          }
+        segments.add(MarkdownSegment.Math(latex, child))
+      }
+
+      else -> {
+        currentTextNodes.add(child)
+      }
+    }
+  }
+  flushTextNodes()
+  return segments
+}


### PR DESCRIPTION
### What/Why?
Unifies duplicated AST segment splitting logic on Android. `EnrichedMarkdown.kt` and `MeasurementStore.kt` each had their own copy of the segmentation code (splitting markdown AST into text, table, and math segments). This extracts it into a shared `MarkdownSegment`.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

