### PR TITLE
docs: add missing spoiler documentation and move spoiler syntax note …

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@
 - 🔗 Auto-link detection with customizable regex
 - 🔄 Smart copy/paste with Markdown preservation
 - 🎨 Customizable bold, italic, and link colors
-
-> **Note:** Spoiler syntax (`||text||`) is always enabled. Any double-pipe delimiters in your content will be parsed as spoilers — for example, `a || b || c` would render `b` as a spoiler span rather than plain text.
-
 Since 2012 [Software Mansion](https://swmansion.com) is a software agency with experience in building web and mobile apps. We are Core React Native Contributors and experts in dealing with all kinds of React Native issues.
 We can help you build your next dream product –
 [Hire us](https://swmansion.com/contact/projects?utm_source=react-native-enriched-markdown&utm_medium=readme).

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -168,6 +168,27 @@ Markdown flavor. Set to `'github'` to enable GitHub Flavored Markdown table supp
 > - **`'commonmark'`**: All Markdown content is rendered as a single TextView. Selecting text will select all content in the view.
 > - **`'github'`**: The Markdown AST is split into segments. Consecutive text blocks (paragraphs, headings, lists, etc.) are grouped into separate TextView segments, while tables are rendered as separate table views. This allows for granular text selection within each segment and enables interactive table features (horizontal scrolling, context menus). Text selection cannot span across segments.
 
+### `streamingAnimation`
+
+When `true`, newly appended content fades in during streaming updates. Only the tail (new characters beyond the previous content) is animated. Recommended for LLM streaming use cases with `flavor="commonmark"`.
+
+| Type      | Default Value | Platform |
+| --------- | ------------- | -------- |
+| `boolean` | `false`       | Both     |
+
+### `spoilerMode`
+
+Controls how spoiler text (`||hidden text||`) is displayed before being revealed.
+
+| Type                          | Default Value | Platform |
+| ----------------------------- | ------------- | -------- |
+| `'particles' \| 'solid'`     | `'particles'` | Both     |
+
+- **`'particles'`**: Animated particle overlay (CAEmitterLayer on iOS, Choreographer-driven Canvas particles on Android).
+- **`'solid'`**: Opaque rectangle covering the text (Discord-style).
+
+Both modes support tap-to-reveal.
+
 ### `contextMenuItems`
 
 Custom items to add to the text selection context menu. Items appear before the system actions (Copy, etc.). Items with `visible: false` are hidden from the menu.
@@ -326,6 +347,8 @@ Style configuration for formatted text in the input.
 - `em.color` — text color for italic text (defaults to the input's text color).
 - `link.color` — text color for links (defaults to `#2563EB`).
 - `link.underline` — whether links are underlined (defaults to `true`).
+- `spoiler.color` — text color for spoiler text.
+- `spoiler.backgroundColor` — background color for spoiler text.
 
 ### `style`
 
@@ -377,6 +400,7 @@ interface StyleState {
   italic: { isActive: boolean };
   underline: { isActive: boolean };
   strikethrough: { isActive: boolean };
+  spoiler: { isActive: boolean };
   link: { isActive: boolean };
 }
 ```
@@ -463,6 +487,7 @@ interface ContextMenuItem {
       italic: { isActive: boolean };
       underline: { isActive: boolean };
       strikethrough: { isActive: boolean };
+      spoiler: { isActive: boolean };
       link: { isActive: boolean };
     };
   }) => void;
@@ -529,6 +554,10 @@ Toggles underline on the current selection or cursor.
 ### `toggleStrikethrough()`
 
 Toggles strikethrough on the current selection or cursor.
+
+### `toggleSpoiler()`
+
+Toggles spoiler on the current selection or cursor.
 
 ### `setLink(url: string)`
 

--- a/docs/ELEMENTS_STRUCTURE.md
+++ b/docs/ELEMENTS_STRUCTURE.md
@@ -37,6 +37,8 @@ Markdown elements in `react-native-enriched-markdown` are organized into block a
 | Inline Math | `$...$` | `inlineMath` | Parent block | LaTeX math rendered within the text flow |
 | Spoiler | `||text||` | `spoiler` | Parent block | Text concealed behind animated particle overlay, tap to reveal. Can wrap inline text or entire blocks (e.g. a full paragraph) |
 
+> **Note:** Spoiler syntax (`||text||`) is always enabled. Any double-pipe delimiters in your content will be parsed as spoilers — for example, `a || b || c` would render `b` as a spoiler span rather than plain text.
+
 > **Note:** Underscore syntax (`__text__`, `_text_`) works for bold/italic by default. Enable underline via `md4cFlags={{ underline: true }}` to treat `_text_` as underline instead of emphasis.
 
 ### Nested Lists Example

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -58,6 +58,7 @@ Supported styles:
 - italic
 - underline
 - strikethrough
+- spoiler
 
 Each of the styles can be toggled the same way as in the example from [usage section](#usage); call a proper `toggle` function on the component ref.
 
@@ -182,3 +183,5 @@ Available style properties:
 - `em.color` — text color for italic text (defaults to the input's text color).
 - `link.color` — text color for links (defaults to `#2563EB`).
 - `link.underline` — whether links are underlined (defaults to `true`).
+- `spoiler.color` — text color for spoiler text.
+- `spoiler.backgroundColor` — background color for spoiler text.

--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -183,6 +183,11 @@ The library provides sensible default styles for all Markdown elements out of th
     inlineMath: {
       color: '#1F2937',
     },
+    spoiler: {
+      color: '#6B7280',
+      particles: { density: 10, speed: 25 },
+      solid: { borderRadius: 6 },
+    },
   }}
 />
 ```


### PR DESCRIPTION
### What/Why?
Add missing spoiler-related documentation across API reference, input docs, and element structure.

### Testing
<!-- How to test changed code? What testing has been done? -->


<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

