### PR TITLE
feat: custom selection color

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -18,6 +18,7 @@ import com.swmansion.enriched.markdown.utils.common.FeatureFlags
 import com.swmansion.enriched.markdown.utils.common.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.utils.common.RenderedSegment
 import com.swmansion.enriched.markdown.utils.common.splitASTIntoSegments
+import com.swmansion.enriched.markdown.utils.text.view.applyMarkdownSelectionColors
 import com.swmansion.enriched.markdown.utils.text.view.emitLinkLongPressEvent
 import com.swmansion.enriched.markdown.utils.text.view.emitLinkPressEvent
 import com.swmansion.enriched.markdown.views.BlockSegmentView
@@ -54,6 +55,8 @@ class EnrichedMarkdown
     private var maxFontSizeMultiplier: Float = 0f
     private var allowTrailingMargin: Boolean = false
     private var selectable: Boolean = true
+    private var propSelectionColor: Int? = null
+    private var propSelectionHandleColor: Int? = null
 
     private var onLinkPressCallback: ((String) -> Unit)? = null
     private var onLinkLongPressCallback: ((String) -> Unit)? = null
@@ -125,6 +128,22 @@ class EnrichedMarkdown
       selectable = value
       segmentViews.filterIsInstance<EnrichedMarkdownInternalText>().forEach {
         it.setIsSelectable(value)
+      }
+    }
+
+    fun setSelectionColorFromProps(color: Int?) {
+      propSelectionColor = color
+      applySelectionColorsToSegments()
+    }
+
+    fun setSelectionHandleColorFromProps(color: Int?) {
+      propSelectionHandleColor = color
+      applySelectionColorsToSegments()
+    }
+
+    private fun applySelectionColorsToSegments() {
+      segmentViews.filterIsInstance<EnrichedMarkdownInternalText>().forEach {
+        it.applyMarkdownSelectionColors(propSelectionColor, propSelectionHandleColor)
       }
     }
 
@@ -234,6 +253,8 @@ class EnrichedMarkdown
         if (contextMenuItemTexts.isNotEmpty()) {
           setContextMenuItems(contextMenuItemTexts, ::forwardContextMenuItemPress)
         }
+
+        applyMarkdownSelectionColors(propSelectionColor, propSelectionHandleColor)
       }
 
     private fun createTableView(

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -18,7 +18,7 @@ import com.swmansion.enriched.markdown.utils.common.FeatureFlags
 import com.swmansion.enriched.markdown.utils.common.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.utils.common.RenderedSegment
 import com.swmansion.enriched.markdown.utils.common.splitASTIntoSegments
-import com.swmansion.enriched.markdown.utils.text.view.applyMarkdownSelectionColors
+import com.swmansion.enriched.markdown.utils.text.view.applySelectionColors
 import com.swmansion.enriched.markdown.utils.text.view.emitLinkLongPressEvent
 import com.swmansion.enriched.markdown.utils.text.view.emitLinkPressEvent
 import com.swmansion.enriched.markdown.views.BlockSegmentView
@@ -55,8 +55,8 @@ class EnrichedMarkdown
     private var maxFontSizeMultiplier: Float = 0f
     private var allowTrailingMargin: Boolean = false
     private var selectable: Boolean = true
-    private var propSelectionColor: Int? = null
-    private var propSelectionHandleColor: Int? = null
+    private var selectionColor: Int? = null
+    private var selectionHandleColor: Int? = null
 
     private var onLinkPressCallback: ((String) -> Unit)? = null
     private var onLinkLongPressCallback: ((String) -> Unit)? = null
@@ -131,19 +131,19 @@ class EnrichedMarkdown
       }
     }
 
-    fun setSelectionColorFromProps(color: Int?) {
-      propSelectionColor = color
+    fun setSelectionColor(color: Int?) {
+      selectionColor = color
       applySelectionColorsToSegments()
     }
 
-    fun setSelectionHandleColorFromProps(color: Int?) {
-      propSelectionHandleColor = color
+    fun setSelectionHandleColor(color: Int?) {
+      selectionHandleColor = color
       applySelectionColorsToSegments()
     }
 
     private fun applySelectionColorsToSegments() {
       segmentViews.filterIsInstance<EnrichedMarkdownInternalText>().forEach {
-        it.applyMarkdownSelectionColors(propSelectionColor, propSelectionHandleColor)
+        it.applySelectionColors(selectionColor, selectionHandleColor)
       }
     }
 
@@ -254,7 +254,7 @@ class EnrichedMarkdown
           setContextMenuItems(contextMenuItemTexts, ::forwardContextMenuItemPress)
         }
 
-        applyMarkdownSelectionColors(propSelectionColor, propSelectionHandleColor)
+        applySelectionColors(selectionColor, selectionHandleColor)
       }
 
     private fun createTableView(

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -80,6 +80,20 @@ class EnrichedMarkdownManager :
     view?.setIsSelectable(selectable)
   }
 
+  override fun setSelectionColor(
+    view: EnrichedMarkdown?,
+    value: Int?,
+  ) {
+    view?.setSelectionColorFromProps(value)
+  }
+
+  override fun setSelectionHandleColor(
+    view: EnrichedMarkdown?,
+    value: Int?,
+  ) {
+    view?.setSelectionHandleColorFromProps(value)
+  }
+
   @ReactProp(name = "md4cFlags")
   override fun setMd4cFlags(
     view: EnrichedMarkdown?,

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -84,14 +84,14 @@ class EnrichedMarkdownManager :
     view: EnrichedMarkdown?,
     value: Int?,
   ) {
-    view?.setSelectionColorFromProps(value)
+    view?.setSelectionColor(value)
   }
 
   override fun setSelectionHandleColor(
     view: EnrichedMarkdown?,
     value: Int?,
   ) {
-    view?.setSelectionHandleColorFromProps(value)
+    view?.setSelectionHandleColor(value)
   }
 
   @ReactProp(name = "md4cFlags")

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -22,6 +22,7 @@ import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.text.TailFadeInAnimator
 import com.swmansion.enriched.markdown.utils.text.interaction.CheckboxTouchHelper
 import com.swmansion.enriched.markdown.utils.text.view.LinkLongPressMovementMethod
+import com.swmansion.enriched.markdown.utils.text.view.applyMarkdownSelectionColors
 import com.swmansion.enriched.markdown.utils.text.view.applySelectableState
 import com.swmansion.enriched.markdown.utils.text.view.cancelJSTouchForCheckboxTap
 import com.swmansion.enriched.markdown.utils.text.view.cancelJSTouchForLinkTap
