### PR TITLE
feat: add getCaretRect command and onCaretRectChange event

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputManager.kt
@@ -15,6 +15,7 @@ import com.facebook.react.viewmanagers.EnrichedMarkdownInputManagerDelegate
 import com.facebook.react.viewmanagers.EnrichedMarkdownInputManagerInterface
 import com.facebook.yoga.YogaMeasureMode
 import com.swmansion.enriched.markdown.input.autolink.LinkRegexConfig
+import com.swmansion.enriched.markdown.input.events.OnCaretRectChangeEvent
 import com.swmansion.enriched.markdown.input.events.OnChangeMarkdownEvent
 import com.swmansion.enriched.markdown.input.events.OnChangeSelectionEvent
 import com.swmansion.enriched.markdown.input.events.OnChangeStateEvent
@@ -23,6 +24,7 @@ import com.swmansion.enriched.markdown.input.events.OnContextMenuItemPressEvent
 import com.swmansion.enriched.markdown.input.events.OnInputBlurEvent
 import com.swmansion.enriched.markdown.input.events.OnInputFocusEvent
 import com.swmansion.enriched.markdown.input.events.OnLinkDetectedEvent
+import com.swmansion.enriched.markdown.input.events.OnRequestCaretRectResultEvent
 import com.swmansion.enriched.markdown.input.events.OnRequestMarkdownResultEvent
 import com.swmansion.enriched.markdown.input.layout.InputMeasurementStore
 import com.swmansion.enriched.markdown.input.model.StyleType
@@ -83,6 +85,8 @@ class EnrichedMarkdownInputManager :
       OnChangeSelectionEvent.EVENT_NAME,
       OnChangeStateEvent.EVENT_NAME,
       OnRequestMarkdownResultEvent.EVENT_NAME,
+      OnRequestCaretRectResultEvent.EVENT_NAME,
+      OnCaretRectChangeEvent.EVENT_NAME,
       OnInputFocusEvent.EVENT_NAME,
       OnInputBlurEvent.EVENT_NAME,
       OnContextMenuItemPressEvent.EVENT_NAME,
