### PR TITLE
fix(android): prevent scroll flicker in auto-grow mode by blocking scrollTo

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownInputView.kt
@@ -169,6 +169,16 @@ class EnrichedMarkdownInputView(
 
   override fun performClick(): Boolean = super.performClick()
 
+  // In auto-grow mode (scrollEnabled=false) TextView's internal bringPointIntoView
+  // scrolls content before Fabric has resized the view, causing a visible flicker.
+  override fun scrollTo(
+    x: Int,
+    y: Int,
+  ) {
+    if (!scrollEnabled) return
+    super.scrollTo(x, y)
+  }
+
   override fun canScrollVertically(direction: Int): Boolean = scrollEnabled && super.canScrollVertically(direction)
 
   override fun canScrollHorizontally(direction: Int): Boolean = scrollEnabled && super.canScrollHorizontally(direction)


### PR DESCRIPTION
### What/Why?
Fixes a visible flicker on Android when pressing Enter on the last line of a growing EnrichedMarkdownInput with scrollEnabled={false}.

The flicker happens because TextView internally scrolls the content before Fabric has resized the view to its new height. Overriding scrollTo() to no-op in auto-grow mode prevents this — Fabric handles the height, so internal scrolling is never needed.

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

