### PR TITLE
refactor(ios): extract shared text view setup, layout manager, and measurement helpers

### DIFF
--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -9,12 +9,11 @@
 #import "ENRMSpoilerOverlayManager.h"
 #import "ENRMSpoilerTapUtils.h"
 #import "ENRMTailFadeInAnimator.h"
-#import "ENRMUIKit.h"
+#import "ENRMTextViewSetup.h"
 #import "EditMenuUtils.h"
 #import "FontScaleObserver.h"
 #import "FontUtils.h"
 #import "HeightUpdateUtils.h"
-#import "LastElementUtils.h"
 #import "LinkTapUtils.h"
 #import "MarkdownASTNode.h"
 #import "MarkdownAccessibilityElementBuilder.h"
@@ -22,12 +21,8 @@
 #import "ParagraphStyleUtils.h"
 #import "RenderContext.h"
 #import "RuntimeKeys.h"
-#import "StyleConfig.h"
 #import "StylePropsUtils.h"
 #import "TaskListTapUtils.h"
-#import "TextViewLayoutManager.h"
-#import <React/RCTUtils.h>
-#import <objc/runtime.h>
 
 #import <ReactNativeEnrichedMarkdown/EnrichedMarkdownTextComponentDescriptor.h>
 #import <ReactNativeEnrichedMarkdown/EventEmitters.h>