@@ -369,6 +373,13 @@ class EnrichedMarkdownInputManager :
     requestId: Int,
   ) {
     view?.eventEmitter?.emitRequestMarkdownResult(requestId)
+  }
+
+  override fun requestCaretRect(
+    view: EnrichedMarkdownInputView?,
+    requestId: Int,
+  ) {
+    view?.eventEmitter?.emitRequestCaretRectResult(requestId)
   }
 
   companion object {

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputView.kt
@@ -221,6 +221,7 @@ class EnrichedMarkdownInputView(
       forceScrollToSelection()
       eventEmitter.emitChangeText()
       if (emitMarkdown) eventEmitter.emitChangeMarkdown()
+      eventEmitter.emitCaretRectChangeIfNeeded()
       isTextChanging = false
       didTextChangeRecently = true
       lastProcessedText = currentText
@@ -247,6 +248,7 @@ class EnrichedMarkdownInputView(
 
     eventEmitter.emitSelection(selStart, selEnd)
     eventEmitter.emitState()
+    eventEmitter.emitCaretRectChangeIfNeeded()
   }
 
   private fun applyPendingStyles(

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnCaretRectChangeEvent.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnCaretRectChangeEvent.kt
@@ -1,0 +1,20 @@
+package com.swmansion.enriched.markdown.input.events
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.swmansion.enriched.markdown.input.model.CaretRect
+
+class OnCaretRectChangeEvent(
+  surfaceId: Int,
+  viewId: Int,
+  private val rect: CaretRect,
+) : Event<OnCaretRectChangeEvent>(surfaceId, viewId) {
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap = Arguments.createMap().also { rect.putInto(it) }
+
+  companion object {
+    const val EVENT_NAME = "onCaretRectChange"
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnRequestCaretRectResultEvent.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnRequestCaretRectResultEvent.kt
@@ -1,0 +1,25 @@
+package com.swmansion.enriched.markdown.input.events
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.swmansion.enriched.markdown.input.model.CaretRect
+
+class OnRequestCaretRectResultEvent(
+  surfaceId: Int,
+  viewId: Int,
+  private val requestId: Int,
+  private val rect: CaretRect,
+) : Event<OnRequestCaretRectResultEvent>(surfaceId, viewId) {
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap =
+    Arguments.createMap().apply {
+      putInt("requestId", requestId)
+      rect.putInto(this)
+    }
+
+  companion object {
+    const val EVENT_NAME = "onRequestCaretRectResult"
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
@@ -116,8 +116,8 @@ class InputEventEmitter(
     return CaretRect(
       x = rawX / density,
       y = rawY / density,
-      w = 2f / density,
-      h = (rawBottom - rawY) / density,
+      width = 2f / density,
+      height = (rawBottom - rawY) / density,
     )
   }
 

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
 import com.swmansion.enriched.markdown.input.EnrichedMarkdownInputView
+import com.swmansion.enriched.markdown.input.events.OnCaretRectChangeEvent
 import com.swmansion.enriched.markdown.input.events.OnChangeMarkdownEvent
 import com.swmansion.enriched.markdown.input.events.OnChangeSelectionEvent
 import com.swmansion.enriched.markdown.input.events.OnChangeStateEvent
@@ -12,14 +13,17 @@ import com.swmansion.enriched.markdown.input.events.OnContextMenuItemPressEvent
 import com.swmansion.enriched.markdown.input.events.OnInputBlurEvent
 import com.swmansion.enriched.markdown.input.events.OnInputFocusEvent
 import com.swmansion.enriched.markdown.input.events.OnLinkDetectedEvent
+import com.swmansion.enriched.markdown.input.events.OnRequestCaretRectResultEvent
 import com.swmansion.enriched.markdown.input.events.OnRequestMarkdownResultEvent
 import com.swmansion.enriched.markdown.input.formatting.MarkdownSerializer
+import com.swmansion.enriched.markdown.input.model.CaretRect
 import com.swmansion.enriched.markdown.input.model.StyleType
 
 class InputEventEmitter(
   private val view: EnrichedMarkdownInputView,
 ) {
   private var prevState: Map<StyleType, Boolean> = emptyMap()
+  private var prevCaretRect: CaretRect? = null
 
   fun emitChangeText() {
     val plainText = view.text?.toString() ?: ""
@@ -80,6 +84,41 @@ class InputEventEmitter(
 
   fun emitRequestMarkdownResult(requestId: Int) {
     dispatch(OnRequestMarkdownResultEvent(surfaceId(), view.id, requestId, serializeToMarkdown()))
+  }
+
+  fun emitRequestCaretRectResult(requestId: Int) {
+    val rect = computeCaretRect()
+    dispatch(OnRequestCaretRectResultEvent(surfaceId(), view.id, requestId, rect))
+  }
+
+  fun emitCaretRectChangeIfNeeded() {
+    val rect = computeCaretRect()
+    if (rect == prevCaretRect) return
+
+    prevCaretRect = rect
+    dispatch(OnCaretRectChangeEvent(surfaceId(), view.id, rect))
+  }
+
+  private fun computeCaretRect(): CaretRect {
+    val textLayout = view.layout
+    val cursorOffset = view.selectionStart
+
+    if (textLayout == null || cursorOffset < 0) {
+      return CaretRect(0f, 0f, 0f, 0f)
+    }
+
+    val line = textLayout.getLineForOffset(cursorOffset)
+    val rawX = textLayout.getPrimaryHorizontal(cursorOffset) + view.paddingLeft
+    val rawY = (textLayout.getLineTop(line) + view.paddingTop).toFloat()
+    val rawBottom = (textLayout.getLineBottom(line) + view.paddingTop).toFloat()
+    val density = view.resources.displayMetrics.density
+
+    return CaretRect(
+      x = rawX / density,
+      y = rawY / density,
+      w = 2f / density,
+      h = (rawBottom - rawY) / density,
+    )
   }
 
   fun emitContextMenuItemPress(

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/model/CaretRect.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/model/CaretRect.kt
@@ -5,13 +5,13 @@ import com.facebook.react.bridge.WritableMap
 data class CaretRect(
   val x: Float,
   val y: Float,
-  val w: Float,
-  val h: Float,
+  val width: Float,
+  val height: Float,
 ) {
   fun putInto(map: WritableMap) {
     map.putDouble("x", x.toDouble())
     map.putDouble("y", y.toDouble())
-    map.putDouble("width", w.toDouble())
-    map.putDouble("height", h.toDouble())
+    map.putDouble("width", width.toDouble())
+    map.putDouble("height", height.toDouble())
   }
 }

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/model/CaretRect.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/model/CaretRect.kt
@@ -1,0 +1,17 @@
+package com.swmansion.enriched.markdown.input.model
+
+import com.facebook.react.bridge.WritableMap
+
+data class CaretRect(
+  val x: Float,
+  val y: Float,
+  val w: Float,
+  val h: Float,
+) {
+  fun putInto(map: WritableMap) {
+    map.putDouble("x", x.toDouble())
+    map.putDouble("y", y.toDouble())
+    map.putDouble("width", w.toDouble())
+    map.putDouble("height", h.toDouble())
+  }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -381,6 +381,38 @@ interface StyleState {
 }
 ```
 
+### `onCaretRectChange`
+
+Fires when the caret's pixel position changes (typing, selection change, content reflow). The rect is relative to the input's top-left corner, in density-independent pixels. The native side diffs the rect before emitting, so redundant events are suppressed.
+
+| Type                              | Default Value | Platform |
+| --------------------------------- | ------------- | -------- |
+| `(rect: CaretRect) => void`      | -             | Both     |
+
+**`CaretRect` shape:**
+
+```ts
+interface CaretRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+```
+
+All values are in density-independent pixels, relative to the input's top-left corner.
+
+**Example:**
+
+```tsx
+<EnrichedMarkdownInput
+  scrollEnabled={false}
+  onCaretRectChange={(rect) => {
+    console.log('Caret at:', rect.x, rect.y);
+  }}
+/>
+```
+
 ### `onFocus`
 
 Fires when the input gains focus.
@@ -473,6 +505,10 @@ Sets the input content from a Markdown string. Parses the Markdown and applies f
 ### `getMarkdown(): Promise<string>`
 
 Returns a Promise that resolves with the current Markdown content. The async nature is due to the native bridge — the request is sent to the native side and the result is returned via an event.
+
+### `getCaretRect(): Promise<CaretRect>`
+
+Returns a Promise that resolves with the current caret's pixel position relative to the input. Useful for one-off queries; for continuous tracking, prefer `onCaretRectChange`.
 
 ### `setSelection(start: number, end: number)`
 

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -121,6 +121,32 @@ The callback fires only for newly detected links — not for links that were alr
 
 When a manual link is applied (via `setLink` or `insertLink`) over an auto-detected link, the auto-detected link is replaced by the manual one. Auto-link detection skips ranges that already contain a manual link.
 
+## Caret Position Tracking
+
+`EnrichedMarkdownInput` can report the caret's pixel position relative to the input, which is useful when the input is embedded in a scrollable container with `scrollEnabled={false}` and you need to keep the caret visible.
+
+### `onCaretRectChange`
+
+A push-based callback that fires whenever the caret moves (typing, selection change, content reflow). The native side diffs the caret rect before emitting, so redundant events are suppressed automatically.
+
+```tsx
+<EnrichedMarkdownInput
+  scrollEnabled={false}
+  onCaretRectChange={(rect) => {
+    console.log(rect); // { x, y, width, height } in dp, relative to input top-left
+  }}
+/>
+```
+
+### `getCaretRect()`
+
+An imperative, pull-based method for one-off queries. Returns a Promise that resolves with the current caret rect.
+
+```tsx
+const rect = await ref.current?.getCaretRect();
+// { x: 24.5, y: 140.2, width: 1, height: 18.3 }
+```
+
 ## Style Detection
 
 All of the above styles can be detected with the use of [onChangeState](API_REFERENCE.md#onchangestate) callback payload.

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -133,7 +133,7 @@ A push-based callback that fires whenever the caret moves (typing, selection cha
 <EnrichedMarkdownInput
   scrollEnabled={false}
   onCaretRectChange={(rect) => {
-    console.log(rect); // { x, y, width, height } in dp, relative to input top-left
+    console.log(rect);
   }}
 />
 ```
@@ -144,7 +144,6 @@ An imperative, pull-based method for one-off queries. Returns a Promise that res
 
 ```tsx
 const rect = await ref.current?.getCaretRect();
-// { x: 24.5, y: 140.2, width: 1, height: 18.3 }
 ```
 
 ## Style Detection

--- a/ios/input/EnrichedMarkdownInput.mm
+++ b/ios/input/EnrichedMarkdownInput.mm
@@ -67,6 +67,8 @@ using namespace facebook::react;
     BOOL bold, italic, underline, strikethrough, spoiler, link, initialized;
   } _prevState;
 
+  std::optional<CGRect> _prevCaretRect;
+
 #if TARGET_OS_OSX
   NSScrollView *_scrollView;
 #endif
@@ -761,6 +763,44 @@ using namespace facebook::react;
   });
 }
 
+- (CGRect)computeCaretRect
+{
+  CGRect caretRect = CGRectZero;
+#if !TARGET_OS_OSX
+  UITextRange *selectedRange = _textView.selectedTextRange;
+  if (selectedRange != nil) {
+    caretRect = [_textView caretRectForPosition:selectedRange.start];
+  }
+#else
+  NSRange selection = _textView.selectedRange;
+  if (selection.location != NSNotFound) {
+    NSRange glyphRange = [_textView.layoutManager glyphRangeForCharacterRange:NSMakeRange(selection.location, 0)
+                                                         actualCharacterRange:NULL];
+    caretRect = [_textView.layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:_textView.textContainer];
+    caretRect.origin.x += _textView.textContainerInset.width;
+    caretRect.origin.y += _textView.textContainerInset.height;
+  }
+#endif
+  return caretRect;
+}
+
+- (void)requestCaretRect:(NSInteger)requestId
+{
+  auto emitter = [self getEventEmitter];
+  if (emitter == nullptr) {
+    return;
+  }
+
+  CGRect caretRect = [self computeCaretRect];
+  emitter->onRequestCaretRectResult({
+      .requestId = static_cast<int>(requestId),
+      .x = caretRect.origin.x,
+      .y = caretRect.origin.y,
+      .width = caretRect.size.width,
+      .height = caretRect.size.height,
+  });
+}
+
 - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args
 {
   RCTEnrichedMarkdownInputHandleCommand(self, commandName, args);
@@ -880,6 +920,29 @@ using namespace facebook::react;
       .strikethrough = {.isActive = strikethroughActive},
       .spoiler = {.isActive = spoilerActive},
       .link = {.isActive = linkActive},
+  });
+}
+
+- (void)emitCaretRectChangeIfNeeded
+{
+  auto emitter = [self getEventEmitter];
+  if (emitter == nullptr) {
+    return;
+  }
+
+  CGRect caretRect = [self computeCaretRect];
+
+  if (_prevCaretRect.has_value() && CGRectEqualToRect(_prevCaretRect.value(), caretRect)) {
+    return;
+  }
+
+  _prevCaretRect = caretRect;
+
+  emitter->onCaretRectChange({
+      .x = caretRect.origin.x,
+      .y = caretRect.origin.y,
+      .width = caretRect.size.width,
+      .height = caretRect.size.height,
   });
 }
 
@@ -1036,6 +1099,7 @@ using namespace facebook::react;
   [self emitOnChangeText];
   [self emitOnChangeSelection];
   [self emitFormattingChanged];
+  [self emitCaretRectChangeIfNeeded];
   [self requestHeightUpdate];
   [self scheduleRelayoutIfNeeded];
 }
@@ -1139,6 +1203,7 @@ using namespace facebook::react;
 
   [self emitOnChangeSelection];
   [self emitOnChangeState];
+  [self emitCaretRectChangeIfNeeded];
 }
 
 #else
@@ -1209,6 +1274,7 @@ using namespace facebook::react;
 
   [self emitOnChangeSelection];
   [self emitOnChangeState];
+  [self emitCaretRectChangeIfNeeded];
 }
 
 // @required stubs for RCTBackedTextInputDelegate — RCTUITextView's internal adapter

--- a/src/EnrichedMarkdownInput.tsx
+++ b/src/EnrichedMarkdownInput.tsx
@@ -14,6 +14,8 @@ import EnrichedMarkdownInputNativeComponent, {
   type OnChangeSelectionEvent,
   type OnChangeStateEvent,
   type OnRequestMarkdownResultEvent,
+  type OnRequestCaretRectResultEvent,
+  type OnCaretRectChangeEvent,
   type OnContextMenuItemPressEvent,
   type OnLinkDetected,
 } from './EnrichedMarkdownInputNativeComponent';
@@ -68,6 +70,13 @@ export interface ContextMenuItem {
   visible?: boolean;
 }
 
+export interface CaretRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export interface EnrichedMarkdownInputInstance {
   focus: () => void;
   blur: () => void;
@@ -85,6 +94,7 @@ export interface EnrichedMarkdownInputInstance {
   insertLink: (text: string, url: string) => void;
   removeLink: () => void;
   getMarkdown: () => Promise<string>;
+  getCaretRect: () => Promise<CaretRect>;
 }
 
 export interface EnrichedMarkdownInputProps {
@@ -105,6 +115,7 @@ export interface EnrichedMarkdownInputProps {
   onChangeMarkdown?: (markdown: string) => void;
   onChangeSelection?: (selection: { start: number; end: number }) => void;
   onChangeState?: (state: StyleState) => void;
+  onCaretRectChange?: (rect: CaretRect) => void;
   onLinkDetected?: (event: OnLinkDetected) => void;
   onFocus?: () => void;
   onBlur?: () => void;
@@ -112,8 +123,8 @@ export interface EnrichedMarkdownInputProps {
   linkRegex?: RegExp | null;
 }
 
-type MarkdownRequest = {
-  resolve: (markdown: string) => void;
+type PendingRequest<T> = {
+  resolve: (value: T) => void;
   reject: (error: Error) => void;
 };
 
@@ -144,6 +155,7 @@ export const EnrichedMarkdownInput = ({
   onChangeMarkdown,
   onChangeSelection,
   onChangeState,
+  onCaretRectChange,
   onLinkDetected,
   onFocus,
   onBlur,
@@ -153,7 +165,10 @@ export const EnrichedMarkdownInput = ({
   const nativeRef = useRef<NativeRef | null>(null);
 
   const nextRequestId = useRef(1);
-  const pendingRequests = useRef(new Map<number, MarkdownRequest>());
+  const pendingRequests = useRef(new Map<number, PendingRequest<string>>());
+  const pendingCaretRectRequests = useRef(
+    new Map<number, PendingRequest<CaretRect>>()
+  );
 
   const contextMenuCallbacksRef = useRef<
     Map<string, ContextMenuItem['onPress']>
@@ -179,11 +194,13 @@ export const EnrichedMarkdownInput = ({
 
   useEffect(() => {
     const pending = pendingRequests.current;
+    const pendingCaretRect = pendingCaretRectRequests.current;
     return () => {
-      pending.forEach(({ reject }) => {
-        reject(new Error('Component unmounted'));
-      });
+      const err = new Error('Component unmounted');
+      pending.forEach(({ reject }) => reject(err));
       pending.clear();
+      pendingCaretRect.forEach(({ reject }) => reject(err));
+      pendingCaretRect.clear();
     };
   }, []);
 
@@ -240,6 +257,14 @@ export const EnrichedMarkdownInput = ({
     [onChangeState]
   );
 
+  const handleCaretRectChange = useCallback(
+    (e: NativeSyntheticEvent<OnCaretRectChangeEvent>) => {
+      const { x, y, width, height } = e.nativeEvent;
+      onCaretRectChange?.({ x, y, width, height });
+    },
+    [onCaretRectChange]
+  );
+
   const handleFocus = useCallback(() => {
     onFocus?.();
   }, [onFocus]);
@@ -256,6 +281,18 @@ export const EnrichedMarkdownInput = ({
 
       pending.resolve(markdown);
       pendingRequests.current.delete(requestId);
+    },
+    []
+  );
+
+  const handleRequestCaretRectResult = useCallback(
+    (e: NativeSyntheticEvent<OnRequestCaretRectResultEvent>) => {
+      const { requestId, x, y, width, height } = e.nativeEvent;
+      const pending = pendingCaretRectRequests.current.get(requestId);
+      if (!pending) return;
+
+      pending.resolve({ x, y, width, height });
+      pendingCaretRectRequests.current.delete(requestId);
     },
     []
   );
@@ -308,6 +345,15 @@ export const EnrichedMarkdownInput = ({
           pendingRequests.current.set(requestId, { resolve, reject });
           Commands.requestMarkdown(commandRef, requestId);
         }),
+      getCaretRect: () =>
+        new Promise<CaretRect>((resolve, reject) => {
+          const requestId = nextRequestId.current++;
+          pendingCaretRectRequests.current.set(requestId, {
+            resolve,
+            reject,
+          });
+          Commands.requestCaretRect(commandRef, requestId);
+        }),
     };
   });
 
@@ -338,6 +384,12 @@ export const EnrichedMarkdownInput = ({
       onInputBlur={handleBlur as NativeProps['onInputBlur']}
       onRequestMarkdownResult={
         handleRequestMarkdownResult as NativeProps['onRequestMarkdownResult']
+      }
+      onRequestCaretRectResult={
+        handleRequestCaretRectResult as NativeProps['onRequestCaretRectResult']
+      }
+      onCaretRectChange={
+        handleCaretRectChange as NativeProps['onCaretRectChange']
       }
       contextMenuItems={nativeContextMenuItems}
       onContextMenuItemPress={

--- a/src/EnrichedMarkdownInputNativeComponent.ts
+++ b/src/EnrichedMarkdownInputNativeComponent.ts
@@ -56,6 +56,21 @@ export interface OnRequestMarkdownResultEvent {
   markdown: string;
 }
 
+export interface OnRequestCaretRectResultEvent {
+  requestId: CodegenTypes.Int32;
+  x: CodegenTypes.Double;
+  y: CodegenTypes.Double;
+  width: CodegenTypes.Double;
+  height: CodegenTypes.Double;
+}
+
+export interface OnCaretRectChangeEvent {
+  x: CodegenTypes.Double;
+  y: CodegenTypes.Double;
+  width: CodegenTypes.Double;
+  height: CodegenTypes.Double;
+}
+
 export interface LinkNativeRegex {
   pattern: string;
   caseInsensitive: boolean;
@@ -175,6 +190,8 @@ export interface NativeProps extends ViewProps {
   onInputFocus?: CodegenTypes.DirectEventHandler<TargetedEvent>;
   onInputBlur?: CodegenTypes.DirectEventHandler<TargetedEvent>;
   onRequestMarkdownResult?: CodegenTypes.DirectEventHandler<OnRequestMarkdownResultEvent>;
+  onRequestCaretRectResult?: CodegenTypes.DirectEventHandler<OnRequestCaretRectResultEvent>;
+  onCaretRectChange?: CodegenTypes.DirectEventHandler<OnCaretRectChangeEvent>;
   onContextMenuItemPress?: CodegenTypes.DirectEventHandler<OnContextMenuItemPressEvent>;
   onLinkDetected?: CodegenTypes.DirectEventHandler<OnLinkDetected>;
 }
@@ -209,6 +226,10 @@ interface NativeCommands {
     viewRef: React.ElementRef<ComponentType>,
     requestId: CodegenTypes.Int32
   ) => void;
+  requestCaretRect: (
+    viewRef: React.ElementRef<ComponentType>,
+    requestId: CodegenTypes.Int32
+  ) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
@@ -226,6 +247,7 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
     'insertLink',
     'removeLink',
     'requestMarkdown',
+    'requestCaretRect',
   ],
 });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,4 +19,5 @@ export type {
   StyleState,
   ContextMenuItem,
   OnLinkDetected,
+  CaretRect,
 } from './EnrichedMarkdownInput';


### PR DESCRIPTION
### What/Why?

Fixes: #233 

Add `onCaretRectChange` callback and imperative `getCaretRect()` command to `EnrichedMarkdownInput`.

When the input is used with `scrollEnabled={false}` inside an outer `ScrollView` (e.g., a post composer), there's no built-in way to know where the caret is in pixel coordinates — `onChangeSelection` only provides character offsets, which aren't enough to determine screen position with word-wrapped lines.

`onCaretRectChange` fires whenever the caret moves (typing, selection change, content reflow) and returns `{ x, y, width, height }` in dp relative to the input's top-left corner. The native side diffs the rect before emitting to avoid redundant bridge traffic. `getCaretRect()` provides the same data as a one-off Promise-based query.

Both APIs surface caret geometry that the native text systems already track internally (`UITextView.caretRectForPosition` on iOS, `Layout.getLineForOffset`/`getLineTop`/`getPrimaryHorizontal` on Android).

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

