### PR TITLE
refactor: rename EnrichedMarkdownInput to EnrichedMarkdownTextInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - 🗣️ Accessibility support (VoiceOver on iOS, TalkBack on Android, semantic HTML on web)
 - 🔄 Full RTL (right-to-left) support including text, lists, blockquotes, tables, and task lists
 
-### EnrichedMarkdownInput
+### EnrichedMarkdownTextInput
 
 - ✏️ Rich text input with Markdown output
 - 🕹️ Imperative API for toggling styles and managing links
@@ -51,14 +51,14 @@ We can help you build your next dream product –
   - [LaTeX Math](docs/LATEX_MATH.md)
   - [Image Caching](docs/IMAGE_CACHING.md)
   - [Markdown Streaming](docs/MARKDOWN_STREAMING.md)
-- [EnrichedMarkdownInput](#enrichedmarkdowninput-1)
+- [EnrichedMarkdownTextInput](#enrichedmarkdowntextinput-1)
   - [Usage](docs/INPUT.md#usage)
   - [Inline Styles](docs/INPUT.md#inline-styles)
   - [Links](docs/INPUT.md#links)
   - [Auto-Link Detection](docs/INPUT.md#auto-link-detection)
   - [Style Detection](docs/INPUT.md#style-detection)
   - [Other Events](docs/INPUT.md#other-events)
-  - [Customizing Styles](docs/INPUT.md#customizing-enrichedmarkdowninput--styles)
+  - [Customizing Styles](docs/INPUT.md#customizing-enrichedmarkdowntextinput--styles)
 - [API Reference](#api-reference)
 - [Web Support](docs/WEB.md)
 - [macOS Support](docs/MACOS.md)
@@ -78,7 +78,7 @@ We can help you build your next dream product –
 
 - Requires [`react-native-web`](https://necolas.github.io/react-native-web/) and Metro (or another bundler with `.web.tsx` platform resolution)
 - No New Architecture requirement — the web renderer runs entirely in JavaScript via WebAssembly
-- Only `EnrichedMarkdownText` is supported on web (`EnrichedMarkdownInput` is native-only)
+- Only `EnrichedMarkdownText` is supported on web (`EnrichedMarkdownTextInput` is native-only)
 - LaTeX math requires the optional [`katex`](https://katex.org/) peer dependency
 
 ## Installation
@@ -157,9 +157,9 @@ npx expo prebuild
 
 See [EnrichedMarkdownText](docs/TEXT.md) for detailed documentation on usage examples, GFM tables, task lists, link handling, supported elements, copy options, accessibility, RTL support, and customizing styles.
 
-## EnrichedMarkdownInput
+## EnrichedMarkdownTextInput
 
-See [EnrichedMarkdownInput](docs/INPUT.md) for detailed documentation on usage examples, inline styles, links, style detection, events, and customizing styles.
+See [EnrichedMarkdownTextInput](docs/INPUT.md) for detailed documentation on usage examples, inline styles, links, style detection, events, and customizing styles.
 
 ## API Reference
 
@@ -177,8 +177,8 @@ See [Web Support](docs/WEB.md) for details on supported features, web-specific p
 
 We're actively working on expanding the capabilities of `react-native-enriched-markdown`. Here's what's on the roadmap:
 
-- `EnrichedMarkdownInput`: headings, lists, blockquotes, code blocks, mentions, inline images
-- `EnrichedMarkdownInput` web support
+- `EnrichedMarkdownTextInput`: headings, lists, blockquotes, code blocks, mentions, inline images
+- `EnrichedMarkdownTextInput` web support
 - macOS: block math rendering, VoiceOver accessibility, tail fade-in animation
 - Web: spoiler text, streaming animation, configurable link `target`, copy options (Copy as Markdown, multi-format clipboard)
 

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextPackage.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextPackage.kt
@@ -4,7 +4,7 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
-import com.swmansion.enriched.markdown.input.EnrichedMarkdownInputManager
+import com.swmansion.enriched.markdown.input.EnrichedMarkdownTextInputManager
 import java.util.ArrayList
 
 class EnrichedMarkdownTextPackage : ReactPackage {
@@ -12,7 +12,7 @@ class EnrichedMarkdownTextPackage : ReactPackage {
     val viewManagers: MutableList<ViewManager<*, *>> = ArrayList()
     viewManagers.add(EnrichedMarkdownTextManager())
     viewManagers.add(EnrichedMarkdownManager())
-    viewManagers.add(EnrichedMarkdownInputManager())
+    viewManagers.add(EnrichedMarkdownTextInputManager())
     return viewManagers
   }
 

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
@@ -11,8 +11,8 @@ import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
-import com.facebook.react.viewmanagers.EnrichedMarkdownInputManagerDelegate
-import com.facebook.react.viewmanagers.EnrichedMarkdownInputManagerInterface
+import com.facebook.react.viewmanagers.EnrichedMarkdownTextInputManagerDelegate
+import com.facebook.react.viewmanagers.EnrichedMarkdownTextInputManagerInterface
 import com.facebook.yoga.YogaMeasureMode
 import com.swmansion.enriched.markdown.input.autolink.LinkRegexConfig
 import com.swmansion.enriched.markdown.input.events.OnCaretRectChangeEvent
@@ -31,21 +31,22 @@ import com.swmansion.enriched.markdown.input.model.StyleType
 import com.swmansion.enriched.markdown.utils.input.BorderPropsApplicator
 import com.swmansion.enriched.markdown.utils.input.MarkdownStyleParser
 
-@ReactModule(name = EnrichedMarkdownInputManager.NAME)
-class EnrichedMarkdownInputManager :
-  SimpleViewManager<EnrichedMarkdownInputView>(),
-  EnrichedMarkdownInputManagerInterface<EnrichedMarkdownInputView> {
-  private val delegate: ViewManagerDelegate<EnrichedMarkdownInputView> =
-    EnrichedMarkdownInputManagerDelegate(this)
+@ReactModule(name = EnrichedMarkdownTextInputManager.NAME)
+class EnrichedMarkdownTextInputManager :
+  SimpleViewManager<EnrichedMarkdownTextInputView>(),
+  EnrichedMarkdownTextInputManagerInterface<EnrichedMarkdownTextInputView> {
+  private val delegate: ViewManagerDelegate<EnrichedMarkdownTextInputView> =
+    EnrichedMarkdownTextInputManagerDelegate(this)
 
-  override fun getDelegate(): ViewManagerDelegate<EnrichedMarkdownInputView> = delegate
+  override fun getDelegate(): ViewManagerDelegate<EnrichedMarkdownTextInputView> = delegate
 
   override fun getName(): String = NAME
 
-  override fun createViewInstance(reactContext: ThemedReactContext): EnrichedMarkdownInputView = EnrichedMarkdownInputView(reactContext)
+  override fun createViewInstance(reactContext: ThemedReactContext): EnrichedMarkdownTextInputView =
+    EnrichedMarkdownTextInputView(reactContext)
 
   override fun updateState(
-    view: EnrichedMarkdownInputView,
+    view: EnrichedMarkdownTextInputView,
     props: ReactStylesDiffMap?,
     stateWrapper: StateWrapper?,
   ): Any? {
@@ -53,12 +54,12 @@ class EnrichedMarkdownInputManager :
     return super.updateState(view, props, stateWrapper)
   }
 
-  override fun onAfterUpdateTransaction(view: EnrichedMarkdownInputView) {
+  override fun onAfterUpdateTransaction(view: EnrichedMarkdownTextInputView) {
     super.onAfterUpdateTransaction(view)
     view.afterUpdateTransaction()
   }
 
-  override fun onDropViewInstance(view: EnrichedMarkdownInputView) {
+  override fun onDropViewInstance(view: EnrichedMarkdownTextInputView) {
     super.onDropViewInstance(view)
     view.layoutManager.release()
   }
@@ -97,7 +98,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "defaultValue")
   override fun setDefaultValue(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: String?,
   ) {
     if (value != null && view?.text?.isEmpty() == true) {
@@ -107,7 +108,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "placeholder")
   override fun setPlaceholder(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: String?,
   ) {
     view?.hint = value
@@ -115,7 +116,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "placeholderTextColor", customType = "Color")
   override fun setPlaceholderTextColor(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: Int?,
   ) {
     view?.setHintTextColor(value ?: Color.GRAY)
@@ -123,7 +124,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "editable", defaultBoolean = true)
   override fun setEditable(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: Boolean,
   ) {
     view?.isEnabled = value
@@ -131,7 +132,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "autoFocus", defaultBoolean = false)
   override fun setAutoFocus(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: Boolean,
   ) {
     view?.autoFocusRequested = value
@@ -139,7 +140,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "scrollEnabled", defaultBoolean = true)
   override fun setScrollEnabled(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: Boolean,
   ) {
     view?.scrollEnabled = value
@@ -148,7 +149,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "autoCapitalize")
   override fun setAutoCapitalize(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: String?,
   ) {
     view?.setAutoCapitalize(value)
@@ -156,7 +157,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "multiline", defaultBoolean = true)
   override fun setMultiline(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: Boolean,
   ) {
     view?.isSingleLine = !value
@@ -164,7 +165,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "cursorColor", customType = "Color")
   override fun setCursorColor(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: Int?,
   ) {
     view?.setCursorColorFromProps(value)
@@ -172,7 +173,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "selectionColor", customType = "Color")
   override fun setSelectionColor(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: Int?,
   ) {
     if (value != null) {
@@ -182,7 +183,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "markdownStyle")
   override fun setMarkdownStyle(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: ReadableMap?,
   ) {
     if (view == null || value == null) return
@@ -197,7 +198,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "color", customType = "Color")
   override fun setColor(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: Int?,
   ) {
     view?.setColorFromProps(value)
@@ -205,7 +206,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "fontSize", defaultFloat = 16f)
   override fun setFontSize(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: Float,
   ) {
     view?.setFontSizeFromProps(value)
@@ -213,7 +214,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "lineHeight", defaultFloat = 0f)
   override fun setLineHeight(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: Float,
   ) {
     if (value > 0 && view != null) {
@@ -223,7 +224,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "fontFamily")
   override fun setFontFamily(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: String?,
   ) {
     view?.setFontFamily(value)
@@ -231,7 +232,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "fontWeight")
   override fun setFontWeight(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: String?,
   ) {
     view?.setFontWeight(value)
@@ -239,7 +240,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "isOnChangeMarkdownSet", defaultBoolean = false)
   override fun setIsOnChangeMarkdownSet(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: Boolean,
   ) {
     view?.emitMarkdown = value
@@ -247,7 +248,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "contextMenuItems")
   override fun setContextMenuItems(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: ReadableArray?,
   ) {
     if (view == null) return
@@ -257,7 +258,7 @@ class EnrichedMarkdownInputManager :
 
   @ReactProp(name = "linkRegex")
   override fun setLinkRegex(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     value: ReadableMap?,
   ) {
     if (view == null) return
@@ -277,7 +278,7 @@ class EnrichedMarkdownInputManager :
   }
 
   override fun updateProperties(
-    view: EnrichedMarkdownInputView,
+    view: EnrichedMarkdownTextInputView,
     props: ReactStylesDiffMap,
   ) {
     BorderPropsApplicator.apply(view, props)
@@ -285,7 +286,7 @@ class EnrichedMarkdownInputManager :
   }
 
   override fun setPadding(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     left: Int,
     top: Int,
     right: Int,
@@ -297,16 +298,16 @@ class EnrichedMarkdownInputManager :
 
   // Commands
 
-  override fun focus(view: EnrichedMarkdownInputView?) {
+  override fun focus(view: EnrichedMarkdownTextInputView?) {
     view?.requestFocusProgrammatically()
   }
 
-  override fun blur(view: EnrichedMarkdownInputView?) {
+  override fun blur(view: EnrichedMarkdownTextInputView?) {
     view?.clearFocus()
   }
 
   override fun setValue(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     markdown: String?,
   ) {
     if (markdown != null) {
@@ -315,7 +316,7 @@ class EnrichedMarkdownInputManager :
   }
 
   override fun setSelection(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     start: Int,
     end: Int,
   ) {
@@ -325,28 +326,28 @@ class EnrichedMarkdownInputManager :
     view?.setSelection(clampedStart, clampedEnd)
   }
 
-  override fun toggleBold(view: EnrichedMarkdownInputView?) {
+  override fun toggleBold(view: EnrichedMarkdownTextInputView?) {
     view?.toggleInlineStyle(StyleType.BOLD)
   }
 
-  override fun toggleItalic(view: EnrichedMarkdownInputView?) {
+  override fun toggleItalic(view: EnrichedMarkdownTextInputView?) {
     view?.toggleInlineStyle(StyleType.ITALIC)
   }
 
-  override fun toggleUnderline(view: EnrichedMarkdownInputView?) {
+  override fun toggleUnderline(view: EnrichedMarkdownTextInputView?) {
     view?.toggleInlineStyle(StyleType.UNDERLINE)
   }
 
-  override fun toggleStrikethrough(view: EnrichedMarkdownInputView?) {
+  override fun toggleStrikethrough(view: EnrichedMarkdownTextInputView?) {
     view?.toggleInlineStyle(StyleType.STRIKETHROUGH)
   }
 
-  override fun toggleSpoiler(view: EnrichedMarkdownInputView?) {
+  override fun toggleSpoiler(view: EnrichedMarkdownTextInputView?) {
     view?.toggleInlineStyle(StyleType.SPOILER)
   }
 
   override fun setLink(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     url: String?,
   ) {
     if (url != null) {
@@ -355,7 +356,7 @@ class EnrichedMarkdownInputManager :
   }
 
   override fun insertLink(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     text: String?,
     url: String?,
   ) {
@@ -364,25 +365,25 @@ class EnrichedMarkdownInputManager :
     }
   }
 
-  override fun removeLink(view: EnrichedMarkdownInputView?) {
+  override fun removeLink(view: EnrichedMarkdownTextInputView?) {
     view?.removeLinkAtCursor()
   }
 
   override fun requestMarkdown(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     requestId: Int,
   ) {
     view?.eventEmitter?.emitRequestMarkdownResult(requestId)
   }
 
   override fun requestCaretRect(
-    view: EnrichedMarkdownInputView?,
+    view: EnrichedMarkdownTextInputView?,
     requestId: Int,
   ) {
     view?.eventEmitter?.emitRequestCaretRectResult(requestId)
   }
 
   companion object {
-    const val NAME = "EnrichedMarkdownInput"
+    const val NAME = "EnrichedMarkdownTextInput"
   }
 }

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -38,7 +38,7 @@ import com.swmansion.enriched.markdown.input.toolbar.InputContextMenu
 import com.swmansion.enriched.markdown.utils.input.AutoCapitalizeUtils
 import kotlin.math.ceil
 
-class EnrichedMarkdownInputView(
+class EnrichedMarkdownTextInputView(
   context: Context,
 ) : AppCompatEditText(context) {
   private var isComponentReady = false

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/editing/InputConnectionWrapper.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/editing/InputConnectionWrapper.kt
@@ -2,12 +2,12 @@ package com.swmansion.enriched.markdown.input.editing
 
 import android.view.KeyEvent
 import android.view.inputmethod.InputConnection
-import com.swmansion.enriched.markdown.input.EnrichedMarkdownInputView
+import com.swmansion.enriched.markdown.input.EnrichedMarkdownTextInputView
 import android.view.inputmethod.InputConnectionWrapper as AndroidInputConnectionWrapper
 
 class InputConnectionWrapper(
   target: InputConnection,
-  private val editText: EnrichedMarkdownInputView,
+  private val editText: EnrichedMarkdownTextInputView,
 ) : AndroidInputConnectionWrapper(target, false) {
   var isBatchEdit = false
     private set

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/editing/MarkdownEditableFactory.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/editing/MarkdownEditableFactory.kt
@@ -2,10 +2,10 @@ package com.swmansion.enriched.markdown.input.editing
 
 import android.text.Editable
 import android.text.SpannableStringBuilder
-import com.swmansion.enriched.markdown.input.EnrichedMarkdownInputView
+import com.swmansion.enriched.markdown.input.EnrichedMarkdownTextInputView
 
 class MarkdownEditableFactory(
-  private val view: EnrichedMarkdownInputView,
+  private val view: EnrichedMarkdownTextInputView,
 ) : Editable.Factory() {
   override fun newEditable(source: CharSequence): Editable {
     val builder = (source as? SpannableStringBuilder) ?: SpannableStringBuilder(source)

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/editing/MarkdownTextWatcher.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/editing/MarkdownTextWatcher.kt
@@ -2,10 +2,10 @@ package com.swmansion.enriched.markdown.input.editing
 
 import android.text.Editable
 import android.text.TextWatcher
-import com.swmansion.enriched.markdown.input.EnrichedMarkdownInputView
+import com.swmansion.enriched.markdown.input.EnrichedMarkdownTextInputView
 
 class MarkdownTextWatcher(
-  private val view: EnrichedMarkdownInputView,
+  private val view: EnrichedMarkdownTextInputView,
 ) : TextWatcher {
   private var editStart = 0
   private var deletedLength = 0

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
@@ -3,7 +3,7 @@ package com.swmansion.enriched.markdown.input.layout
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
-import com.swmansion.enriched.markdown.input.EnrichedMarkdownInputView
+import com.swmansion.enriched.markdown.input.EnrichedMarkdownTextInputView
 import com.swmansion.enriched.markdown.input.events.OnCaretRectChangeEvent
 import com.swmansion.enriched.markdown.input.events.OnChangeMarkdownEvent
 import com.swmansion.enriched.markdown.input.events.OnChangeSelectionEvent
@@ -20,7 +20,7 @@ import com.swmansion.enriched.markdown.input.model.CaretRect
 import com.swmansion.enriched.markdown.input.model.StyleType
 
 class InputEventEmitter(
-  private val view: EnrichedMarkdownInputView,
+  private val view: EnrichedMarkdownTextInputView,
 ) {
   private var prevState: Map<StyleType, Boolean> = emptyMap()
   private var prevCaretRect: CaretRect? = null

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputLayoutManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputLayoutManager.kt
@@ -1,10 +1,10 @@
 package com.swmansion.enriched.markdown.input.layout
 
 import com.facebook.react.bridge.Arguments
-import com.swmansion.enriched.markdown.input.EnrichedMarkdownInputView
+import com.swmansion.enriched.markdown.input.EnrichedMarkdownTextInputView
 
 class InputLayoutManager(
-  private val view: EnrichedMarkdownInputView,
+  private val view: EnrichedMarkdownTextInputView,
 ) {
   private var forceHeightRecalculationCounter = 0
 

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/toolbar/InputContextMenu.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/toolbar/InputContextMenu.kt
@@ -9,7 +9,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
-import com.swmansion.enriched.markdown.input.EnrichedMarkdownInputView
+import com.swmansion.enriched.markdown.input.EnrichedMarkdownTextInputView
 import com.swmansion.enriched.markdown.input.formatting.MarkdownSerializer
 import com.swmansion.enriched.markdown.input.model.FormattingRange
 import com.swmansion.enriched.markdown.input.model.StyleType
@@ -17,7 +17,7 @@ import com.swmansion.enriched.markdown.input.model.StyleType
 // TODO: Wrap all user-facing strings for localization support.
 
 class InputContextMenu(
-  private val view: EnrichedMarkdownInputView,
+  private val view: EnrichedMarkdownTextInputView,
 ) {
   private var customItemTexts: List<String> = emptyList()
 

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/ComponentDescriptors.h
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/ComponentDescriptors.h
@@ -44,9 +44,9 @@ private:
   const std::shared_ptr<MarkdownTextMeasurementManager> measurementsManager_;
 };
 
-class EnrichedMarkdownInputComponentDescriptor final : public ConcreteComponentDescriptor<MarkdownInputShadowNode> {
+class EnrichedMarkdownTextInputComponentDescriptor final : public ConcreteComponentDescriptor<MarkdownInputShadowNode> {
 public:
-  EnrichedMarkdownInputComponentDescriptor(const ComponentDescriptorParameters &parameters)
+  EnrichedMarkdownTextInputComponentDescriptor(const ComponentDescriptorParameters &parameters)
       : ConcreteComponentDescriptor(parameters),
         measurementsManager_(std::make_shared<MarkdownInputMeasurementManager>(contextContainer_)) {}
 

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownInputMeasurementManager.cpp
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownInputMeasurementManager.cpp
@@ -9,7 +9,8 @@ using namespace facebook::jni;
 
 namespace facebook::react {
 
-Size MarkdownInputMeasurementManager::measure(SurfaceId surfaceId, int viewTag, const EnrichedMarkdownInputProps &props,
+Size MarkdownInputMeasurementManager::measure(SurfaceId surfaceId, int viewTag,
+                                              const EnrichedMarkdownTextInputProps &props,
                                               LayoutConstraints layoutConstraints) const {
   const jni::global_ref<jobject> &fabricUIManager = contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
 
@@ -21,7 +22,7 @@ Size MarkdownInputMeasurementManager::measure(SurfaceId surfaceId, int viewTag, 
   auto minimumSize = layoutConstraints.minimumSize;
   auto maximumSize = layoutConstraints.maximumSize;
 
-  local_ref<JString> componentName = make_jstring("EnrichedMarkdownInput");
+  local_ref<JString> componentName = make_jstring("EnrichedMarkdownTextInput");
 
   folly::dynamic extraData = folly::dynamic::object();
   extraData["viewTag"] = viewTag;

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownInputMeasurementManager.h
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownInputMeasurementManager.h
@@ -11,7 +11,7 @@ public:
   MarkdownInputMeasurementManager(const std::shared_ptr<const ContextContainer> &contextContainer)
       : contextContainer_(contextContainer) {}
 
-  Size measure(SurfaceId surfaceId, int viewTag, const EnrichedMarkdownInputProps &props,
+  Size measure(SurfaceId surfaceId, int viewTag, const EnrichedMarkdownTextInputProps &props,
                LayoutConstraints layoutConstraints) const;
 
 private:

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownInputShadowNode.cpp
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownInputShadowNode.cpp
@@ -4,7 +4,7 @@
 
 namespace facebook::react {
 
-extern const char MarkdownInputComponentName[] = "EnrichedMarkdownInput";
+extern const char MarkdownInputComponentName[] = "EnrichedMarkdownTextInput";
 
 void MarkdownInputShadowNode::setMeasurementsManager(
     const std::shared_ptr<MarkdownInputMeasurementManager> &measurementsManager) {

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownInputShadowNode.h
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownInputShadowNode.h
@@ -12,8 +12,8 @@ namespace facebook::react {
 JSI_EXPORT extern const char MarkdownInputComponentName[];
 
 class MarkdownInputShadowNode final
-    : public ConcreteViewShadowNode<MarkdownInputComponentName, EnrichedMarkdownInputProps,
-                                    EnrichedMarkdownInputEventEmitter, MarkdownInputState> {
+    : public ConcreteViewShadowNode<MarkdownInputComponentName, EnrichedMarkdownTextInputProps,
+                                    EnrichedMarkdownTextInputEventEmitter, MarkdownInputState> {
 public:
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
@@ -27,7 +27,7 @@ inline folly::dynamic toDynamic(const EnrichedMarkdownProps &props) {
   return serializedProps;
 }
 
-inline folly::dynamic toDynamic(const EnrichedMarkdownInputProps &props) {
+inline folly::dynamic toDynamic(const EnrichedMarkdownTextInputProps &props) {
   folly::dynamic serializedProps = folly::dynamic::object();
   serializedProps["defaultValue"] = props.defaultValue;
   serializedProps["placeholder"] = props.placeholder;

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -2117,7 +2117,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
-  hermes-engine: 40811a005e96e04818cff405ec04a5b4c4411c1c
+  hermes-engine: b0f9c82a51be8e938eb979ada628323e1e093f1d
   iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
   RCTDeprecation: af44b104091a34482596cd9bd7e8d90c4e9b4bd7
   RCTRequired: bb77b070f75f53398ce43c0aaaa58337cebe2bf6
@@ -2127,7 +2127,7 @@ SPEC CHECKSUMS:
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
   React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
-  React-Core-prebuilt: 7965d06a81dcc544164f8e98b26d35ae2a4eb36e
+  React-Core-prebuilt: 3dc04e91547fc0f260f4b84c12da0f672b813862
   React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
   React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
   React-debug: 755200a6e7f5e6e0a40ff8d215493d43cce285fc
@@ -2189,7 +2189,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
   ReactCodegen: 797de5178718324c6eba3327b07f9a423fbd5787
   ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
-  ReactNativeDependencies: 0811b43c669e637a9f3c485fdb106f187fa88398
+  ReactNativeDependencies: 44f7326a697de7f6c8629036b1a4689f0e64c684
   ReactNativeEnrichedMarkdown: 1daba1851810704ba2f5c6e5fff638a94661e317
   Yoga: c0b3f2c7e8d3e327e450223a2414ca3fa296b9a2
 

--- a/apps/example/src/InputScreen.tsx
+++ b/apps/example/src/InputScreen.tsx
@@ -11,9 +11,9 @@ import {
 } from 'react-native';
 import type { HostInstance } from 'react-native';
 import {
-  EnrichedMarkdownInput,
+  EnrichedMarkdownTextInput,
   EnrichedMarkdownText,
-  type EnrichedMarkdownInputInstance,
+  type EnrichedMarkdownTextInputInstance,
   type StyleState,
 } from 'react-native-enriched-markdown';
 import { LinkModal } from './LinkModal';
@@ -69,7 +69,7 @@ const MARKDOWN_STYLE = {
 let nextId = 6;
 
 export default function InputScreen() {
-  const inputRef = useRef<EnrichedMarkdownInputInstance>(null);
+  const inputRef = useRef<EnrichedMarkdownTextInputInstance>(null);
   const scrollRef = useRef<React.ElementRef<typeof ScrollView>>(null);
   const [state, setState] = useState<StyleState | null>(null);
   const [messages, setMessages] = useState<Message[]>(INITIAL_MESSAGES);
@@ -302,7 +302,7 @@ export default function InputScreen() {
           </TouchableOpacity>
         </View>
         <View style={styles.inputRow}>
-          <EnrichedMarkdownInput
+          <EnrichedMarkdownTextInput
             ref={inputRef}
             placeholder="Message..."
             placeholderTextColor="#9CA3AF"

--- a/apps/macos-example/src/InputScreen.tsx
+++ b/apps/macos-example/src/InputScreen.tsx
@@ -8,9 +8,9 @@ import {
   Alert,
 } from 'react-native-macos';
 import {
-  EnrichedMarkdownInput,
+  EnrichedMarkdownTextInput,
   EnrichedMarkdownText,
-  type EnrichedMarkdownInputInstance,
+  type EnrichedMarkdownTextInputInstance,
   type StyleState,
 } from 'react-native-enriched-markdown';
 
@@ -58,7 +58,7 @@ const MARKDOWN_STYLE = {
 let nextId = 5;
 
 export default function InputScreen() {
-  const inputRef = useRef<EnrichedMarkdownInputInstance>(null);
+  const inputRef = useRef<EnrichedMarkdownTextInputInstance>(null);
   const scrollRef = useRef<ScrollView>(null);
   const [state, setState] = useState<StyleState | null>(null);
   const [messages, setMessages] = useState<Message[]>(INITIAL_MESSAGES);
@@ -267,7 +267,7 @@ export default function InputScreen() {
 
         {/* Input row */}
         <View style={styles.inputRow}>
-          <EnrichedMarkdownInput
+          <EnrichedMarkdownTextInput
             ref={inputRef}
             placeholder="Message..."
             placeholderTextColor="#9CA3AF"

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -249,7 +249,7 @@ interface ContextMenuItem {
 
 ---
 
-## EnrichedMarkdownInput
+## EnrichedMarkdownTextInput
 
 ### Props
 
@@ -339,7 +339,7 @@ Style configuration for formatted text in the input.
 
 | Type                 | Default Value | Platform |
 | -------------------- | ------------- | -------- |
-| `MarkdownInputStyle` | `{}`          | Both     |
+| `MarkdownTextInputStyle` | `{}`          | Both     |
 
 **Properties:**
 
@@ -429,7 +429,7 @@ All values are in density-independent pixels, relative to the input's top-left c
 **Example:**
 
 ```tsx
-<EnrichedMarkdownInput
+<EnrichedMarkdownTextInput
   scrollEnabled={false}
   onCaretRectChange={(rect) => {
     console.log('Caret at:', rect.x, rect.y);
@@ -499,7 +499,7 @@ interface ContextMenuItem {
 **Example:**
 
 ```tsx
-<EnrichedMarkdownInput
+<EnrichedMarkdownTextInput
   contextMenuItems={[
     {
       text: 'Summarize with AI',

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -1,6 +1,6 @@
-# EnrichedMarkdownInput
+# EnrichedMarkdownTextInput
 
-`EnrichedMarkdownInput` is a rich text input component that outputs Markdown. It is an uncontrolled input — it doesn't use any state or props to store its value, but instead directly interacts with the underlying platform-specific components. Thanks to this, the component is really performant and simple to use.
+`EnrichedMarkdownTextInput` is a rich text input component that outputs Markdown. It is an uncontrolled input — it doesn't use any state or props to store its value, but instead directly interacts with the underlying platform-specific components. Thanks to this, the component is really performant and simple to use.
 
 ## Usage
 
@@ -10,18 +10,18 @@ Here's a simple example of an input that lets you toggle bold on its text and sh
 import { useRef, useState } from 'react';
 import { View, Button, StyleSheet } from 'react-native';
 import {
-  EnrichedMarkdownInput,
-  type EnrichedMarkdownInputInstance,
+  EnrichedMarkdownTextInput,
+  type EnrichedMarkdownTextInputInstance,
   type StyleState,
 } from 'react-native-enriched-markdown';
 
 export default function App() {
-  const ref = useRef<EnrichedMarkdownInputInstance>(null);
+  const ref = useRef<EnrichedMarkdownTextInputInstance>(null);
   const [state, setState] = useState<StyleState | null>(null);
 
   return (
     <View style={styles.container}>
-      <EnrichedMarkdownInput
+      <EnrichedMarkdownTextInput
         ref={ref}
         placeholder="Type here..."
         onChangeState={setState}
@@ -47,7 +47,7 @@ const styles = StyleSheet.create({
 
 Summary of what happens here:
 
-1. Any methods imperatively called on the input to e.g. toggle some style must be used through a `ref` of `EnrichedMarkdownInputInstance` type. Here, `toggleBold` method that is called on the button press calls `ref.current?.toggleBold()`, which toggles the bold styling within the current selection.
+1. Any methods imperatively called on the input to e.g. toggle some style must be used through a `ref` of `EnrichedMarkdownTextInputInstance` type. Here, `toggleBold` method that is called on the button press calls `ref.current?.toggleBold()`, which toggles the bold styling within the current selection.
 2. All style state information is emitted by the `onChangeState` callback. The callback payload provides a nested object for each style (e.g., `bold`, `italic`), containing an `isActive` property to guide your UI logic — indicating if the style is currently applied (highlight the button).
 
 ## Inline Styles
@@ -80,7 +80,7 @@ A complete example of a setup that supports both setting links on the selected t
 
 ## Auto-Link Detection
 
-`EnrichedMarkdownInput` can automatically detect URLs as the user types and convert them into Markdown links. Detected links are visually styled in the input and serialized as `[text](url)` in the Markdown output.
+`EnrichedMarkdownTextInput` can automatically detect URLs as the user types and convert them into Markdown links. Detected links are visually styled in the input and serialized as `[text](url)` in the Markdown output.
 
 ### Basic usage
 
@@ -93,7 +93,7 @@ Bare domains and `www.` prefixes are automatically normalized with `https://` (e
 You can provide a custom regex pattern to control which text is detected as a link:
 
 ```tsx
-<EnrichedMarkdownInput
+<EnrichedMarkdownTextInput
   linkRegex={/https?:\/\/[^\s]+/i}
 />
 ```
@@ -101,7 +101,7 @@ You can provide a custom regex pattern to control which text is detected as a li
 Pass `null` to disable auto-link detection entirely:
 
 ```tsx
-<EnrichedMarkdownInput linkRegex={null} />
+<EnrichedMarkdownTextInput linkRegex={null} />
 ```
 
 ### Listening for detections
@@ -109,7 +109,7 @@ Pass `null` to disable auto-link detection entirely:
 Use the `onLinkDetected` callback to be notified when a new link is detected:
 
 ```tsx
-<EnrichedMarkdownInput
+<EnrichedMarkdownTextInput
   onLinkDetected={({ text, url, start, end }) => {
     console.log(`Detected link: ${text} -> ${url} at [${start}, ${end}]`);
   }}
@@ -124,14 +124,14 @@ When a manual link is applied (via `setLink` or `insertLink`) over an auto-detec
 
 ## Caret Position Tracking
 
-`EnrichedMarkdownInput` can report the caret's pixel position relative to the input, which is useful when the input is embedded in a scrollable container with `scrollEnabled={false}` and you need to keep the caret visible.
+`EnrichedMarkdownTextInput` can report the caret's pixel position relative to the input, which is useful when the input is embedded in a scrollable container with `scrollEnabled={false}` and you need to keep the caret visible.
 
 ### `onCaretRectChange`
 
 A push-based callback that fires whenever the caret moves (typing, selection change, content reflow). The native side diffs the caret rect before emitting, so redundant events are suppressed automatically.
 
 ```tsx
-<EnrichedMarkdownInput
+<EnrichedMarkdownTextInput
   scrollEnabled={false}
   onCaretRectChange={(rect) => {
     console.log(rect);
@@ -155,7 +155,7 @@ You can find some examples in the [usage section](#usage) or in the example app.
 
 ## Other Events
 
-`EnrichedMarkdownInput` emits a few more events that may be of use:
+`EnrichedMarkdownTextInput` emits a few more events that may be of use:
 
 - [onFocus](API_REFERENCE.md#onfocus-1) - emits whenever input focuses.
 - [onBlur](API_REFERENCE.md#onblur) - emits whenever input blurs.
@@ -163,12 +163,12 @@ You can find some examples in the [usage section](#usage) or in the example app.
 - [onChangeMarkdown](API_REFERENCE.md#onchangemarkdown) - returns the Markdown string parsed from current input text and styles anytime it would change. As parsing the Markdown on each input change can be expensive, not assigning the event's callback will skip the serialization for better performance.
 - [onChangeSelection](API_REFERENCE.md#onchangeselection) - returns `{ start, end }` of the current selection, useful for working with [links](#links).
 
-## Customizing \<EnrichedMarkdownInput /> Styles
+## Customizing \<EnrichedMarkdownTextInput /> Styles
 
-`EnrichedMarkdownInput` accepts a `markdownStyle` prop for customizing how formatted text appears in the input:
+`EnrichedMarkdownTextInput` accepts a `markdownStyle` prop for customizing how formatted text appears in the input:
 
 ```tsx
-<EnrichedMarkdownInput
+<EnrichedMarkdownTextInput
   markdownStyle={{
     strong: { color: '#1D4ED8' },
     em: { color: '#7C3AED' },

--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -2,7 +2,7 @@
 
 `react-native-enriched-markdown` supports macOS via [react-native-macos](https://github.com/microsoft/react-native-macos). The native layer shares code with iOS through a platform abstraction header (`ENRMUIKit.h`), with macOS-specific implementations for context menus, text selection, and clipboard handling.
 
-The macOS implementation supports the same rendering elements as iOS — CommonMark, GitHub Flavored Markdown (tables, task lists, strikethrough), inline math, images, code blocks, blockquotes, and all other supported elements. `EnrichedMarkdownInput` is also available on macOS with full support for inline styles, links, and the native context menu.
+The macOS implementation supports the same rendering elements as iOS — CommonMark, GitHub Flavored Markdown (tables, task lists, strikethrough), inline math, images, code blocks, blockquotes, and all other supported elements. `EnrichedMarkdownTextInput` is also available on macOS with full support for inline styles, links, and the native context menu.
 
 ## Known limitations
 

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -42,5 +42,5 @@ The web implementation also exports `WebMarkdownTextProps` which extends `Enrich
 
 ## Not supported on web
 
-- `EnrichedMarkdownInput` — native-only
+- `EnrichedMarkdownTextInput` — native-only
 - Configurable link `target` — all links open in a new tab (`target="_blank"`). Use `onLinkPress` for custom navigation.

--- a/ios/input/ENRMInputTextView.h
+++ b/ios/input/ENRMInputTextView.h
@@ -2,12 +2,12 @@
 
 #import "ENRMUIKit.h"
 
-@class EnrichedMarkdownInput;
+@class EnrichedMarkdownTextInput;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ENRMInputTextView : ENRMPlatformTextView
-@property (nonatomic, weak, nullable) EnrichedMarkdownInput *markdownInput;
+@property (nonatomic, weak, nullable) EnrichedMarkdownTextInput *markdownInput;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/input/ENRMInputTextView.mm
+++ b/ios/input/ENRMInputTextView.mm
@@ -1,7 +1,7 @@
 #import "ENRMInputTextView.h"
-#import "EnrichedMarkdownInput.h"
+#import "EnrichedMarkdownTextInput.h"
 #if TARGET_OS_OSX
-#import "EnrichedMarkdownInput+Internal.h"
+#import "EnrichedMarkdownTextInput+Internal.h"
 #endif
 
 static NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-markdown.markdown";

--- a/ios/input/ENRMLinkRegexConfig.mm
+++ b/ios/input/ENRMLinkRegexConfig.mm
@@ -37,7 +37,7 @@
                                                                              error:&error];
     if (error) {
       RCTLogWarn(
-          @"[EnrichedMarkdownInput]: Couldn't parse the user-defined link regex '%@', "
+          @"[EnrichedMarkdownTextInput]: Couldn't parse the user-defined link regex '%@', "
            "falling back to default regex.",
           _pattern);
     } else {

--- a/ios/input/EnrichedMarkdownTextInput+ContextMenu.mm
+++ b/ios/input/EnrichedMarkdownTextInput+ContextMenu.mm
@@ -1,11 +1,11 @@
 #import "ContextMenuUtils.h"
 #import "ENRMUIKit.h"
-#import "EnrichedMarkdownInput+Internal.h"
+#import "EnrichedMarkdownTextInput+Internal.h"
 #import "PasteboardUtils.h"
 
 // TODO: Wrap all user-facing strings with NSLocalizedString for localization support.
 
-@implementation EnrichedMarkdownInput (ContextMenu)
+@implementation EnrichedMarkdownTextInput (ContextMenu)
 
 - (void)copySelectedRangeAsMarkdown
 {
@@ -25,7 +25,7 @@
     return nil;
   }
 
-  __weak EnrichedMarkdownInput *weakSelf = self;
+  __weak EnrichedMarkdownTextInput *weakSelf = self;
 
   static const struct {
     NSString *title;
@@ -104,7 +104,7 @@
     return menu;
   }
 
-  __weak EnrichedMarkdownInput *weakSelf = self;
+  __weak EnrichedMarkdownTextInput *weakSelf = self;
   NSArray<NSMenuItem *> *customItems =
       ENRMBuildContextMenuItems([self contextMenuItemTexts], [self contextMenuItemIcons], textView,
                                 ^(NSString *itemText, NSString *_, NSUInteger __, NSUInteger ___) {

--- a/ios/input/EnrichedMarkdownTextInput+Internal.h
+++ b/ios/input/EnrichedMarkdownTextInput+Internal.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #import "ENRMInputStyledRange.h"
-#import "EnrichedMarkdownInput.h"
+#import "EnrichedMarkdownTextInput.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EnrichedMarkdownInput (Internal)
+@interface EnrichedMarkdownTextInput (Internal)
 
 - (void)toggleBold;
 - (void)toggleItalic;

--- a/ios/input/EnrichedMarkdownTextInput.h
+++ b/ios/input/EnrichedMarkdownTextInput.h
@@ -1,12 +1,12 @@
 #import "ENRMUIKit.h"
 #import <React/RCTViewComponentView.h>
 
-#ifndef EnrichedMarkdownInput_h
-#define EnrichedMarkdownInput_h
+#ifndef EnrichedMarkdownTextInput_h
+#define EnrichedMarkdownTextInput_h
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EnrichedMarkdownInput : RCTViewComponentView
+@interface EnrichedMarkdownTextInput : RCTViewComponentView
 @property (nonatomic, assign) BOOL blockEmitting;
 - (CGSize)measureSize:(CGFloat)maxWidth;
 - (nullable NSString *)markdownForSelectedRange;

--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -1,4 +1,4 @@
-#import "EnrichedMarkdownInput.h"
+#import "EnrichedMarkdownTextInput.h"
 #import "ContextMenuUtils.h"
 #import "ENRMAutoLinkDetector.h"
 #import "ENRMDetectorPipeline.h"
@@ -19,12 +19,12 @@
 #import <React/RCTBackedTextInputDelegate.h>
 #endif
 
-#import <ReactNativeEnrichedMarkdown/EnrichedMarkdownInputComponentDescriptor.h>
+#import <ReactNativeEnrichedMarkdown/EnrichedMarkdownTextInputComponentDescriptor.h>
 #import <ReactNativeEnrichedMarkdown/EventEmitters.h>
 #import <ReactNativeEnrichedMarkdown/Props.h>
 #import <ReactNativeEnrichedMarkdown/RCTComponentViewHelpers.h>
 
-#import "EnrichedMarkdownInputShadowNode.h"
+#import "EnrichedMarkdownTextInputShadowNode.h"
 #import "RCTFabricComponentsPlugins.h"
 #import <React/RCTConversions.h>
 #import <react/utils/ManagedObjectWrapper.h>
@@ -32,9 +32,9 @@
 using namespace facebook::react;
 
 #if !TARGET_OS_OSX
-@interface EnrichedMarkdownInput () <RCTEnrichedMarkdownInputViewProtocol, UITextViewDelegate>
+@interface EnrichedMarkdownTextInput () <RCTEnrichedMarkdownTextInputViewProtocol, UITextViewDelegate>
 #else
-@interface EnrichedMarkdownInput () <RCTEnrichedMarkdownInputViewProtocol, RCTBackedTextInputDelegate>
+@interface EnrichedMarkdownTextInput () <RCTEnrichedMarkdownTextInputViewProtocol, RCTBackedTextInputDelegate>
 #endif
 - (void)setupTextView;
 - (void)applyFormatting;
@@ -43,10 +43,10 @@ using namespace facebook::react;
 - (void)replaceSelectedTextWith:(NSString *)text formattingRanges:(NSArray<ENRMFormattingRange *> *)ranges;
 @end
 
-@implementation EnrichedMarkdownInput {
+@implementation EnrichedMarkdownTextInput {
   ENRMPlatformTextView *_textView;
   ENRMInputLayoutManager *_layoutManager;
-  EnrichedMarkdownInputShadowNode::ConcreteState::Shared _state;
+  EnrichedMarkdownTextInputShadowNode::ConcreteState::Shared _state;
   int _heightUpdateCounter;
   ENRMInputFormatter *_formatter;
   ENRMInputFormatterStyle *_formatterStyle;
@@ -84,7 +84,7 @@ using namespace facebook::react;
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return concreteComponentDescriptorProvider<EnrichedMarkdownInputComponentDescriptor>();
+  return concreteComponentDescriptorProvider<EnrichedMarkdownTextInputComponentDescriptor>();
 }
 
 + (BOOL)shouldBeRecycled
@@ -95,7 +95,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const EnrichedMarkdownInputProps>();
+    static const auto defaultProps = std::make_shared<const EnrichedMarkdownTextInputProps>();
     _props = defaultProps;
 
     self.backgroundColor = [RCTUIColor clearColor];
@@ -122,7 +122,7 @@ using namespace facebook::react;
                                                         formattingStore:_formattingStore
                                                                   style:_formatterStyle];
 
-  __weak EnrichedMarkdownInput *weakSelf = self;
+  __weak EnrichedMarkdownTextInput *weakSelf = self;
   _autoLinkDetector.onLinkDetected = ^(NSString *text, NSString *url, NSRange range) {
     [weakSelf emitOnLinkDetectedWithText:text url:url range:range];
   };
@@ -191,7 +191,7 @@ using namespace facebook::react;
 - (void)updateState:(const facebook::react::State::Shared &)state
            oldState:(const facebook::react::State::Shared &)oldState
 {
-  _state = std::static_pointer_cast<const EnrichedMarkdownInputShadowNode::ConcreteState>(state);
+  _state = std::static_pointer_cast<const EnrichedMarkdownTextInputShadowNode::ConcreteState>(state);
 
   if (oldState == nullptr) {
     [self requestHeightUpdate];
@@ -206,7 +206,7 @@ using namespace facebook::react;
 
   _heightUpdateCounter++;
   auto selfRef = wrapManagedObjectWeakly(self);
-  _state->updateState(EnrichedMarkdownInputState(_heightUpdateCounter, selfRef));
+  _state->updateState(EnrichedMarkdownTextInputState(_heightUpdateCounter, selfRef));
 }
 
 #pragma mark - Measurement
@@ -245,8 +245,8 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &oldViewProps = *std::static_pointer_cast<EnrichedMarkdownInputProps const>(_props);
-  const auto &newViewProps = *std::static_pointer_cast<EnrichedMarkdownInputProps const>(props);
+  const auto &oldViewProps = *std::static_pointer_cast<EnrichedMarkdownTextInputProps const>(_props);
+  const auto &newViewProps = *std::static_pointer_cast<EnrichedMarkdownTextInputProps const>(props);
 
   if (newViewProps.editable != oldViewProps.editable) {
     _textView.editable = newViewProps.editable;
@@ -385,7 +385,7 @@ using namespace facebook::react;
     [self updatePlaceholderVisibility];
     [self requestHeightUpdate];
 
-    const auto &viewProps = *std::static_pointer_cast<EnrichedMarkdownInputProps const>(_props);
+    const auto &viewProps = *std::static_pointer_cast<EnrichedMarkdownTextInputProps const>(_props);
     if (viewProps.autoFocus) {
       ENRMFocusTextView(_textView);
     }
@@ -715,7 +715,7 @@ using namespace facebook::react;
   ENRMFormattingRange *activeLink = [_formattingStore rangeOfType:ENRMInputStyleTypeLink containingPosition:cursor];
   NSString *existingURL = activeLink != nil ? activeLink.url : nil;
 
-  __weak EnrichedMarkdownInput *weakSelf = self;
+  __weak EnrichedMarkdownTextInput *weakSelf = self;
   ENRMShowLinkPrompt(self, existingURL, ^(NSString *url) { [weakSelf setLink:url]; });
 }
 
@@ -803,7 +803,7 @@ using namespace facebook::react;
 
 - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args
 {
-  RCTEnrichedMarkdownInputHandleCommand(self, commandName, args);
+  RCTEnrichedMarkdownTextInputHandleCommand(self, commandName, args);
 }
 
 #pragma mark - Style state query
@@ -831,12 +831,12 @@ using namespace facebook::react;
   }
 }
 
-- (std::shared_ptr<EnrichedMarkdownInputEventEmitter const>)getEventEmitter
+- (std::shared_ptr<EnrichedMarkdownTextInputEventEmitter const>)getEventEmitter
 {
   if (_eventEmitter == nullptr || _blockEmitting) {
     return nullptr;
   }
-  return std::static_pointer_cast<EnrichedMarkdownInputEventEmitter const>(_eventEmitter);
+  return std::static_pointer_cast<EnrichedMarkdownTextInputEventEmitter const>(_eventEmitter);
 }
 
 - (NSArray<ENRMFormattingRange *> *)allRangesIncludingTransient
@@ -1343,7 +1343,7 @@ using namespace facebook::react;
 
 @end
 
-Class<RCTComponentViewProtocol> EnrichedMarkdownInputCls(void)
+Class<RCTComponentViewProtocol> EnrichedMarkdownTextInputCls(void)
 {
-  return EnrichedMarkdownInput.class;
+  return EnrichedMarkdownTextInput.class;
 }

--- a/ios/input/internals/EnrichedMarkdownTextInputComponentDescriptor.h
+++ b/ios/input/internals/EnrichedMarkdownTextInputComponentDescriptor.h
@@ -1,17 +1,17 @@
 #pragma once
-#include "EnrichedMarkdownInputShadowNode.h"
+#include "EnrichedMarkdownTextInputShadowNode.h"
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
 namespace facebook::react {
 
-class EnrichedMarkdownInputComponentDescriptor final
-    : public ConcreteComponentDescriptor<EnrichedMarkdownInputShadowNode> {
+class EnrichedMarkdownTextInputComponentDescriptor final
+    : public ConcreteComponentDescriptor<EnrichedMarkdownTextInputShadowNode> {
 public:
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
   void adopt(ShadowNode &shadowNode) const override {
-    react_native_assert(dynamic_cast<EnrichedMarkdownInputShadowNode *>(&shadowNode));
+    react_native_assert(dynamic_cast<EnrichedMarkdownTextInputShadowNode *>(&shadowNode));
     ConcreteComponentDescriptor::adopt(shadowNode);
   }
 };

--- a/ios/input/internals/EnrichedMarkdownTextInputShadowNode.h
+++ b/ios/input/internals/EnrichedMarkdownTextInputShadowNode.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "EnrichedMarkdownInputState.h"
+#include "EnrichedMarkdownTextInputState.h"
 #include <ReactNativeEnrichedMarkdown/EventEmitters.h>
 #include <ReactNativeEnrichedMarkdown/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
@@ -7,18 +7,18 @@
 
 namespace facebook::react {
 
-JSI_EXPORT extern const char EnrichedMarkdownInputComponentName[];
+JSI_EXPORT extern const char EnrichedMarkdownTextInputComponentName[];
 
-class EnrichedMarkdownInputShadowNode
-    : public ConcreteViewShadowNode<EnrichedMarkdownInputComponentName, EnrichedMarkdownInputProps,
-                                    EnrichedMarkdownInputEventEmitter, EnrichedMarkdownInputState> {
+class EnrichedMarkdownTextInputShadowNode
+    : public ConcreteViewShadowNode<EnrichedMarkdownTextInputComponentName, EnrichedMarkdownTextInputProps,
+                                    EnrichedMarkdownTextInputEventEmitter, EnrichedMarkdownTextInputState> {
 public:
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
-  EnrichedMarkdownInputShadowNode(const ShadowNodeFragment &fragment, const ShadowNodeFamily::Shared &family,
-                                  ShadowNodeTraits traits);
+  EnrichedMarkdownTextInputShadowNode(const ShadowNodeFragment &fragment, const ShadowNodeFamily::Shared &family,
+                                      ShadowNodeTraits traits);
 
-  EnrichedMarkdownInputShadowNode(const ShadowNode &sourceShadowNode, const ShadowNodeFragment &fragment);
+  EnrichedMarkdownTextInputShadowNode(const ShadowNode &sourceShadowNode, const ShadowNodeFragment &fragment);
 
   void dirtyLayoutIfNeeded();
 

--- a/ios/input/internals/EnrichedMarkdownTextInputShadowNode.mm
+++ b/ios/input/internals/EnrichedMarkdownTextInputShadowNode.mm
@@ -1,27 +1,27 @@
-#import "EnrichedMarkdownInputShadowNode.h"
-#import "EnrichedMarkdownInput.h"
+#import "EnrichedMarkdownTextInputShadowNode.h"
+#import "EnrichedMarkdownTextInput.h"
 #import <react/utils/ManagedObjectWrapper.h>
 #import <yoga/Yoga.h>
 
 namespace facebook::react {
 
-extern const char EnrichedMarkdownInputComponentName[] = "EnrichedMarkdownInput";
+extern const char EnrichedMarkdownTextInputComponentName[] = "EnrichedMarkdownTextInput";
 
-EnrichedMarkdownInputShadowNode::EnrichedMarkdownInputShadowNode(const ShadowNodeFragment &fragment,
-                                                                 const ShadowNodeFamily::Shared &family,
-                                                                 ShadowNodeTraits traits)
+EnrichedMarkdownTextInputShadowNode::EnrichedMarkdownTextInputShadowNode(const ShadowNodeFragment &fragment,
+                                                                         const ShadowNodeFamily::Shared &family,
+                                                                         ShadowNodeTraits traits)
     : ConcreteViewShadowNode(fragment, family, traits)
 {
 }
 
-EnrichedMarkdownInputShadowNode::EnrichedMarkdownInputShadowNode(const ShadowNode &sourceShadowNode,
-                                                                 const ShadowNodeFragment &fragment)
+EnrichedMarkdownTextInputShadowNode::EnrichedMarkdownTextInputShadowNode(const ShadowNode &sourceShadowNode,
+                                                                         const ShadowNodeFragment &fragment)
     : ConcreteViewShadowNode(sourceShadowNode, fragment)
 {
   dirtyLayoutIfNeeded();
 }
 
-void EnrichedMarkdownInputShadowNode::dirtyLayoutIfNeeded()
+void EnrichedMarkdownTextInputShadowNode::dirtyLayoutIfNeeded()
 {
   const auto state = this->getStateData();
   const int receivedCounter = state.getHeightRecalculationCounter();
@@ -32,9 +32,10 @@ void EnrichedMarkdownInputShadowNode::dirtyLayoutIfNeeded()
   }
 }
 
-id EnrichedMarkdownInputShadowNode::setupMockInputView_(CGFloat width) const
+id EnrichedMarkdownTextInputShadowNode::setupMockInputView_(CGFloat width) const
 {
-  EnrichedMarkdownInput *mockView = [[EnrichedMarkdownInput alloc] initWithFrame:CGRectMake(20000, 20000, width, 1000)];
+  EnrichedMarkdownTextInput *mockView =
+      [[EnrichedMarkdownTextInput alloc] initWithFrame:CGRectMake(20000, 20000, width, 1000)];
 
   mockView.blockEmitting = YES;
 
@@ -44,14 +45,14 @@ id EnrichedMarkdownInputShadowNode::setupMockInputView_(CGFloat width) const
   return mockView;
 }
 
-Size EnrichedMarkdownInputShadowNode::measureContent(const LayoutContext &layoutContext,
-                                                     const LayoutConstraints &layoutConstraints) const
+Size EnrichedMarkdownTextInputShadowNode::measureContent(const LayoutContext &layoutContext,
+                                                         const LayoutConstraints &layoutConstraints) const
 {
   CGFloat maxWidth = layoutConstraints.maximumSize.width;
 
   RCTInternalGenericWeakWrapper *weakWrapper =
       (RCTInternalGenericWeakWrapper *)unwrapManagedObject(getStateData().getComponentViewRef());
-  EnrichedMarkdownInput *view = weakWrapper ? (EnrichedMarkdownInput *)weakWrapper.object : nil;
+  EnrichedMarkdownTextInput *view = weakWrapper ? (EnrichedMarkdownTextInput *)weakWrapper.object : nil;
 
   __block CGSize size;
 
@@ -59,7 +60,7 @@ Size EnrichedMarkdownInputShadowNode::measureContent(const LayoutContext &layout
     if (view) {
       size = [view measureSize:maxWidth];
     } else {
-      EnrichedMarkdownInput *mockView = setupMockInputView_(maxWidth);
+      EnrichedMarkdownTextInput *mockView = setupMockInputView_(maxWidth);
       size = [mockView measureSize:maxWidth];
     }
   };

--- a/ios/input/internals/EnrichedMarkdownTextInputState.h
+++ b/ios/input/internals/EnrichedMarkdownTextInputState.h
@@ -3,10 +3,10 @@
 
 namespace facebook::react {
 
-class EnrichedMarkdownInputState {
+class EnrichedMarkdownTextInputState {
 public:
-  EnrichedMarkdownInputState() = default;
-  EnrichedMarkdownInputState(int counter, std::shared_ptr<void> ref) : counter_(counter), viewRef_(ref) {}
+  EnrichedMarkdownTextInputState() = default;
+  EnrichedMarkdownTextInputState(int counter, std::shared_ptr<void> ref) : counter_(counter), viewRef_(ref) {}
 
   int getHeightRecalculationCounter() const {
     return counter_;

--- a/package.json
+++ b/package.json
@@ -193,8 +193,8 @@
         "EnrichedMarkdown": {
           "className": "EnrichedMarkdown"
         },
-        "EnrichedMarkdownInput": {
-          "className": "EnrichedMarkdownInput"
+        "EnrichedMarkdownTextInput": {
+          "className": "EnrichedMarkdownTextInput"
         }
       }
     },

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -9,7 +9,7 @@ module.exports = {
         componentDescriptors: [
           'EnrichedMarkdownTextComponentDescriptor',
           'EnrichedMarkdownComponentDescriptor',
-          'EnrichedMarkdownInputComponentDescriptor',
+          'EnrichedMarkdownTextInputComponentDescriptor',
         ],
       },
     },

--- a/src/EnrichedMarkdownTextInput.tsx
+++ b/src/EnrichedMarkdownTextInput.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
 } from 'react';
 import type React from 'react';
-import EnrichedMarkdownInputNativeComponent, {
+import EnrichedMarkdownTextInputNativeComponent, {
   Commands,
   type NativeProps,
   type OnChangeTextEvent,
@@ -18,8 +18,8 @@ import EnrichedMarkdownInputNativeComponent, {
   type OnCaretRectChangeEvent,
   type OnContextMenuItemPressEvent,
   type OnLinkDetected,
-} from './EnrichedMarkdownInputNativeComponent';
-export type { OnLinkDetected } from './EnrichedMarkdownInputNativeComponent';
+} from './EnrichedMarkdownTextInputNativeComponent';
+export type { OnLinkDetected } from './EnrichedMarkdownTextInputNativeComponent';
 import type {
   HostInstance,
   NativeSyntheticEvent,
@@ -27,13 +27,13 @@ import type {
   TextStyle,
   ColorValue,
 } from 'react-native';
-import { normalizeMarkdownInputStyle } from './normalizeMarkdownInputStyle';
+import { normalizeMarkdownTextInputStyle } from './normalizeMarkdownTextInputStyle';
 import { toNativeRegexConfig } from './utils/regexParser';
 import type { RefObject } from 'react';
 
 type NativeRef = HostInstance;
 
-export interface MarkdownInputStyle {
+export interface MarkdownTextInputStyle {
   strong?: {
     color?: string;
   };
@@ -77,7 +77,7 @@ export interface CaretRect {
   height: number;
 }
 
-export interface EnrichedMarkdownInputInstance {
+export interface EnrichedMarkdownTextInputInstance {
   focus: () => void;
   blur: () => void;
   measure: HostInstance['measure'];
@@ -97,8 +97,8 @@ export interface EnrichedMarkdownInputInstance {
   getCaretRect: () => Promise<CaretRect>;
 }
 
-export interface EnrichedMarkdownInputProps {
-  ref?: RefObject<EnrichedMarkdownInputInstance | null>;
+export interface EnrichedMarkdownTextInputProps {
+  ref?: RefObject<EnrichedMarkdownTextInputInstance | null>;
   defaultValue?: string;
   placeholder?: string;
   placeholderTextColor?: ColorValue;
@@ -109,7 +109,7 @@ export interface EnrichedMarkdownInputProps {
   multiline?: boolean;
   cursorColor?: ColorValue;
   selectionColor?: ColorValue;
-  markdownStyle?: MarkdownInputStyle;
+  markdownStyle?: MarkdownTextInputStyle;
   style?: ViewStyle | TextStyle;
   onChangeText?: (text: string) => void;
   onChangeMarkdown?: (markdown: string) => void;
@@ -131,13 +131,13 @@ type PendingRequest<T> = {
 function getNativeRef(ref: React.RefObject<NativeRef | null>): NativeRef {
   if (ref.current == null) {
     throw new Error(
-      'EnrichedMarkdownInput: native ref is not attached. Ensure the component is mounted.'
+      'EnrichedMarkdownTextInput: native ref is not attached. Ensure the component is mounted.'
     );
   }
   return ref.current;
 }
 
-export const EnrichedMarkdownInput = ({
+export const EnrichedMarkdownTextInput = ({
   ref,
   markdownStyle,
   style,
@@ -161,7 +161,7 @@ export const EnrichedMarkdownInput = ({
   onBlur,
   contextMenuItems,
   linkRegex: _linkRegex,
-}: EnrichedMarkdownInputProps) => {
+}: EnrichedMarkdownTextInputProps) => {
   const nativeRef = useRef<NativeRef | null>(null);
 
   const nextRequestId = useRef(1);
@@ -204,7 +204,7 @@ export const EnrichedMarkdownInput = ({
     };
   }, []);
 
-  const normalizedStyle = normalizeMarkdownInputStyle(markdownStyle);
+  const normalizedStyle = normalizeMarkdownTextInputStyle(markdownStyle);
 
   const linkRegex = useMemo(
     () => toNativeRegexConfig(_linkRegex),
@@ -358,7 +358,7 @@ export const EnrichedMarkdownInput = ({
   });
 
   return (
-    <EnrichedMarkdownInputNativeComponent
+    <EnrichedMarkdownTextInputNativeComponent
       ref={nativeRef}
       style={style}
       markdownStyle={normalizedStyle}
@@ -400,4 +400,4 @@ export const EnrichedMarkdownInput = ({
   );
 };
 
-export default EnrichedMarkdownInput;
+export default EnrichedMarkdownTextInput;

--- a/src/EnrichedMarkdownTextInputNativeComponent.ts
+++ b/src/EnrichedMarkdownTextInputNativeComponent.ts
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import type React from 'react';
 
-interface MarkdownInputStyleInternal {
+interface MarkdownTextInputStyleInternal {
   strong: {
     color?: ColorValue;
   };
@@ -153,9 +153,9 @@ export interface NativeProps extends ViewProps {
   selectionColor?: ColorValue;
   /**
    * Inline format style overrides.
-   * Always provided with complete defaults via normalizeMarkdownInputStyle.
+   * Always provided with complete defaults via normalizeMarkdownTextInputStyle.
    */
-  markdownStyle: MarkdownInputStyleInternal;
+  markdownStyle: MarkdownTextInputStyleInternal;
 
   // These should not be passed as regular props.
   color?: ColorValue;
@@ -251,6 +251,9 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
   ],
 });
 
-export default codegenNativeComponent<NativeProps>('EnrichedMarkdownInput', {
-  interfaceOnly: true,
-}) as HostComponent<NativeProps>;
+export default codegenNativeComponent<NativeProps>(
+  'EnrichedMarkdownTextInput',
+  {
+    interfaceOnly: true,
+  }
+) as HostComponent<NativeProps>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,13 +11,13 @@ export type {
   TaskListItemPressEvent,
 } from './types/events';
 
-export { EnrichedMarkdownInput } from './EnrichedMarkdownInput';
+export { EnrichedMarkdownTextInput } from './EnrichedMarkdownTextInput';
 export type {
-  EnrichedMarkdownInputProps,
-  EnrichedMarkdownInputInstance,
-  MarkdownInputStyle,
+  EnrichedMarkdownTextInputProps,
+  EnrichedMarkdownTextInputInstance,
+  MarkdownTextInputStyle,
   StyleState,
   ContextMenuItem,
   OnLinkDetected,
   CaretRect,
-} from './EnrichedMarkdownInput';
+} from './EnrichedMarkdownTextInput';

--- a/src/normalizeMarkdownTextInputStyle.ts
+++ b/src/normalizeMarkdownTextInputStyle.ts
@@ -1,8 +1,8 @@
 import { processColor, type ColorValue } from 'react-native';
-import type { MarkdownInputStyle } from './EnrichedMarkdownInput';
+import type { MarkdownTextInputStyle } from './EnrichedMarkdownTextInput';
 import { normalizeColor } from './styleUtils';
 
-interface MarkdownInputStyleInternal {
+interface MarkdownTextInputStyleInternal {
   strong: {
     color?: ColorValue;
   };
@@ -23,7 +23,7 @@ const DEFAULT_LINK_COLOR = '#2563EB';
 const DEFAULT_SPOILER_COLOR = '#374151';
 const DEFAULT_SPOILER_BG_COLOR = '#E5E7EB';
 
-const defaultInternal: MarkdownInputStyleInternal = Object.freeze({
+const defaultInternal: MarkdownTextInputStyleInternal = Object.freeze({
   strong: {
     color: undefined,
   },
@@ -40,12 +40,12 @@ const defaultInternal: MarkdownInputStyleInternal = Object.freeze({
   },
 });
 
-let cachedInput: MarkdownInputStyle | undefined;
-let cachedResult: MarkdownInputStyleInternal | undefined;
+let cachedInput: MarkdownTextInputStyle | undefined;
+let cachedResult: MarkdownTextInputStyleInternal | undefined;
 
-export const normalizeMarkdownInputStyle = (
-  style?: MarkdownInputStyle
-): MarkdownInputStyleInternal => {
+export const normalizeMarkdownTextInputStyle = (
+  style?: MarkdownTextInputStyle
+): MarkdownTextInputStyleInternal => {
   if (!style || Object.keys(style).length === 0) {
     return defaultInternal;
   }
@@ -54,7 +54,7 @@ export const normalizeMarkdownInputStyle = (
     return cachedResult;
   }
 
-  const result: MarkdownInputStyleInternal = {
+  const result: MarkdownTextInputStyleInternal = {
     strong: {
       color: normalizeColor(style.strong?.color),
     },

--- a/src/utils/regexParser.ts
+++ b/src/utils/regexParser.ts
@@ -1,4 +1,4 @@
-import type { LinkNativeRegex } from '../EnrichedMarkdownInputNativeComponent';
+import type { LinkNativeRegex } from '../EnrichedMarkdownTextInputNativeComponent';
 
 const DISABLED_REGEX: LinkNativeRegex = {
   pattern: '',


### PR DESCRIPTION
### What/Why?

Rename `EnrichedMarkdownInput` to `EnrichedMarkdownTextInput` to align with React Native's `TextInput` naming convention. Updates JS/TS exports, native view managers, codegen registrations, ObjC classes, C++ descriptors, example apps, and docs.

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