@@ -98,35 +93,12 @@ using namespace facebook::react;
 
 - (CGSize)measureSize:(CGFloat)maxWidth
 {
-  NSAttributedString *text = ENRMGetAttributedText(_textView);
-  CGFloat defaultHeight = UIFontLineHeight([UIFont systemFontOfSize:16.0]);
-
-  if (text.length == 0) {
+  CGSize size = ENRMMeasureMarkdownText(_textView, maxWidth, _config, _allowTrailingMargin, _lastElementMarginBottom);
+  if (CGSizeEqualToSize(size, CGSizeZero)) {
+    CGFloat defaultHeight = UIFontLineHeight([UIFont systemFontOfSize:16.0]);
     return CGSizeMake(maxWidth, defaultHeight);
   }
-
-  ENRMTextLayoutResult layout = ENRMMeasureTextLayout(_textView, maxWidth);
-
-  CGFloat measuredWidth = layout.usedRect.size.width;
-  CGFloat measuredHeight = layout.usedRect.size.height;
-
-  if (!CGRectIsEmpty(layout.extraLineFragmentRect)) {
-    measuredHeight -= layout.extraLineFragmentRect.size.height;
-  }
-
-  // Code block's bottom padding is a spacer \n with minimumLineHeight = codeBlockPadding.
-  // The layout manager may not size it accurately, so add the padding explicitly.
-  if (isLastElementCodeBlock(text)) {
-    measuredHeight += [_config codeBlockPadding];
-  }
-
-  if (_allowTrailingMargin && _lastElementMarginBottom > 0) {
-    measuredHeight += _lastElementMarginBottom;
-  }
-
-  // Round to pixel boundaries to match React Native's <Text> measurement
-  CGFloat scale = RCTScreenScale();
-  return CGSizeMake(ceil(measuredWidth * scale) / scale, ceil(measuredHeight * scale) / scale);
+  return size;
 }
 
 - (BOOL)hasRenderedMarkdown:(NSString *)markdown
@@ -250,28 +222,15 @@ using namespace facebook::react;
 
 - (void)willRemoveSubview:(RCTUIView *)subview
 {
-  if (subview == _textView && _textView.layoutManager != nil) {
-    NSLayoutManager *layoutManager = _textView.layoutManager;
-    if ([object_getClass(layoutManager) isEqual:[TextViewLayoutManager class]]) {
-      [layoutManager setValue:nil forKey:@"config"];
-      object_setClass(layoutManager, [NSLayoutManager class]);
-    }
+  if (subview == _textView) {
+    ENRMDetachLayoutManager(_textView);
   }
   [super willRemoveSubview:subview];
 }
 
 - (void)setupLayoutManager
 {
-  // Custom layout manager handles drawing for code blocks, blockquotes, etc.
-  NSLayoutManager *layoutManager = _textView.layoutManager;
-  if (layoutManager != nil) {
-    layoutManager.allowsNonContiguousLayout = NO; // workaround for onScroll issue
-    object_setClass(layoutManager, [TextViewLayoutManager class]);
-
-    if (_config != nil) {
-      [layoutManager setValue:_config forKey:@"config"];
-    }
-  }
+  ENRMAttachLayoutManager(_textView, _config);
 }
 
 - (void)renderMarkdownContent:(NSString *)markdownString

--- a/ios/utils/ENRMTextViewSetup.h
+++ b/ios/utils/ENRMTextViewSetup.h
@@ -1,0 +1,62 @@
+#pragma once
+#import "ENRMUIKit.h"
+#import "LastElementUtils.h"
+#import "StyleConfig.h"
+#import "TextViewLayoutManager.h"
+#import <React/RCTUtils.h>
+#import <objc/runtime.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static inline void ENRMAttachLayoutManager(ENRMPlatformTextView *textView, StyleConfig *_Nullable config)
+{
+  NSLayoutManager *layoutManager = textView.layoutManager;
+  if (layoutManager == nil) {
+    return;
+  }
+  layoutManager.allowsNonContiguousLayout = NO;
+  object_setClass(layoutManager, [TextViewLayoutManager class]);
+  if (config != nil) {
+    [layoutManager setValue:config forKey:@"config"];
+  }
+}
+
+static inline void ENRMDetachLayoutManager(ENRMPlatformTextView *textView)
+{
+  NSLayoutManager *layoutManager = textView.layoutManager;
+  if (layoutManager != nil && [object_getClass(layoutManager) isEqual:[TextViewLayoutManager class]]) {
+    [layoutManager setValue:nil forKey:@"config"];
+    object_setClass(layoutManager, [NSLayoutManager class]);
+  }
+}
+
+static inline CGSize ENRMMeasureMarkdownText(ENRMPlatformTextView *textView, CGFloat maxWidth, StyleConfig *config,
+                                             BOOL allowTrailingMargin, CGFloat lastElementMarginBottom)
+{
+  NSAttributedString *text = ENRMGetAttributedText(textView);
+  if (text.length == 0) {
+    return CGSizeZero;
+  }
+
+  ENRMTextLayoutResult layout = ENRMMeasureTextLayout(textView, maxWidth);
+
+  CGFloat measuredWidth = layout.usedRect.size.width;
+  CGFloat measuredHeight = layout.usedRect.size.height;
+
+  if (!CGRectIsEmpty(layout.extraLineFragmentRect)) {
+    measuredHeight -= layout.extraLineFragmentRect.size.height;
+  }
+
+  if (isLastElementCodeBlock(text)) {
+    measuredHeight += [config codeBlockPadding];
+  }
+
+  if (allowTrailingMargin && lastElementMarginBottom > 0) {
+    measuredHeight += lastElementMarginBottom;
+  }
+
+  CGFloat scale = RCTScreenScale();
+  return CGSizeMake(ceil(measuredWidth * scale) / scale, ceil(measuredHeight * scale) / scale);
+}
+
+NS_ASSUME_NONNULL_END

--- a/ios/views/EnrichedMarkdownInternalText.m
+++ b/ios/views/EnrichedMarkdownInternalText.m
@@ -2,16 +2,11 @@
 #import "AccessibilityInfo.h"
 #import "ENRMContextMenuTextView+macOS.h"
 #import "ENRMSpoilerOverlayManager.h"
-#import "ENRMUIKit.h"
-#import "LastElementUtils.h"
+#import "ENRMTextViewSetup.h"
 #import "MarkdownAccessibilityElementBuilder.h"
 #import "RenderContext.h"
 #import "RuntimeKeys.h"
-#import "StyleConfig.h"
-#import "TextViewLayoutManager.h"
-#import <React/RCTUtils.h>
 #include <TargetConditionals.h>
-#import <objc/runtime.h>
 
 @implementation EnrichedMarkdownInternalText {
   ENRMPlatformTextView *_textView;
@@ -59,14 +54,7 @@
 
 - (void)setupLayoutManager
 {
-  NSLayoutManager *layoutManager = _textView.layoutManager;
-  if (layoutManager != nil) {
-    layoutManager.allowsNonContiguousLayout = NO;
-    object_setClass(layoutManager, [TextViewLayoutManager class]);
-    if (_config != nil) {
-      [layoutManager setValue:_config forKey:@"config"];
-    }
-  }
+  ENRMAttachLayoutManager(_textView, _config);
 }
 
 - (void)setSpoilerMode:(ENRMSpoilerMode)spoilerMode
@@ -108,30 +96,7 @@
 
 - (CGSize)measureSize:(CGFloat)maxWidth
 {
-  NSAttributedString *text = ENRMGetAttributedText(_textView);
-  if (text.length == 0) {
-    return CGSizeZero;
-  }
-
-  ENRMTextLayoutResult layout = ENRMMeasureTextLayout(_textView, maxWidth);
-
-  CGFloat measuredHeight = layout.usedRect.size.height;
-  CGFloat measuredWidth = layout.usedRect.size.width;
-
-  if (!CGRectIsEmpty(layout.extraLineFragmentRect)) {
-    measuredHeight -= layout.extraLineFragmentRect.size.height;
-  }
-
-  if (isLastElementCodeBlock(text)) {
-    measuredHeight += [_config codeBlockPadding];
-  }
-
-  if (_allowTrailingMargin && _lastElementMarginBottom > 0) {
-    measuredHeight += _lastElementMarginBottom;
-  }
-
-  CGFloat scale = RCTScreenScale();
-  return CGSizeMake(ceil(measuredWidth * scale) / scale, ceil(measuredHeight * scale) / scale);
+  return ENRMMeasureMarkdownText(_textView, maxWidth, _config, _allowTrailingMargin, _lastElementMarginBottom);
 }
 
 - (void)layoutSubviews


### PR DESCRIPTION
### What/Why?
Extracts duplicated text view setup, layout manager swizzling, and markdown measurement logic from `EnrichedMarkdownText.mm` and `EnrichedMarkdownInternalText.m` into a shared `ENRMTextViewSetup.h` header. Both files had near-identical implementations of `setupLayoutManager` and `measureSize:` — this consolidates them into `ENRMAttachLayoutManager`, `ENRMDetachLayoutManager`, and `ENRMMeasureMarkdownText`, reducing duplication and making future measurement changes a single-point edit.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