@@ -80,6 +81,9 @@ class EnrichedMarkdownText
     override var spoilerOverlayDrawer: SpoilerOverlayDrawer? = null
       private set
     var spoilerOverlay: SpoilerOverlay = SpoilerOverlay.PARTICLES
+
+    private var propSelectionColor: Int? = null
+    private var propSelectionHandleColor: Int? = null
 
     init {
       setupAsMarkdownTextView()
@@ -248,6 +252,8 @@ class EnrichedMarkdownText
         fadeAnimator?.animate(tailStart, styledText.length)
         previousTextLength = styledText.length
       }
+
+      applyMarkdownSelectionColors(propSelectionColor, propSelectionHandleColor)
     }
 
     fun setContextMenuItems(items: List<String>) {
@@ -256,6 +262,16 @@ class EnrichedMarkdownText
 
     fun setIsSelectable(selectable: Boolean) {
       applySelectableState(selectable)
+    }
+
+    fun setSelectionColorFromProps(color: Int?) {
+      propSelectionColor = color
+      applyMarkdownSelectionColors(propSelectionColor, propSelectionHandleColor)
+    }
+
+    fun setSelectionHandleColorFromProps(color: Int?) {
+      propSelectionHandleColor = color
+      applyMarkdownSelectionColors(propSelectionColor, propSelectionHandleColor)
     }
 
     fun emitOnLinkPress(url: String) {

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -22,8 +22,8 @@ import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.text.TailFadeInAnimator
 import com.swmansion.enriched.markdown.utils.text.interaction.CheckboxTouchHelper
 import com.swmansion.enriched.markdown.utils.text.view.LinkLongPressMovementMethod
-import com.swmansion.enriched.markdown.utils.text.view.applyMarkdownSelectionColors
 import com.swmansion.enriched.markdown.utils.text.view.applySelectableState
+import com.swmansion.enriched.markdown.utils.text.view.applySelectionColors
 import com.swmansion.enriched.markdown.utils.text.view.cancelJSTouchForCheckboxTap
 import com.swmansion.enriched.markdown.utils.text.view.cancelJSTouchForLinkTap
 import com.swmansion.enriched.markdown.utils.text.view.createSelectionActionModeCallback
@@ -82,8 +82,8 @@ class EnrichedMarkdownText
       private set
     var spoilerOverlay: SpoilerOverlay = SpoilerOverlay.PARTICLES
 
-    private var propSelectionColor: Int? = null
-    private var propSelectionHandleColor: Int? = null
+    private var selectionColor: Int? = null
+    private var selectionHandleColor: Int? = null
 
     init {
       setupAsMarkdownTextView()
@@ -253,7 +253,7 @@ class EnrichedMarkdownText
         previousTextLength = styledText.length
       }
 
-      applyMarkdownSelectionColors(propSelectionColor, propSelectionHandleColor)
+      applySelectionColors(selectionColor, selectionHandleColor)
     }
 
     fun setContextMenuItems(items: List<String>) {
@@ -264,14 +264,14 @@ class EnrichedMarkdownText
       applySelectableState(selectable)
     }
 
-    fun setSelectionColorFromProps(color: Int?) {
-      propSelectionColor = color
-      applyMarkdownSelectionColors(propSelectionColor, propSelectionHandleColor)
+    fun setSelectionColor(color: Int?) {
+      selectionColor = color
+      applySelectionColors(selectionColor, selectionHandleColor)
     }
 
-    fun setSelectionHandleColorFromProps(color: Int?) {
-      propSelectionHandleColor = color
-      applyMarkdownSelectionColors(propSelectionColor, propSelectionHandleColor)
+    fun setSelectionHandleColor(color: Int?) {
+      selectionHandleColor = color
+      applySelectionColors(selectionColor, selectionHandleColor)
     }
 
     fun emitOnLinkPress(url: String) {

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -100,6 +100,20 @@ class EnrichedMarkdownTextManager :
     view?.setIsSelectable(selectable)
   }
 
+  override fun setSelectionColor(
+    view: EnrichedMarkdownText?,
+    value: Int?,
+  ) {
+    view?.setSelectionColorFromProps(value)
+  }
+
+  override fun setSelectionHandleColor(
+    view: EnrichedMarkdownText?,
+    value: Int?,
+  ) {
+    view?.setSelectionHandleColorFromProps(value)
+  }
+
   @ReactProp(name = "md4cFlags")
   override fun setMd4cFlags(
     view: EnrichedMarkdownText?,

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -104,14 +104,14 @@ class EnrichedMarkdownTextManager :
     view: EnrichedMarkdownText?,
     value: Int?,
   ) {
-    view?.setSelectionColorFromProps(value)
+    view?.setSelectionColor(value)
   }
 
   override fun setSelectionHandleColor(
     view: EnrichedMarkdownText?,
     value: Int?,
   ) {
-    view?.setSelectionHandleColorFromProps(value)
+    view?.setSelectionHandleColor(value)
   }
 
   @ReactProp(name = "md4cFlags")

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextSelectionColors.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextSelectionColors.kt
@@ -1,5 +1,6 @@
 package com.swmansion.enriched.markdown.utils.text.view
 
+import android.graphics.drawable.Drawable
 import android.os.Build
 import android.util.Log
 import android.widget.TextView
@@ -7,6 +8,9 @@ import androidx.annotation.ColorInt
 import androidx.core.graphics.drawable.DrawableCompat
 
 private const val TAG = "TextSelectionColors"
+
+private typealias HandleGetter = (TextView) -> Drawable?
+private typealias HandleSetter = (TextView, Drawable) -> Unit
 
 /**
  * Applies selection highlight and (where supported) handle tinting to a [TextView].
@@ -29,16 +33,16 @@ private fun TextView.applySelectionHandleTint(
     return
   }
 
-  val handles =
+  val handles: List<Pair<HandleGetter, HandleSetter>> =
     listOf(
-      this::getTextSelectHandleLeft to this::setTextSelectHandleLeft,
-      this::getTextSelectHandle to this::setTextSelectHandle,
-      this::getTextSelectHandleRight to this::setTextSelectHandleRight,
+      TextView::getTextSelectHandleLeft to { tv, d -> tv.setTextSelectHandleLeft(d) },
+      TextView::getTextSelectHandle to { tv, d -> tv.setTextSelectHandle(d) },
+      TextView::getTextSelectHandleRight to { tv, d -> tv.setTextSelectHandleRight(d) },
     )
 
   handles.forEach { (getter, setter) ->
     try {
-      getter()?.mutate()?.also { DrawableCompat.setTint(it, color) }?.let(setter)
+      getter(this)?.mutate()?.also { DrawableCompat.setTint(it, color) }?.let { setter(this, it) }
     } catch (e: LinkageError) {
       // Defensive: OEM TextView variants may strip individual handle accessors.
       Log.w(TAG, "Selection handle tint skipped: ${e.message}")

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextSelectionColors.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextSelectionColors.kt
@@ -1,0 +1,47 @@
+package com.swmansion.enriched.markdown.utils.text.view
+
+import android.os.Build
+import android.widget.TextView
+import androidx.annotation.ColorInt
+import androidx.core.graphics.drawable.DrawableCompat
+
+/**
+ * Applies selection highlight and (where supported) handle tinting to a [TextView].
+ *
+ * Handle drawables are only tinted on API 29+ where the framework exposes getters;
+ * on older versions the handle theme defaults remain unchanged.
+ */
+fun TextView.applyMarkdownSelectionColors(
+  selectionColor: Int?,
+  selectionHandleColor: Int?,
+) {
+  selectionColor?.let { highlightColor = it }
+  selectionHandleColor?.let { applySelectionHandleTint(it) }
+}
+
+private fun TextView.applySelectionHandleTint(
+  @ColorInt color: Int,
+) {
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+    return
+  }
+  try {
+    tintHandle(textSelectHandleLeft, color)?.let { setTextSelectHandleLeft(it) }
+    tintHandle(textSelectHandle, color)?.let { setTextSelectHandle(it) }
+    tintHandle(textSelectHandleRight, color)?.let { setTextSelectHandleRight(it) }
+  } catch (_: Exception) {
+    // Defensive: OEM TextView variants may not support all handle accessors.
+  }
+}
+
+private fun tintHandle(
+  drawable: android.graphics.drawable.Drawable?,
+  @ColorInt color: Int,
+): android.graphics.drawable.Drawable? {
+  if (drawable == null) {
+    return null
+  }
+  val mutated = drawable.mutate()
+  DrawableCompat.setTint(mutated, color)
+  return mutated
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextSelectionColors.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextSelectionColors.kt
@@ -29,9 +29,7 @@ fun TextView.applySelectionColors(
 private fun TextView.applySelectionHandleTint(
   @ColorInt color: Int,
 ) {
-  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-    return
-  }
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
 
   val handles: List<Pair<HandleGetter, HandleSetter>> =
     listOf(
@@ -44,7 +42,6 @@ private fun TextView.applySelectionHandleTint(
     try {
       getter(this)?.mutate()?.also { DrawableCompat.setTint(it, color) }?.let { setter(this, it) }
     } catch (e: LinkageError) {
-      // Defensive: OEM TextView variants may strip individual handle accessors.
       Log.w(TAG, "Selection handle tint skipped: ${e.message}")
     }
   }

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextSelectionColors.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextSelectionColors.kt
@@ -11,7 +11,7 @@ import androidx.core.graphics.drawable.DrawableCompat
  * Handle drawables are only tinted on API 29+ where the framework exposes getters;
  * on older versions the handle theme defaults remain unchanged.
  */
-fun TextView.applyMarkdownSelectionColors(
+fun TextView.applySelectionColors(
   selectionColor: Int?,
   selectionHandleColor: Int?,
 ) {

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextSelectionColors.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/TextSelectionColors.kt
@@ -1,9 +1,12 @@
 package com.swmansion.enriched.markdown.utils.text.view
 
 import android.os.Build
+import android.util.Log
 import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.core.graphics.drawable.DrawableCompat
+
+private const val TAG = "TextSelectionColors"
 
 /**
  * Applies selection highlight and (where supported) handle tinting to a [TextView].
@@ -25,23 +28,20 @@ private fun TextView.applySelectionHandleTint(
   if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
     return
   }
-  try {
-    tintHandle(textSelectHandleLeft, color)?.let { setTextSelectHandleLeft(it) }
-    tintHandle(textSelectHandle, color)?.let { setTextSelectHandle(it) }
-    tintHandle(textSelectHandleRight, color)?.let { setTextSelectHandleRight(it) }
-  } catch (_: Exception) {
-    // Defensive: OEM TextView variants may not support all handle accessors.
-  }
-}
 
-private fun tintHandle(
-  drawable: android.graphics.drawable.Drawable?,
-  @ColorInt color: Int,
-): android.graphics.drawable.Drawable? {
-  if (drawable == null) {
-    return null
+  val handles =
+    listOf(
+      this::getTextSelectHandleLeft to this::setTextSelectHandleLeft,
+      this::getTextSelectHandle to this::setTextSelectHandle,
+      this::getTextSelectHandleRight to this::setTextSelectHandleRight,
+    )
+
+  handles.forEach { (getter, setter) ->
+    try {
+      getter()?.mutate()?.also { DrawableCompat.setTint(it, color) }?.let(setter)
+    } catch (e: LinkageError) {
+      // Defensive: OEM TextView variants may strip individual handle accessors.
+      Log.w(TAG, "Selection handle tint skipped: ${e.message}")
+    }
   }
-  val mutated = drawable.mutate()
-  DrawableCompat.setTint(mutated, color)
-  return mutated
 }

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -93,6 +93,8 @@ export default function App() {
             onLinkPress={handleLinkPress}
             markdownStyle={markdownStyle}
             contextMenuItems={contextMenuItems}
+            selectionColor={Platform.OS === 'ios' ? '#5A52FA' : '#DCDDFE'}
+            selectionHandleColor="#5A52FA"
           />
         </ScrollView>
       )}

--- a/apps/web-example/src/App.tsx
+++ b/apps/web-example/src/App.tsx
@@ -153,6 +153,8 @@ export default function App() {
           onLinkPress={onLinkPress}
           onLinkLongPress={onLinkLongPress}
           onTaskListItemPress={onTaskListItemPress}
+          selectionColor="#DCDDFE"
+          selectionHandleColor="#5A52FA"
         />
 
         <View style={styles.divider} />

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -901,6 +901,8 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
 #if !TARGET_OS_OSX
   if (isColorMeaningful(props.selectionColor)) {
     ENRMSetSelectionColor(textView, RCTUIColorFromSharedColor(props.selectionColor));
+  } else {
+    ENRMSetSelectionColor(textView, nil); // resets to inherited / system tint
   }
 #endif
 }

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -902,7 +902,7 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
   if (isColorMeaningful(props.selectionColor)) {
     ENRMSetSelectionColor(textView, RCTUIColorFromSharedColor(props.selectionColor));
   } else {
-    ENRMSetSelectionColor(textView, nil); // resets to inherited / system tint
+    ENRMSetSelectionColor(textView, nil);
   }
 #endif
 }

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -7,6 +7,7 @@
 #import "EditMenuUtils.h"
 
 #import "ENRMFeatureFlags.h"
+#import "ENRMUIKit.h"
 
 #if ENRICHED_MARKDOWN_MATH
 #import "ENRMMathContainerView.h"
@@ -90,6 +91,7 @@ using namespace facebook::react;
 #endif
 
 @interface EnrichedMarkdown () <RCTEnrichedMarkdownViewProtocol, UITextViewDelegate>
+- (void)applySelectionTintFromProps:(const EnrichedMarkdownProps &)props toTextView:(ENRMPlatformTextView *)textView;
 @end
 
 @implementation EnrichedMarkdown {
@@ -493,6 +495,9 @@ using namespace facebook::react;
   view.textView.selectable = _selectable;
   [view applyAttributedText:segment.attributedText context:segment.context];
 
+  const auto &selectionProps = *std::static_pointer_cast<EnrichedMarkdownProps const>(self->_props);
+  [self applySelectionTintFromProps:selectionProps toTextView:view.textView];
+
   ENRMTapRecognizer *tapRecognizer = [[ENRMTapRecognizer alloc] initWithTarget:self action:@selector(textTapped:)];
   [view.textView addGestureRecognizer:tapRecognizer];
 
@@ -655,6 +660,18 @@ using namespace facebook::react;
         ((EnrichedMarkdownInternalText *)segment).spoilerOverlay = _spoilerOverlay;
       }
     }
+  }
+
+  if (newViewProps.selectionHandleColor != oldViewProps.selectionHandleColor ||
+      newViewProps.selectionColor != oldViewProps.selectionColor) {
+#if !TARGET_OS_OSX
+    for (RCTUIView *segment in _segmentViews) {
+      if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
+        ENRMPlatformTextView *tv = ((EnrichedMarkdownInternalText *)segment).textView;
+        [self applySelectionTintFromProps:newViewProps toTextView:tv];
+      }
+    }
+#endif
   }
 
   if (markdownChanged || stylePropChanged || md4cFlagsChanged || allowTrailingMarginChanged) {
@@ -879,5 +896,16 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
   return [MarkdownAccessibilityElementBuilder buildRotorsFromElements:[self accessibilityElements]];
 }
 #endif
+
+- (void)applySelectionTintFromProps:(const EnrichedMarkdownProps &)props toTextView:(ENRMPlatformTextView *)textView
+{
+#if !TARGET_OS_OSX
+  if (isColorMeaningful(props.selectionHandleColor)) {
+    ENRMSetSelectionColor(textView, RCTUIColorFromSharedColor(props.selectionHandleColor));
+  } else if (isColorMeaningful(props.selectionColor)) {
+    ENRMSetSelectionColor(textView, RCTUIColorFromSharedColor(props.selectionColor));
+  }
+#endif
+}
 
 @end

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -91,7 +91,7 @@ using namespace facebook::react;
 #endif
 
 @interface EnrichedMarkdown () <RCTEnrichedMarkdownViewProtocol, UITextViewDelegate>
-- (void)applySelectionTintFromProps:(const EnrichedMarkdownProps &)props toTextView:(ENRMPlatformTextView *)textView;
+- (void)applySelectionColor:(const EnrichedMarkdownProps &)props toTextView:(ENRMPlatformTextView *)textView;
 @end
 
 @implementation EnrichedMarkdown {
@@ -496,7 +496,7 @@ using namespace facebook::react;
   [view applyAttributedText:segment.attributedText context:segment.context];
 
   const auto &selectionProps = *std::static_pointer_cast<EnrichedMarkdownProps const>(self->_props);
-  [self applySelectionTintFromProps:selectionProps toTextView:view.textView];
+  [self applySelectionColor:selectionProps toTextView:view.textView];
 
   ENRMTapRecognizer *tapRecognizer = [[ENRMTapRecognizer alloc] initWithTarget:self action:@selector(textTapped:)];
   [view.textView addGestureRecognizer:tapRecognizer];
@@ -667,7 +667,7 @@ using namespace facebook::react;
     for (RCTUIView *segment in _segmentViews) {
       if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
         ENRMPlatformTextView *tv = ((EnrichedMarkdownInternalText *)segment).textView;
-        [self applySelectionTintFromProps:newViewProps toTextView:tv];
+        [self applySelectionColor:newViewProps toTextView:tv];
       }
     }
 #endif
@@ -896,7 +896,7 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
 }
 #endif
 
-- (void)applySelectionTintFromProps:(const EnrichedMarkdownProps &)props toTextView:(ENRMPlatformTextView *)textView
+- (void)applySelectionColor:(const EnrichedMarkdownProps &)props toTextView:(ENRMPlatformTextView *)textView
 {
 #if !TARGET_OS_OSX
   if (isColorMeaningful(props.selectionColor)) {

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -662,8 +662,7 @@ using namespace facebook::react;
     }
   }
 
-  if (newViewProps.selectionHandleColor != oldViewProps.selectionHandleColor ||
-      newViewProps.selectionColor != oldViewProps.selectionColor) {
+  if (newViewProps.selectionColor != oldViewProps.selectionColor) {
 #if !TARGET_OS_OSX
     for (RCTUIView *segment in _segmentViews) {
       if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
@@ -900,9 +899,7 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
 - (void)applySelectionTintFromProps:(const EnrichedMarkdownProps &)props toTextView:(ENRMPlatformTextView *)textView
 {
 #if !TARGET_OS_OSX
-  if (isColorMeaningful(props.selectionHandleColor)) {
-    ENRMSetSelectionColor(textView, RCTUIColorFromSharedColor(props.selectionHandleColor));
-  } else if (isColorMeaningful(props.selectionColor)) {
+  if (isColorMeaningful(props.selectionColor)) {
     ENRMSetSelectionColor(textView, RCTUIColorFromSharedColor(props.selectionColor));
   }
 #endif

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -412,12 +412,9 @@ using namespace facebook::react;
     _textView.selectable = newViewProps.selectable;
   }
 
-  if (newViewProps.selectionHandleColor != oldViewProps.selectionHandleColor ||
-      newViewProps.selectionColor != oldViewProps.selectionColor) {
+  if (newViewProps.selectionColor != oldViewProps.selectionColor) {
 #if !TARGET_OS_OSX
-    if (isColorMeaningful(newViewProps.selectionHandleColor)) {
-      ENRMSetSelectionColor(_textView, RCTUIColorFromSharedColor(newViewProps.selectionHandleColor));
-    } else if (isColorMeaningful(newViewProps.selectionColor)) {
+    if (isColorMeaningful(newViewProps.selectionColor)) {
       ENRMSetSelectionColor(_textView, RCTUIColorFromSharedColor(newViewProps.selectionColor));
     }
 #endif

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -9,6 +9,7 @@
 #import "ENRMTailFadeInAnimator.h"
 #import "ENRMTextRenderer.h"
 #import "ENRMTextViewSetup.h"
+#import "ENRMUIKit.h"
 #import "EditMenuUtils.h"
 #import "FontScaleObserver.h"
 #import "FontUtils.h"
@@ -409,6 +410,17 @@ using namespace facebook::react;
 
   if (_textView.selectable != newViewProps.selectable) {
     _textView.selectable = newViewProps.selectable;
+  }
+
+  if (newViewProps.selectionHandleColor != oldViewProps.selectionHandleColor ||
+      newViewProps.selectionColor != oldViewProps.selectionColor) {
+#if !TARGET_OS_OSX
+    if (isColorMeaningful(newViewProps.selectionHandleColor)) {
+      ENRMSetSelectionColor(_textView, RCTUIColorFromSharedColor(newViewProps.selectionHandleColor));
+    } else if (isColorMeaningful(newViewProps.selectionColor)) {
+      ENRMSetSelectionColor(_textView, RCTUIColorFromSharedColor(newViewProps.selectionColor));
+    }
+#endif
   }
 
   if (newViewProps.allowFontScaling != oldViewProps.allowFontScaling) {

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -416,6 +416,8 @@ using namespace facebook::react;
 #if !TARGET_OS_OSX
     if (isColorMeaningful(newViewProps.selectionColor)) {
       ENRMSetSelectionColor(_textView, RCTUIColorFromSharedColor(newViewProps.selectionColor));
+    } else {
+      ENRMSetSelectionColor(_textView, nil); // resets to inherited / system tint
     }
 #endif
   }

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -417,7 +417,7 @@ using namespace facebook::react;
     if (isColorMeaningful(newViewProps.selectionColor)) {
       ENRMSetSelectionColor(_textView, RCTUIColorFromSharedColor(newViewProps.selectionColor));
     } else {
-      ENRMSetSelectionColor(_textView, nil); // resets to inherited / system tint
+      ENRMSetSelectionColor(_textView, nil);
     }
 #endif
   }

--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -293,7 +293,7 @@ using namespace facebook::react;
     if (isColorMeaningful(newViewProps.selectionColor)) {
       ENRMSetSelectionColor(_textView, RCTUIColorFromSharedColor(newViewProps.selectionColor));
     } else {
-      ENRMSetSelectionColor(_textView, nil); // resets to inherited / system tint
+      ENRMSetSelectionColor(_textView, nil);
     }
   }
 

--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -292,6 +292,8 @@ using namespace facebook::react;
   if (newViewProps.selectionColor != oldViewProps.selectionColor) {
     if (isColorMeaningful(newViewProps.selectionColor)) {
       ENRMSetSelectionColor(_textView, RCTUIColorFromSharedColor(newViewProps.selectionColor));
+    } else {
+      ENRMSetSelectionColor(_textView, nil); // resets to inherited / system tint
     }
   }
 

--- a/src/EnrichedMarkdownNativeComponent.ts
+++ b/src/EnrichedMarkdownNativeComponent.ts
@@ -278,8 +278,7 @@ export interface NativeProps extends ViewProps {
    *
    * - **Android**: maps to `TextView.highlightColor`.
    * - **iOS**: `UITextView.tintColor` drives the selection highlight, caret, and
-   *   selection handles together. When `selectionHandleColor` is also set, it
-   *   takes precedence for `tintColor` (see that prop).
+   *   selection handles together.
    * - **Web**: maps to `::selection` background via a CSS variable on the root.
    *
    * @platform ios, android, web
@@ -290,11 +289,7 @@ export interface NativeProps extends ViewProps {
    *
    * - **Android**: tints the left, mid, and right handle drawables (API 29+;
    *   older API levels leave handles at the default theme color).
-   * - **iOS**: merged with selection via `tintColor` — when set, it overrides
-   *   `selectionColor` for the shared `tintColor` (highlight + handles + caret).
-   * - **Web**: best-effort via `accent-color` on the root; browser support varies.
-   *
-   * @platform ios, android, web
+   * @platform android
    */
   selectionHandleColor?: ColorValue;
   /**

--- a/src/EnrichedMarkdownNativeComponent.ts
+++ b/src/EnrichedMarkdownNativeComponent.ts
@@ -274,21 +274,18 @@ export interface NativeProps extends ViewProps {
    */
   selectable?: boolean;
   /**
-   * Color of the text selection highlight (selected text background).
+   * Color of the text selection highlight.
    *
-   * - **Android**: maps to `TextView.highlightColor`.
-   * - **iOS**: `UITextView.tintColor` drives the selection highlight, caret, and
-   *   selection handles together.
-   * - **Web**: maps to `::selection` background via a CSS variable on the root.
+   * On iOS, this also affects the caret and selection handle colors
+   * (they share a single tint).
    *
    * @platform ios, android, web
    */
   selectionColor?: ColorValue;
   /**
    * Color of the selection handles (drag anchors).
+   * No-op on API levels below 29.
    *
-   * - **Android**: tints the left, mid, and right handle drawables (API 29+;
-   *   older API levels leave handles at the default theme color).
    * @platform android
    */
   selectionHandleColor?: ColorValue;

--- a/src/EnrichedMarkdownNativeComponent.ts
+++ b/src/EnrichedMarkdownNativeComponent.ts
@@ -274,6 +274,30 @@ export interface NativeProps extends ViewProps {
    */
   selectable?: boolean;
   /**
+   * Color of the text selection highlight (selected text background).
+   *
+   * - **Android**: maps to `TextView.highlightColor`.
+   * - **iOS**: `UITextView.tintColor` drives the selection highlight, caret, and
+   *   selection handles together. When `selectionHandleColor` is also set, it
+   *   takes precedence for `tintColor` (see that prop).
+   * - **Web**: maps to `::selection` background via a CSS variable on the root.
+   *
+   * @platform ios, android, web
+   */
+  selectionColor?: ColorValue;
+  /**
+   * Color of the selection handles (drag anchors).
+   *
+   * - **Android**: tints the left, mid, and right handle drawables (API 29+;
+   *   older API levels leave handles at the default theme color).
+   * - **iOS**: merged with selection via `tintColor` — when set, it overrides
+   *   `selectionColor` for the shared `tintColor` (highlight + handles + caret).
+   * - **Web**: best-effort via `accent-color` on the root; browser support varies.
+   *
+   * @platform ios, android, web
+   */
+  selectionHandleColor?: ColorValue;
+  /**
    * MD4C parser flags configuration.
    * Controls how the markdown parser interprets certain syntax.
    */

--- a/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/src/EnrichedMarkdownTextNativeComponent.ts
@@ -278,8 +278,7 @@ export interface NativeProps extends ViewProps {
    *
    * - **Android**: maps to `TextView.highlightColor`.
    * - **iOS**: `UITextView.tintColor` drives the selection highlight, caret, and
-   *   selection handles together. When `selectionHandleColor` is also set, it
-   *   takes precedence for `tintColor` (see that prop).
+   *   selection handles together.
    * - **Web**: maps to `::selection` background via a CSS variable on the root.
    *
    * @platform ios, android, web
@@ -290,11 +289,7 @@ export interface NativeProps extends ViewProps {
    *
    * - **Android**: tints the left, mid, and right handle drawables (API 29+;
    *   older API levels leave handles at the default theme color).
-   * - **iOS**: merged with selection via `tintColor` — when set, it overrides
-   *   `selectionColor` for the shared `tintColor` (highlight + handles + caret).
-   * - **Web**: best-effort via `accent-color` on the root; browser support varies.
-   *
-   * @platform ios, android, web
+   * @platform android
    */
   selectionHandleColor?: ColorValue;
   /**

--- a/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/src/EnrichedMarkdownTextNativeComponent.ts
@@ -274,21 +274,18 @@ export interface NativeProps extends ViewProps {
    */
   selectable?: boolean;
   /**
-   * Color of the text selection highlight (selected text background).
+   * Color of the text selection highlight.
    *
-   * - **Android**: maps to `TextView.highlightColor`.
-   * - **iOS**: `UITextView.tintColor` drives the selection highlight, caret, and
-   *   selection handles together.
-   * - **Web**: maps to `::selection` background via a CSS variable on the root.
+   * On iOS, this also affects the caret and selection handle colors
+   * (they share a single tint).
    *
    * @platform ios, android, web
    */
   selectionColor?: ColorValue;
   /**
    * Color of the selection handles (drag anchors).
+   * No-op on API levels below 29.
    *
-   * - **Android**: tints the left, mid, and right handle drawables (API 29+;
-   *   older API levels leave handles at the default theme color).
    * @platform android
    */
   selectionHandleColor?: ColorValue;

--- a/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/src/EnrichedMarkdownTextNativeComponent.ts
@@ -274,6 +274,30 @@ export interface NativeProps extends ViewProps {
    */
   selectable?: boolean;
   /**
+   * Color of the text selection highlight (selected text background).
+   *
+   * - **Android**: maps to `TextView.highlightColor`.
+   * - **iOS**: `UITextView.tintColor` drives the selection highlight, caret, and
+   *   selection handles together. When `selectionHandleColor` is also set, it
+   *   takes precedence for `tintColor` (see that prop).
+   * - **Web**: maps to `::selection` background via a CSS variable on the root.
+   *
+   * @platform ios, android, web
+   */
+  selectionColor?: ColorValue;
+  /**
+   * Color of the selection handles (drag anchors).
+   *
+   * - **Android**: tints the left, mid, and right handle drawables (API 29+;
+   *   older API levels leave handles at the default theme color).
+   * - **iOS**: merged with selection via `tintColor` — when set, it overrides
+   *   `selectionColor` for the shared `tintColor` (highlight + handles + caret).
+   * - **Web**: best-effort via `accent-color` on the root; browser support varies.
+   *
+   * @platform ios, android, web
+   */
+  selectionHandleColor?: ColorValue;
+  /**
    * MD4C parser flags configuration.
    * Controls how the markdown parser interprets certain syntax.
    */

--- a/src/native/EnrichedMarkdownText.tsx
+++ b/src/native/EnrichedMarkdownText.tsx
@@ -42,6 +42,8 @@ export const EnrichedMarkdownText = ({
   streamingAnimation = false,
   spoilerOverlay = 'particles',
   contextMenuItems,
+  selectionColor,
+  selectionHandleColor,
   ...rest
 }: EnrichedMarkdownTextProps) => {
   const normalizedStyleRef = useRef<MarkdownStyleInternal | null>(null);
@@ -137,6 +139,8 @@ export const EnrichedMarkdownText = ({
     style: containerStyle,
     contextMenuItems: nativeContextMenuItems,
     onContextMenuItemPress: handleContextMenuItemPress,
+    selectionColor,
+    selectionHandleColor,
     ...rest,
   };
 

--- a/src/types/MarkdownTextProps.ts
+++ b/src/types/MarkdownTextProps.ts
@@ -1,4 +1,4 @@
-import type { ViewProps, ViewStyle, TextStyle } from 'react-native';
+import type { ColorValue, ViewProps, ViewStyle, TextStyle } from 'react-native';
 import type { MarkdownStyle, Md4cFlags } from './MarkdownStyle';
 import type {
   LinkPressEvent,
@@ -91,6 +91,30 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    * @platform ios, android, web
    */
   selectable?: boolean;
+  /**
+   * Color of the text selection highlight (selected text background).
+   *
+   * - **Android**: maps to `TextView.highlightColor`.
+   * - **iOS**: `UITextView.tintColor` drives the selection highlight, caret, and
+   *   selection handles together. When `selectionHandleColor` is also set, it
+   *   takes precedence for `tintColor` (see that prop).
+   * - **Web**: maps to `::selection` background via a CSS variable on the root.
+   *
+   * @platform ios, android, web
+   */
+  selectionColor?: ColorValue;
+  /**
+   * Color of the selection handles (drag anchors).
+   *
+   * - **Android**: tints the left, mid, and right handle drawables (API 29+;
+   *   older API levels leave handles at the default theme color).
+   * - **iOS**: merged with selection via `tintColor` — when set, it overrides
+   *   `selectionColor` for the shared `tintColor` (highlight + handles + caret).
+   * - **Web**: best-effort via `accent-color` on the root; browser support varies.
+   *
+   * @platform ios, android, web
+   */
+  selectionHandleColor?: ColorValue;
   /**
    * Specifies whether fonts should scale to respect Text Size accessibility settings.
    * When false, text will not scale with the user's accessibility settings.

--- a/src/types/MarkdownTextProps.ts
+++ b/src/types/MarkdownTextProps.ts
@@ -96,8 +96,7 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    *
    * - **Android**: maps to `TextView.highlightColor`.
    * - **iOS**: `UITextView.tintColor` drives the selection highlight, caret, and
-   *   selection handles together. When `selectionHandleColor` is also set, it
-   *   takes precedence for `tintColor` (see that prop).
+   *   selection handles together.
    * - **Web**: maps to `::selection` background via a CSS variable on the root.
    *
    * @platform ios, android, web
@@ -108,11 +107,8 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    *
    * - **Android**: tints the left, mid, and right handle drawables (API 29+;
    *   older API levels leave handles at the default theme color).
-   * - **iOS**: merged with selection via `tintColor` — when set, it overrides
-   *   `selectionColor` for the shared `tintColor` (highlight + handles + caret).
-   * - **Web**: best-effort via `accent-color` on the root; browser support varies.
    *
-   * @platform ios, android, web
+   * @platform android
    */
   selectionHandleColor?: ColorValue;
   /**

--- a/src/types/MarkdownTextProps.ts
+++ b/src/types/MarkdownTextProps.ts
@@ -92,21 +92,17 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    */
   selectable?: boolean;
   /**
-   * Color of the text selection highlight (selected text background).
+   * Color of the text selection highlight.
    *
-   * - **Android**: maps to `TextView.highlightColor`.
-   * - **iOS**: `UITextView.tintColor` drives the selection highlight, caret, and
-   *   selection handles together.
-   * - **Web**: maps to `::selection` background via a CSS variable on the root.
+   * On iOS, this also affects the caret and selection handle colors
+   * (they share a single tint).
    *
    * @platform ios, android, web
    */
   selectionColor?: ColorValue;
   /**
    * Color of the selection handles (drag anchors).
-   *
-   * - **Android**: tints the left, mid, and right handle drawables (API 29+;
-   *   older API levels leave handles at the default theme color).
+   * No-op on API levels below 29.
    *
    * @platform android
    */

--- a/src/types/MarkdownTextProps.web.ts
+++ b/src/types/MarkdownTextProps.web.ts
@@ -1,3 +1,4 @@
+import type { ColorValue } from 'react-native';
 import type { CSSProperties, HTMLAttributes } from 'react';
 import type { MarkdownStyle, Md4cFlags } from './MarkdownStyle';
 import type {
@@ -65,6 +66,17 @@ export interface EnrichedMarkdownTextProps
    * @platform ios, android, web
    */
   selectable?: boolean;
+  /**
+   * Color of the text selection highlight (`::selection` background).
+   * @platform web
+   */
+  selectionColor?: ColorValue;
+  /**
+   * Best-effort tint for selection affordances (`accent-color` on the root).
+   * Selection handle appearance is largely browser-controlled.
+   * @platform web
+   */
+  selectionHandleColor?: ColorValue;
   /**
    * When false (default), removes trailing margin from the last element to
    * eliminate bottom spacing.

--- a/src/types/MarkdownTextProps.web.ts
+++ b/src/types/MarkdownTextProps.web.ts
@@ -67,7 +67,7 @@ export interface EnrichedMarkdownTextProps
    */
   selectable?: boolean;
   /**
-   * Color of the text selection highlight (`::selection` background).
+   * Color of the text selection highlight.
    * @platform web
    */
   selectionColor?: ColorValue;

--- a/src/types/MarkdownTextProps.web.ts
+++ b/src/types/MarkdownTextProps.web.ts
@@ -72,12 +72,6 @@ export interface EnrichedMarkdownTextProps
    */
   selectionColor?: ColorValue;
   /**
-   * Best-effort tint for selection affordances (`accent-color` on the root).
-   * Selection handle appearance is largely browser-controlled.
-   * @platform web
-   */
-  selectionHandleColor?: ColorValue;
-  /**
    * When false (default), removes trailing margin from the last element to
    * eliminate bottom spacing.
    * When true, keeps the trailing margin from the last element's marginBottom style.

--- a/src/web/EnrichedMarkdownText.tsx
+++ b/src/web/EnrichedMarkdownText.tsx
@@ -104,7 +104,7 @@ export const EnrichedMarkdownText = ({
   );
 
   const wrapperStyle = useMemo<CSSProperties>(() => {
-    const selectionBgVar = selectionColor
+    const selectionColorCss = selectionColor
       ? normalizeColor(String(selectionColor))
       : undefined;
 
@@ -113,8 +113,8 @@ export const EnrichedMarkdownText = ({
       flexDirection: 'column',
       ...(containerStyle as CSSProperties),
       ...(selectable ? undefined : { userSelect: 'none' }),
-      ...(selectionBgVar != null
-        ? ({ ['--enrm-selection-bg']: selectionBgVar } as CSSProperties)
+      ...(selectionColorCss != null
+        ? ({ ['--enrm-selection-bg']: selectionColorCss } as CSSProperties)
         : null),
     };
   }, [containerStyle, selectable, selectionColor]);

--- a/src/web/EnrichedMarkdownText.tsx
+++ b/src/web/EnrichedMarkdownText.tsx
@@ -31,7 +31,6 @@ export const EnrichedMarkdownText = ({
   selectable = true,
   dir,
   selectionColor,
-  selectionHandleColor,
   ...rest
 }: EnrichedMarkdownTextProps) => {
   const normalizedStyle = useMemo(
@@ -117,11 +116,8 @@ export const EnrichedMarkdownText = ({
       ...(selectionBgVar != null
         ? ({ ['--enrm-selection-bg']: selectionBgVar } as CSSProperties)
         : null),
-      ...(selectionHandleColor != null && selectionHandleColor !== undefined
-        ? { accentColor: String(selectionHandleColor) }
-        : null),
     };
-  }, [containerStyle, selectable, selectionColor, selectionHandleColor]);
+  }, [containerStyle, selectable, selectionColor]);
 
   const selectionStyle =
     selectionColor != null && selectionColor !== undefined ? (

--- a/src/web/EnrichedMarkdownText.tsx
+++ b/src/web/EnrichedMarkdownText.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, useMemo, type CSSProperties } from 'react';
+import {
+  useState,
+  useEffect,
+  useMemo,
+  Fragment,
+  type CSSProperties,
+} from 'react';
 import type { EnrichedMarkdownTextProps } from '../types/MarkdownTextProps.web';
 import { normalizeMarkdownStyle } from '../normalizeMarkdownStyle.web';
 import {
@@ -24,6 +30,8 @@ export const EnrichedMarkdownText = ({
   containerStyle,
   selectable = true,
   dir,
+  selectionColor,
+  selectionHandleColor,
   ...rest
 }: EnrichedMarkdownTextProps) => {
   const normalizedStyle = useMemo(
@@ -95,21 +103,46 @@ export const EnrichedMarkdownText = ({
     [lastChildStyle]
   );
 
-  const wrapperStyle = useMemo<CSSProperties>(
-    () => ({
+  const wrapperStyle = useMemo<CSSProperties>(() => {
+    const selectionBgVar =
+      selectionColor != null && selectionColor !== undefined
+        ? String(selectionColor)
+        : undefined;
+
+    return {
       display: 'flex',
       flexDirection: 'column',
       ...(containerStyle as CSSProperties),
       ...(selectable ? undefined : { userSelect: 'none' }),
-    }),
-    [containerStyle, selectable]
-  );
+      ...(selectionBgVar != null
+        ? ({ ['--enrm-selection-bg']: selectionBgVar } as CSSProperties)
+        : null),
+      ...(selectionHandleColor != null && selectionHandleColor !== undefined
+        ? { accentColor: String(selectionHandleColor) }
+        : null),
+    };
+  }, [containerStyle, selectable, selectionColor, selectionHandleColor]);
+
+  const selectionStyle =
+    selectionColor != null && selectionColor !== undefined ? (
+      <style>{`[data-enriched-markdown-text] ::selection {
+    background-color: var(--enrm-selection-bg);
+    }`}</style>
+    ) : null;
 
   if (parseError) {
     return (
-      <div style={wrapperStyle} dir={dir} {...rest}>
-        <pre style={parseErrorFallbackStyle}>{markdown}</pre>
-      </div>
+      <Fragment>
+        {selectionStyle}
+        <div
+          data-enriched-markdown-text
+          style={wrapperStyle}
+          dir={dir}
+          {...rest}
+        >
+          <pre style={parseErrorFallbackStyle}>{markdown}</pre>
+        </div>
+      </Fragment>
     );
   }
 
@@ -119,18 +152,21 @@ export const EnrichedMarkdownText = ({
   const lastIdx = children.length - 1;
 
   return (
-    <div style={wrapperStyle} dir={dir} {...rest}>
-      {children.map((child, index) => (
-        <RenderNode
-          key={`${child.type}-${index}`}
-          node={child}
-          style={index === lastIdx ? lastChildStyle : normalizedStyle}
-          styles={index === lastIdx ? lastChildStyles : styles}
-          callbacks={callbacks}
-          capabilities={capabilities}
-        />
-      ))}
-    </div>
+    <Fragment>
+      {selectionStyle}
+      <div data-enriched-markdown-text style={wrapperStyle} dir={dir} {...rest}>
+        {children.map((child, index) => (
+          <RenderNode
+            key={`${child.type}-${index}`}
+            node={child}
+            style={index === lastIdx ? lastChildStyle : normalizedStyle}
+            styles={index === lastIdx ? lastChildStyles : styles}
+            callbacks={callbacks}
+            capabilities={capabilities}
+          />
+        ))}
+      </div>
+    </Fragment>
   );
 };
 

--- a/src/web/EnrichedMarkdownText.tsx
+++ b/src/web/EnrichedMarkdownText.tsx
@@ -18,6 +18,7 @@ import type { ASTNode, RendererCallbacks, RenderCapabilities } from './types';
 import { indexTaskItems, markInlineImages } from './utils';
 import { loadKaTeX } from './katex';
 import type { KaTeXInstance } from './katex';
+import { normalizeColor } from '../styleUtils';
 
 export const EnrichedMarkdownText = ({
   markdown,
@@ -103,10 +104,9 @@ export const EnrichedMarkdownText = ({
   );
 
   const wrapperStyle = useMemo<CSSProperties>(() => {
-    const selectionBgVar =
-      selectionColor != null && selectionColor !== undefined
-        ? String(selectionColor)
-        : undefined;
+    const selectionBgVar = selectionColor
+      ? normalizeColor(String(selectionColor))
+      : undefined;
 
     return {
       display: 'flex',
@@ -119,12 +119,11 @@ export const EnrichedMarkdownText = ({
     };
   }, [containerStyle, selectable, selectionColor]);
 
-  const selectionStyle =
-    selectionColor != null && selectionColor !== undefined ? (
-      <style>{`[data-enriched-markdown-text] ::selection {
+  const selectionStyle = selectionColor ? (
+    <style>{`[data-enriched-markdown-text] ::selection {
     background-color: var(--enrm-selection-bg);
     }`}</style>
-    ) : null;
+  ) : null;
 
   if (parseError) {
     return (


### PR DESCRIPTION
### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->

Add support for custom selection color to the `<EnrichedMarkdownText />` component. Added 2 props: `selectionColor` and `selectionHandleColor`. See React Native doc:
https://reactnative.dev/docs/textinput#selectioncolor and https://reactnative.dev/docs/textinput#selectioncolor for more detail


### Testing
<!-- How to test changed code? What testing has been done? -->

Test with selecting text in both ios and android.

#### Screenshots 

| iOS | Android | web
| - | - | - |
| <img width="606" height="1166" alt="ios custom selection color" src="https://github.com/user-attachments/assets/98e545e0-a7f6-4ef0-bccf-aa2a1c5fc6e7" /> | <img width="578" height="1084" alt="android custom selection color" src="https://github.com/user-attachments/assets/df869635-ad8f-4ee5-99ed-9aab7631345a" /> | <img width="1392" height="1522" alt="web custom selection color" src="https://github.com/user-attachments/assets/1e9b3a88-4622-41a4-ba19-12fc6e1fc774" />


<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes

