### PR TITLE
feat: add list.markerMinWidth to align UL/OL/task lists

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/spans/OrderedListSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/spans/OrderedListSpan.kt
@@ -52,7 +52,7 @@ class OrderedListSpan(
 
   override fun getMarkerWidth(): Float {
     val paint = configureMarkerPaint()
-    return paint.measureText("99.")
+    return listStyle.effectiveMarkerWidth(paint.measureText("99."))
   }
 
   var itemNumber: Int = 1

--- a/android/src/main/java/com/swmansion/enriched/markdown/spans/TaskListSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/spans/TaskListSpan.kt
@@ -13,7 +13,7 @@ import com.swmansion.enriched.markdown.styles.TaskListStyle
 
 class TaskListSpan(
   private val taskStyle: TaskListStyle,
-  listStyle: ListStyle,
+  private val listStyle: ListStyle,
   depth: Int,
   context: Context,
   styleCache: SpanStyleCache,
@@ -34,6 +34,7 @@ class TaskListSpan(
     gapWidth = listStyle.gapWidth,
   ) {
   private val checkboxSize = taskStyle.checkboxSize
+  private val markerColumnWidth = listStyle.effectiveMarkerWidth(checkboxSize)
   private val cornerRadius = taskStyle.checkboxBorderRadius
   private val rect = RectF()
   private val checkPath = Path()
@@ -55,7 +56,7 @@ class TaskListSpan(
       strokeJoin = Paint.Join.ROUND
     }
 
-  override fun getMarkerWidth(): Float = checkboxSize
+  override fun getMarkerWidth(): Float = markerColumnWidth
 
   override fun drawMarker(
     canvas: Canvas,
@@ -71,7 +72,10 @@ class TaskListSpan(
     val fontMetrics = paint.fontMetrics
     val capHeight = -fontMetrics.ascent * CAP_HEIGHT_RATIO
     val centerY = baseline - capHeight / HALF_DIVISOR
-    val centerX = x + (depth * marginLeft + checkboxSize / HALF_DIVISOR) * dir
+    // Right-align the checkbox inside the reserved marker column so it hugs
+    // the gap before the text. At the default (markerColumnWidth ==
+    // checkboxSize) this is identical to the previous flush-left layout.
+    val centerX = x + (depth * marginLeft + markerColumnWidth - checkboxSize / HALF_DIVISOR) * dir
     val half = checkboxSize / HALF_DIVISOR
     rect.set(centerX - half, centerY - half, centerX + half, centerY + half)
 

--- a/android/src/main/java/com/swmansion/enriched/markdown/spans/UnorderedListSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/spans/UnorderedListSpan.kt
@@ -35,13 +35,14 @@ class UnorderedListSpan(
   }
 
   private val radius: Float = listStyle.bulletSize / 2f
+  private val markerColumnWidth: Float = listStyle.effectiveMarkerWidth(radius)
 
   private fun configureBulletPaint(): Paint =
     sharedBulletPaint.apply {
       color = listStyle.bulletColor
     }
 
-  override fun getMarkerWidth(): Float = radius
+  override fun getMarkerWidth(): Float = markerColumnWidth
 
   override fun drawMarker(
     canvas: Canvas,
@@ -55,7 +56,11 @@ class UnorderedListSpan(
     start: Int,
   ) {
     val bulletPaint = configureBulletPaint()
-    val bulletX = x + (depth * marginLeft + radius) * dir
+    // Center the bullet at the right edge of the reserved marker column so
+    // it hugs the gap before the text — matches iOS behavior and stays
+    // visually flush-left when the column width equals the bullet radius
+    // (the default).
+    val bulletX = x + (depth * marginLeft + markerColumnWidth) * dir
     val fontMetrics = paint.fontMetrics
     val bulletY = baseline + (fontMetrics.ascent + fontMetrics.descent) / 2f
 

--- a/android/src/main/java/com/swmansion/enriched/markdown/styles/ListStyle.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/styles/ListStyle.kt
@@ -12,16 +12,13 @@ data class ListStyle(
   override val lineHeight: Float,
   val bulletColor: Int,
   val bulletSize: Float,
-  val markerWidth: Float,
+  val markerMinWidth: Float,
   val markerColor: Int,
   val markerFontWeight: String,
   val gapWidth: Float,
   val marginLeft: Float,
 ) : BaseBlockStyle {
-
-  /** Floor `naturalWidth` by the consumer-configured `markerWidth`. */
-  fun effectiveMarkerWidth(naturalWidth: Float): Float =
-    if (markerWidth > naturalWidth) markerWidth else naturalWidth
+  fun effectiveMarkerWidth(naturalWidth: Float): Float = naturalWidth.coerceAtLeast(markerMinWidth)
 
   companion object {
     fun fromReadableMap(
@@ -38,13 +35,7 @@ data class ListStyle(
       val lineHeight = parser.toPixelFromSP(lineHeightRaw)
       val bulletColor = parser.parseColor(map, "bulletColor")
       val bulletSize = parser.toPixelFromDIP(map.getDouble("bulletSize").toFloat())
-      val markerWidthRaw = map.getDouble("markerWidth").toFloat()
-      val markerWidth =
-        if (markerWidthRaw < 0f) {
-          -1f
-        } else {
-          parser.toPixelFromDIP(markerWidthRaw)
-        }
+      val markerMinWidth = parser.toPixelFromDIP(map.getDouble("markerMinWidth").toFloat().coerceAtLeast(0f))
       val markerColor = parser.parseColor(map, "markerColor")
       val markerFontWeight = parser.parseString(map, "markerFontWeight", "normal")
       val gapWidth = parser.toPixelFromDIP(map.getDouble("gapWidth").toFloat())
@@ -60,7 +51,7 @@ data class ListStyle(
         lineHeight,
         bulletColor,
         bulletSize,
-        markerWidth,
+        markerMinWidth,
         markerColor,
         markerFontWeight,
         gapWidth,

--- a/android/src/main/java/com/swmansion/enriched/markdown/styles/ListStyle.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/styles/ListStyle.kt
@@ -12,11 +12,17 @@ data class ListStyle(
   override val lineHeight: Float,
   val bulletColor: Int,
   val bulletSize: Float,
+  val markerWidth: Float,
   val markerColor: Int,
   val markerFontWeight: String,
   val gapWidth: Float,
   val marginLeft: Float,
 ) : BaseBlockStyle {
+
+  /** Floor `naturalWidth` by the consumer-configured `markerWidth`. */
+  fun effectiveMarkerWidth(naturalWidth: Float): Float =
+    if (markerWidth > naturalWidth) markerWidth else naturalWidth
+
   companion object {
     fun fromReadableMap(
       map: ReadableMap,
@@ -32,6 +38,13 @@ data class ListStyle(
       val lineHeight = parser.toPixelFromSP(lineHeightRaw)
       val bulletColor = parser.parseColor(map, "bulletColor")
       val bulletSize = parser.toPixelFromDIP(map.getDouble("bulletSize").toFloat())
+      val markerWidthRaw = map.getDouble("markerWidth").toFloat()
+      val markerWidth =
+        if (markerWidthRaw < 0f) {
+          -1f
+        } else {
+          parser.toPixelFromDIP(markerWidthRaw)
+        }
       val markerColor = parser.parseColor(map, "markerColor")
       val markerFontWeight = parser.parseString(map, "markerFontWeight", "normal")
       val gapWidth = parser.toPixelFromDIP(map.getDouble("gapWidth").toFloat())
@@ -47,6 +60,7 @@ data class ListStyle(
         lineHeight,
         bulletColor,
         bulletSize,
+        markerWidth,
         markerColor,
         markerFontWeight,
         gapWidth,

--- a/apps/example/src/markdownStyles.ts
+++ b/apps/example/src/markdownStyles.ts
@@ -69,7 +69,7 @@ export const customMarkdownStyle: MarkdownStyle = {
     lineHeight: Platform.select({ ios: 22, android: 26, default: 26 }),
     bulletColor: '#6b7280',
     bulletSize: 6,
-    markerWidth: 20,
+    markerMinWidth: 20,
     markerColor: '#6b7280',
     markerFontWeight: '500',
     gapWidth: 8,

--- a/apps/example/src/markdownStyles.ts
+++ b/apps/example/src/markdownStyles.ts
@@ -69,6 +69,7 @@ export const customMarkdownStyle: MarkdownStyle = {
     lineHeight: Platform.select({ ios: 22, android: 26, default: 26 }),
     bulletColor: '#6b7280',
     bulletSize: 6,
+    markerWidth: 20,
     markerColor: '#6b7280',
     markerFontWeight: '500',
     gapWidth: 8,

--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -238,6 +238,7 @@ The library provides sensible default styles for all Markdown elements out of th
 |----------|------|-------------|
 | `bulletColor` | `string` | Bullet point color |
 | `bulletSize` | `number` | Bullet point size |
+| `markerWidth` | `number` | Minimum reserved marker column width (floors the natural width of every list type) |
 | `markerColor` | `string` | Number marker color |
 | `markerFontWeight` | `string` | Number marker font weight |
 | `gapWidth` | `number` | Gap between marker and text |

--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -238,7 +238,7 @@ The library provides sensible default styles for all Markdown elements out of th
 |----------|------|-------------|
 | `bulletColor` | `string` | Bullet point color |
 | `bulletSize` | `number` | Bullet point size |
-| `markerWidth` | `number` | Minimum reserved marker column width (floors the natural width of every list type) |
+| `markerMinWidth` | `number` | Minimum reserved marker column width (floors the natural width of every list type) |
 | `markerColor` | `string` | Number marker color |
 | `markerFontWeight` | `string` | Number marker font weight |
 | `gapWidth` | `number` | Gap between marker and text |

--- a/ios/internals/MeasurementCache.h
+++ b/ios/internals/MeasurementCache.h
@@ -103,7 +103,7 @@ template <typename StyleStruct> inline size_t computeStyleFingerprint(const Styl
   hashFields(s.blockquote.borderWidth, s.blockquote.gapWidth);
 
   hashTextLayout(s.list);
-  hashFields(s.list.bulletSize, s.list.markerFontWeight, s.list.gapWidth, s.list.marginLeft);
+  hashFields(s.list.bulletSize, s.list.markerWidth, s.list.markerFontWeight, s.list.gapWidth, s.list.marginLeft);
 
   // Code & Inlines
   hashFields(s.codeBlock.fontFamily, s.codeBlock.fontSize, s.codeBlock.fontWeight, s.codeBlock.marginTop,

--- a/ios/internals/MeasurementCache.h
+++ b/ios/internals/MeasurementCache.h
@@ -103,7 +103,7 @@ template <typename StyleStruct> inline size_t computeStyleFingerprint(const Styl
   hashFields(s.blockquote.borderWidth, s.blockquote.gapWidth);
 
   hashTextLayout(s.list);
-  hashFields(s.list.bulletSize, s.list.markerWidth, s.list.markerFontWeight, s.list.gapWidth, s.list.marginLeft);
+  hashFields(s.list.bulletSize, s.list.markerMinWidth, s.list.markerFontWeight, s.list.gapWidth, s.list.marginLeft);
 
   // Code & Inlines
   hashFields(s.codeBlock.fontFamily, s.codeBlock.fontSize, s.codeBlock.fontWeight, s.codeBlock.marginTop,

--- a/ios/renderer/ListItemRenderer.m
+++ b/ios/renderer/ListItemRenderer.m
@@ -73,7 +73,7 @@ NSString *const TaskIndexAttribute = @"TaskIndex";
 
   // currentDepth - 1 handles the horizontal offset for nested lists
   const NSInteger nestingLevel = currentDepth - 1;
-  const CGFloat baseMarkerWidth = isTask                                  ? [_config taskListCheckboxSize]
+  const CGFloat baseMarkerWidth = isTask                                  ? [_config effectiveListMarginLeftForTask]
                                   : (context.listType == ListTypeOrdered) ? [_config effectiveListMarginLeftForNumber]
                                                                           : [_config effectiveListMarginLeftForBullet];
 

--- a/ios/styles/StyleConfig.h
+++ b/ios/styles/StyleConfig.h
@@ -236,6 +236,8 @@
 - (void)setListStyleBulletColor:(RCTUIColor *)newValue;
 - (CGFloat)listStyleBulletSize;
 - (void)setListStyleBulletSize:(CGFloat)newValue;
+- (CGFloat)listStyleMarkerWidth;
+- (void)setListStyleMarkerWidth:(CGFloat)newValue;
 - (RCTUIColor *)listStyleMarkerColor;
 - (void)setListStyleMarkerColor:(RCTUIColor *)newValue;
 - (NSString *)listStyleMarkerFontWeight;
@@ -249,6 +251,7 @@
 - (CGFloat)effectiveListGapWidth;
 - (CGFloat)effectiveListMarginLeftForBullet;
 - (CGFloat)effectiveListMarginLeftForNumber;
+- (CGFloat)effectiveListMarginLeftForTask;
 // Code block properties
 - (CGFloat)codeBlockFontSize;
 - (void)setCodeBlockFontSize:(CGFloat)newValue;

--- a/ios/styles/StyleConfig.h
+++ b/ios/styles/StyleConfig.h
@@ -236,8 +236,8 @@
 - (void)setListStyleBulletColor:(RCTUIColor *)newValue;
 - (CGFloat)listStyleBulletSize;
 - (void)setListStyleBulletSize:(CGFloat)newValue;
-- (CGFloat)listStyleMarkerWidth;
-- (void)setListStyleMarkerWidth:(CGFloat)newValue;
+- (CGFloat)listStyleMarkerMinWidth;
+- (void)setListStyleMarkerMinWidth:(CGFloat)newValue;
 - (RCTUIColor *)listStyleMarkerColor;
 - (void)setListStyleMarkerColor:(RCTUIColor *)newValue;
 - (NSString *)listStyleMarkerFontWeight;

--- a/ios/styles/StyleConfig.mm
+++ b/ios/styles/StyleConfig.mm
@@ -151,6 +151,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   CGFloat _listStyleLineHeight;
   RCTUIColor *_listStyleBulletColor;
   CGFloat _listStyleBulletSize;
+  CGFloat _listStyleMarkerWidth;
   RCTUIColor *_listStyleMarkerColor;
   NSString *_listStyleMarkerFontWeight;
   CGFloat _listStyleGapWidth;
@@ -434,6 +435,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   copy->_listStyleLineHeight = _listStyleLineHeight;
   copy->_listStyleBulletColor = [_listStyleBulletColor copy];
   copy->_listStyleBulletSize = _listStyleBulletSize;
+  copy->_listStyleMarkerWidth = _listStyleMarkerWidth;
   copy->_listStyleMarkerColor = [_listStyleMarkerColor copy];
   copy->_listStyleMarkerFontWeight = [_listStyleMarkerFontWeight copy];
   copy->_listStyleGapWidth = _listStyleGapWidth;
@@ -1706,6 +1708,16 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   _listStyleBulletSize = newValue;
 }
 
+- (CGFloat)listStyleMarkerWidth
+{
+  return _listStyleMarkerWidth;
+}
+
+- (void)setListStyleMarkerWidth:(CGFloat)newValue
+{
+  _listStyleMarkerWidth = newValue;
+}
+
 - (RCTUIColor *)listStyleMarkerColor
 {
   return _listStyleMarkerColor;
@@ -1786,16 +1798,30 @@ static const CGFloat kDefaultMinGap = 4.0;
 
 - (CGFloat)effectiveListMarginLeftForBullet
 {
-  // Just the minimum width needed for bullet (radius)
-  return _listStyleBulletSize / 2.0;
+  // Natural width for a bullet is the bullet radius (bulletSize / 2). The
+  // consumer-provided `markerWidth` acts as a floor so bulleted lists can
+  // line up with ordered / task lists without resizing the bullet glyph.
+  CGFloat natural = _listStyleBulletSize / 2.0;
+  return _listStyleMarkerWidth > natural ? _listStyleMarkerWidth : natural;
 }
 
 - (CGFloat)effectiveListMarginLeftForNumber
 {
-  // Reserve width for numbers up to 99 (matching Android)
+  // Reserve width for numbers up to 99 (matching Android). `markerWidth`
+  // floors the value so consumers can widen the column uniformly.
   UIFont *font = [self listMarkerFont];
-  return
+  CGFloat natural =
       [@"99." sizeWithAttributes:@{NSFontAttributeName : font ?: [UIFont systemFontOfSize:_listStyleFontSize]}].width;
+  return _listStyleMarkerWidth > natural ? _listStyleMarkerWidth : natural;
+}
+
+- (CGFloat)effectiveListMarginLeftForTask
+{
+  // Task checkbox reserves at least its own size. `markerWidth` can widen
+  // the column so task rows align with adjacent UL/OL rows. The checkbox
+  // glyph itself is still drawn at its configured size.
+  CGFloat natural = [self taskListCheckboxSize];
+  return _listStyleMarkerWidth > natural ? _listStyleMarkerWidth : natural;
 }
 
 // Code block properties

--- a/ios/styles/StyleConfig.mm
+++ b/ios/styles/StyleConfig.mm
@@ -151,7 +151,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   CGFloat _listStyleLineHeight;
   RCTUIColor *_listStyleBulletColor;
   CGFloat _listStyleBulletSize;
-  CGFloat _listStyleMarkerWidth;
+  CGFloat _listStyleMarkerMinWidth;
   RCTUIColor *_listStyleMarkerColor;
   NSString *_listStyleMarkerFontWeight;
   CGFloat _listStyleGapWidth;
@@ -435,7 +435,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   copy->_listStyleLineHeight = _listStyleLineHeight;
   copy->_listStyleBulletColor = [_listStyleBulletColor copy];
   copy->_listStyleBulletSize = _listStyleBulletSize;
-  copy->_listStyleMarkerWidth = _listStyleMarkerWidth;
+  copy->_listStyleMarkerMinWidth = _listStyleMarkerMinWidth;
   copy->_listStyleMarkerColor = [_listStyleMarkerColor copy];
   copy->_listStyleMarkerFontWeight = [_listStyleMarkerFontWeight copy];
   copy->_listStyleGapWidth = _listStyleGapWidth;
@@ -1708,14 +1708,14 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   _listStyleBulletSize = newValue;
 }
 
-- (CGFloat)listStyleMarkerWidth
+- (CGFloat)listStyleMarkerMinWidth
 {
-  return _listStyleMarkerWidth;
+  return _listStyleMarkerMinWidth;
 }
 
-- (void)setListStyleMarkerWidth:(CGFloat)newValue
+- (void)setListStyleMarkerMinWidth:(CGFloat)newValue
 {
-  _listStyleMarkerWidth = newValue;
+  _listStyleMarkerMinWidth = newValue;
 }
 
 - (RCTUIColor *)listStyleMarkerColor
@@ -1798,30 +1798,20 @@ static const CGFloat kDefaultMinGap = 4.0;
 
 - (CGFloat)effectiveListMarginLeftForBullet
 {
-  // Natural width for a bullet is the bullet radius (bulletSize / 2). The
-  // consumer-provided `markerWidth` acts as a floor so bulleted lists can
-  // line up with ordered / task lists without resizing the bullet glyph.
-  CGFloat natural = _listStyleBulletSize / 2.0;
-  return _listStyleMarkerWidth > natural ? _listStyleMarkerWidth : natural;
+  return MAX(_listStyleMarkerMinWidth, _listStyleBulletSize / 2.0);
 }
 
 - (CGFloat)effectiveListMarginLeftForNumber
 {
-  // Reserve width for numbers up to 99 (matching Android). `markerWidth`
-  // floors the value so consumers can widen the column uniformly.
   UIFont *font = [self listMarkerFont];
   CGFloat natural =
       [@"99." sizeWithAttributes:@{NSFontAttributeName : font ?: [UIFont systemFontOfSize:_listStyleFontSize]}].width;
-  return _listStyleMarkerWidth > natural ? _listStyleMarkerWidth : natural;
+  return MAX(_listStyleMarkerMinWidth, natural);
 }
 
 - (CGFloat)effectiveListMarginLeftForTask
 {
-  // Task checkbox reserves at least its own size. `markerWidth` can widen
-  // the column so task rows align with adjacent UL/OL rows. The checkbox
-  // glyph itself is still drawn at its configured size.
-  CGFloat natural = [self taskListCheckboxSize];
-  return _listStyleMarkerWidth > natural ? _listStyleMarkerWidth : natural;
+  return MAX(_listStyleMarkerMinWidth, [self taskListCheckboxSize]);
 }
 
 // Code block properties

--- a/ios/utils/StylePropsUtils.h
+++ b/ios/utils/StylePropsUtils.h
@@ -713,8 +713,8 @@ BOOL applyMarkdownStyleToConfig(StyleConfig *config, const MarkdownStyle &newSty
     changed = YES;
   }
 
-  if (newStyle.list.markerWidth != oldStyle.list.markerWidth) {
-    [config setListStyleMarkerWidth:newStyle.list.markerWidth];
+  if (newStyle.list.markerMinWidth != oldStyle.list.markerMinWidth) {
+    [config setListStyleMarkerMinWidth:newStyle.list.markerMinWidth];
     changed = YES;
   }
 

--- a/ios/utils/StylePropsUtils.h
+++ b/ios/utils/StylePropsUtils.h
@@ -713,6 +713,11 @@ BOOL applyMarkdownStyleToConfig(StyleConfig *config, const MarkdownStyle &newSty
     changed = YES;
   }
 
+  if (newStyle.list.markerWidth != oldStyle.list.markerWidth) {
+    [config setListStyleMarkerWidth:newStyle.list.markerWidth];
+    changed = YES;
+  }
+
   if (newStyle.list.markerColor != oldStyle.list.markerColor) {
     RCTUIColor *markerColor = RCTUIColorFromSharedColor(newStyle.list.markerColor);
     [config setListStyleMarkerColor:markerColor];

--- a/src/EnrichedMarkdownNativeComponent.ts
+++ b/src/EnrichedMarkdownNativeComponent.ts
@@ -34,7 +34,7 @@ interface BlockquoteStyleInternal extends BaseBlockStyleInternal {
 interface ListStyleInternal extends BaseBlockStyleInternal {
   bulletColor: ColorValue;
   bulletSize: CodegenTypes.Float;
-  markerWidth: CodegenTypes.Float;
+  markerMinWidth: CodegenTypes.Float;
   markerColor: ColorValue;
   markerFontWeight: string;
   gapWidth: CodegenTypes.Float;

--- a/src/EnrichedMarkdownNativeComponent.ts
+++ b/src/EnrichedMarkdownNativeComponent.ts
@@ -34,6 +34,7 @@ interface BlockquoteStyleInternal extends BaseBlockStyleInternal {
 interface ListStyleInternal extends BaseBlockStyleInternal {
   bulletColor: ColorValue;
   bulletSize: CodegenTypes.Float;
+  markerWidth: CodegenTypes.Float;
   markerColor: ColorValue;
   markerFontWeight: string;
   gapWidth: CodegenTypes.Float;

--- a/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/src/EnrichedMarkdownTextNativeComponent.ts
@@ -34,7 +34,7 @@ interface BlockquoteStyleInternal extends BaseBlockStyleInternal {
 interface ListStyleInternal extends BaseBlockStyleInternal {
   bulletColor: ColorValue;
   bulletSize: CodegenTypes.Float;
-  markerWidth: CodegenTypes.Float;
+  markerMinWidth: CodegenTypes.Float;
   markerColor: ColorValue;
   markerFontWeight: string;
   gapWidth: CodegenTypes.Float;

--- a/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/src/EnrichedMarkdownTextNativeComponent.ts
@@ -34,6 +34,7 @@ interface BlockquoteStyleInternal extends BaseBlockStyleInternal {
 interface ListStyleInternal extends BaseBlockStyleInternal {
   bulletColor: ColorValue;
   bulletSize: CodegenTypes.Float;
+  markerWidth: CodegenTypes.Float;
   markerColor: ColorValue;
   markerFontWeight: string;
   gapWidth: CodegenTypes.Float;

--- a/src/normalizeMarkdownStyle.ts
+++ b/src/normalizeMarkdownStyle.ts
@@ -112,7 +112,7 @@ const DEFAULT_NORMALIZED_STYLE = Object.freeze({
     marginBottom: 16,
     bulletColor: normalizeColor('#6B7280')!,
     bulletSize: 6,
-    markerWidth: -1,
+    markerMinWidth: 0,
     markerColor: normalizeColor('#6B7280')!,
     markerFontWeight: '500',
     gapWidth: 12,

--- a/src/normalizeMarkdownStyle.ts
+++ b/src/normalizeMarkdownStyle.ts
@@ -112,6 +112,7 @@ const DEFAULT_NORMALIZED_STYLE = Object.freeze({
     marginBottom: 16,
     bulletColor: normalizeColor('#6B7280')!,
     bulletSize: 6,
+    markerWidth: -1,
     markerColor: normalizeColor('#6B7280')!,
     markerFontWeight: '500',
     gapWidth: 12,

--- a/src/normalizeMarkdownStyle.web.ts
+++ b/src/normalizeMarkdownStyle.web.ts
@@ -98,6 +98,7 @@ const DEFAULT_NORMALIZED_STYLE: MarkdownStyleInternal = Object.freeze({
     marginBottom: 16,
     bulletColor: '#6B7280',
     bulletSize: 6,
+    markerWidth: -1,
     markerColor: '#6B7280',
     markerFontWeight: '500',
     gapWidth: 12,

--- a/src/normalizeMarkdownStyle.web.ts
+++ b/src/normalizeMarkdownStyle.web.ts
@@ -98,7 +98,7 @@ const DEFAULT_NORMALIZED_STYLE: MarkdownStyleInternal = Object.freeze({
     marginBottom: 16,
     bulletColor: '#6B7280',
     bulletSize: 6,
-    markerWidth: -1,
+    markerMinWidth: 0,
     markerColor: '#6B7280',
     markerFontWeight: '500',
     gapWidth: 12,

--- a/src/types/MarkdownStyle.ts
+++ b/src/types/MarkdownStyle.ts
@@ -28,7 +28,11 @@ interface BlockquoteStyle extends BaseBlockStyle {
 interface ListStyle extends BaseBlockStyle {
   bulletColor?: string;
   bulletSize?: number;
-  markerWidth?: number;
+  /**
+   * Minimum reserved marker column width applied uniformly to UL/OL/task lists.
+   * `0` (the default) means no minimum — each list uses its natural marker width.
+   */
+  markerMinWidth?: number;
   markerColor?: string;
   markerFontWeight?: string;
   gapWidth?: number;

--- a/src/types/MarkdownStyle.ts
+++ b/src/types/MarkdownStyle.ts
@@ -28,6 +28,7 @@ interface BlockquoteStyle extends BaseBlockStyle {
 interface ListStyle extends BaseBlockStyle {
   bulletColor?: string;
   bulletSize?: number;
+  markerWidth?: number;
   markerColor?: string;
   markerFontWeight?: string;
   gapWidth?: number;

--- a/src/types/MarkdownStyleInternal.ts
+++ b/src/types/MarkdownStyleInternal.ts
@@ -34,6 +34,10 @@ interface BlockquoteStyleInternal extends BaseBlockStyleInternal {
 interface ListStyleInternal extends BaseBlockStyleInternal {
   bulletColor: string;
   bulletSize: number;
+  // Minimum reserved marker column width. Negative = "auto" → use each
+  // list's natural marker width (UL: bulletSize/2, OL: width of "99.",
+  // task: checkbox size).
+  markerWidth: number;
   markerColor: string;
   markerFontWeight: string;
   gapWidth: number;

--- a/src/types/MarkdownStyleInternal.ts
+++ b/src/types/MarkdownStyleInternal.ts
@@ -34,10 +34,7 @@ interface BlockquoteStyleInternal extends BaseBlockStyleInternal {
 interface ListStyleInternal extends BaseBlockStyleInternal {
   bulletColor: string;
   bulletSize: number;
-  // Minimum reserved marker column width. Negative = "auto" → use each
-  // list's natural marker width (UL: bulletSize/2, OL: width of "99.",
-  // task: checkbox size).
-  markerWidth: number;
+  markerMinWidth: number;
   markerColor: string;
   markerFontWeight: string;
   gapWidth: number;


### PR DESCRIPTION
### What/Why?

Today each list kind reserves its own natural marker column width: `bulletSize / 2` for unordered, the width of `"99."` at the marker font for ordered, and the checkbox size for tasks. Mixed content therefore looks ragged — bulleted rows sit far to the left of numbered rows, task rows to the left of both.

This PR adds one optional style, `list.markerWidth`, that acts as a **minimum reserved marker column width** applied to all three list kinds. Each list's effective column becomes `max(markerWidth, natural)`, so consumers can line up mixed lists without shrinking ordered lists or resizing the bullet/checkbox glyphs. Values below the natural width are ignored; leaving it unset preserves existing behavior.

```tsx
<EnrichedMarkdownText
  markdownStyle={{
    list: {
      bulletSize: 6,
      markerWidth: 20, // widens UL and task rows to line up with OL at 16pt
    },
  }}
  ...
/>
```

### Implementation

- **Public API**: `ListStyle.markerWidth?: number` (type-only; JSDoc on the internal type captures the sentinel contract).
- **Internal codegen prop**: concrete `Float`; negative = auto. Default is set in `normalizeMarkdownStyle` so consumers never touch the sentinel.
- **iOS**: `StyleConfig` gets a new ivar + getter/setter; `effectiveListMarginLeftForBullet` / `effectiveListMarginLeftForNumber` floor by `markerWidth`; new `effectiveListMarginLeftForTask` handles task rows. Wired through `StylePropsUtils` and included in `MeasurementCache` so cached sizes invalidate when the prop changes. `ListItemRenderer.m` routes the task case through the new accessor.
- **Android**: `ListStyle` carries the field and exposes `effectiveMarkerWidth(natural)`. `UnorderedListSpan`, `OrderedListSpan`, and `TaskListSpan` all apply the floor. Bullets and checkboxes now position themselves relative to the reserved column's right edge (matching iOS), which stays pixel-identical when the column width equals the natural glyph width.
- **Docs**: new row in `docs/STYLES.md`.
- **Example app**: `apps/example/src/markdownStyles.ts` sets `markerWidth: 20` so the feature is visible against the existing mixed-list sample content.

### Testing

- [x] iOS example app built and launched on iPhone 17 Pro simulator.
- [x] Android example app built and launched on Pixel 3a (API 34) emulator.
- [x] Verified before/after visually on the existing `sampleMarkdown` which has mixed UL, OL, and task lists on both platforms.
- [x] Behavior unchanged when `markerWidth` is undefined (floor is below natural).

#### Screenshots

Same mixed-list sample content (UL + OL + task rows from `sampleMarkdown.ts`) rendered with and without `markerWidth: 20`.

**iOS (iPhone 17 Pro simulator)**

| Default | `markerWidth: 20` |
| - | - |
| <img width="360" alt="Default" src="https://github.com/user-attachments/assets/449da8f0-8da9-44aa-afc0-d7ee5ee76771"> | <img width="360" alt="markerWidth: 20" src="https://github.com/user-attachments/assets/f55422ec-3283-4caa-abb6-d4134cbafb8f"> |

**Android (Pixel 3a API 34 emulator)**

| Default | `markerWidth: 20` |
| - | - |
| <img width="360" alt="Default Android" src="https://github.com/user-attachments/assets/0415293b-8268-4121-8609-5918e8845f98" /> | <img width="360" alt="markerWidth: 20 Android" src="https://github.com/user-attachments/assets/903c67c8-b17e-410f-ba53-76fc22398d1c" /> |

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
