### PR TITLE
refactor: rename internal C++/ObjC symbols from MarkdownInput to MarkdownTextInput

### DIFF
--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/ComponentDescriptors.h
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/ComponentDescriptors.h
@@ -2,8 +2,8 @@
 
 #include "MarkdownContainerMeasurementManager.h"
 #include "MarkdownContainerShadowNode.h"
-#include "MarkdownInputMeasurementManager.h"
-#include "MarkdownInputShadowNode.h"
+#include "MarkdownTextInputMeasurementManager.h"
+#include "MarkdownTextInputShadowNode.h"
 #include "MarkdownTextMeasurementManager.h"
 #include "MarkdownTextShadowNode.h"
 
@@ -44,20 +44,21 @@ private:
   const std::shared_ptr<MarkdownTextMeasurementManager> measurementsManager_;
 };
 
-class EnrichedMarkdownTextInputComponentDescriptor final : public ConcreteComponentDescriptor<MarkdownInputShadowNode> {
+class EnrichedMarkdownTextInputComponentDescriptor final
+    : public ConcreteComponentDescriptor<MarkdownTextInputShadowNode> {
 public:
   EnrichedMarkdownTextInputComponentDescriptor(const ComponentDescriptorParameters &parameters)
       : ConcreteComponentDescriptor(parameters),
-        measurementsManager_(std::make_shared<MarkdownInputMeasurementManager>(contextContainer_)) {}
+        measurementsManager_(std::make_shared<MarkdownTextInputMeasurementManager>(contextContainer_)) {}
 
   void adopt(ShadowNode &shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
-    auto &inputShadowNode = static_cast<MarkdownInputShadowNode &>(shadowNode);
+    auto &inputShadowNode = static_cast<MarkdownTextInputShadowNode &>(shadowNode);
     inputShadowNode.setMeasurementsManager(measurementsManager_);
   }
 
 private:
-  const std::shared_ptr<MarkdownInputMeasurementManager> measurementsManager_;
+  const std::shared_ptr<MarkdownTextInputMeasurementManager> measurementsManager_;
 };
 
 void EnrichedMarkdownTextSpec_registerComponentDescriptorsFromCodegen(

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownInputState.cpp
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownInputState.cpp
@@ -1,9 +1,0 @@
-#include "MarkdownInputState.h"
-
-namespace facebook::react {
-
-int MarkdownInputState::getForceHeightRecalculationCounter() const {
-  return forceHeightRecalculationCounter_;
-}
-
-} // namespace facebook::react

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputMeasurementManager.cpp
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputMeasurementManager.cpp
@@ -1,4 +1,4 @@
-#include "MarkdownInputMeasurementManager.h"
+#include "MarkdownTextInputMeasurementManager.h"
 #include "conversions.h"
 
 #include <fbjni/fbjni.h>
@@ -9,9 +9,9 @@ using namespace facebook::jni;
 
 namespace facebook::react {
 
-Size MarkdownInputMeasurementManager::measure(SurfaceId surfaceId, int viewTag,
-                                              const EnrichedMarkdownTextInputProps &props,
-                                              LayoutConstraints layoutConstraints) const {
+Size MarkdownTextInputMeasurementManager::measure(SurfaceId surfaceId, int viewTag,
+                                                  const EnrichedMarkdownTextInputProps &props,
+                                                  LayoutConstraints layoutConstraints) const {
   const jni::global_ref<jobject> &fabricUIManager = contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
 
   static const auto measure =

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputMeasurementManager.h
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputMeasurementManager.h
@@ -6,9 +6,9 @@
 
 namespace facebook::react {
 
-class MarkdownInputMeasurementManager {
+class MarkdownTextInputMeasurementManager {
 public:
-  MarkdownInputMeasurementManager(const std::shared_ptr<const ContextContainer> &contextContainer)
+  MarkdownTextInputMeasurementManager(const std::shared_ptr<const ContextContainer> &contextContainer)
       : contextContainer_(contextContainer) {}
 
   Size measure(SurfaceId surfaceId, int viewTag, const EnrichedMarkdownTextInputProps &props,

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputShadowNode.cpp
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputShadowNode.cpp
@@ -1,18 +1,18 @@
-#include "MarkdownInputShadowNode.h"
+#include "MarkdownTextInputShadowNode.h"
 
 #include <react/renderer/core/LayoutContext.h>
 
 namespace facebook::react {
 
-extern const char MarkdownInputComponentName[] = "EnrichedMarkdownTextInput";
+extern const char MarkdownTextInputComponentName[] = "EnrichedMarkdownTextInput";
 
-void MarkdownInputShadowNode::setMeasurementsManager(
-    const std::shared_ptr<MarkdownInputMeasurementManager> &measurementsManager) {
+void MarkdownTextInputShadowNode::setMeasurementsManager(
+    const std::shared_ptr<MarkdownTextInputMeasurementManager> &measurementsManager) {
   ensureUnsealed();
   measurementsManager_ = measurementsManager;
 }
 
-void MarkdownInputShadowNode::dirtyLayoutIfNeeded() {
+void MarkdownTextInputShadowNode::dirtyLayoutIfNeeded() {
   const auto state = this->getStateData();
   const auto counter = state.getForceHeightRecalculationCounter();
 
@@ -22,8 +22,8 @@ void MarkdownInputShadowNode::dirtyLayoutIfNeeded() {
   }
 }
 
-Size MarkdownInputShadowNode::measureContent(const LayoutContext &layoutContext,
-                                             const LayoutConstraints &layoutConstraints) const {
+Size MarkdownTextInputShadowNode::measureContent(const LayoutContext &layoutContext,
+                                                 const LayoutConstraints &layoutConstraints) const {
   return measurementsManager_->measure(getSurfaceId(), getTag(), getConcreteProps(), layoutConstraints);
 }
 

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputShadowNode.h
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputShadowNode.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "MarkdownInputMeasurementManager.h"
-#include "MarkdownInputState.h"
+#include "MarkdownTextInputMeasurementManager.h"
+#include "MarkdownTextInputState.h"
 
 #include <react/renderer/components/EnrichedMarkdownTextSpec/EventEmitters.h>
 #include <react/renderer/components/EnrichedMarkdownTextSpec/Props.h>
@@ -9,15 +9,15 @@
 
 namespace facebook::react {
 
-JSI_EXPORT extern const char MarkdownInputComponentName[];
+JSI_EXPORT extern const char MarkdownTextInputComponentName[];
 
-class MarkdownInputShadowNode final
-    : public ConcreteViewShadowNode<MarkdownInputComponentName, EnrichedMarkdownTextInputProps,
-                                    EnrichedMarkdownTextInputEventEmitter, MarkdownInputState> {
+class MarkdownTextInputShadowNode final
+    : public ConcreteViewShadowNode<MarkdownTextInputComponentName, EnrichedMarkdownTextInputProps,
+                                    EnrichedMarkdownTextInputEventEmitter, MarkdownTextInputState> {
 public:
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
-  MarkdownInputShadowNode(ShadowNode const &sourceShadowNode, ShadowNodeFragment const &fragment)
+  MarkdownTextInputShadowNode(ShadowNode const &sourceShadowNode, ShadowNodeFragment const &fragment)
       : ConcreteViewShadowNode(sourceShadowNode, fragment) {
     dirtyLayoutIfNeeded();
   }
@@ -29,7 +29,7 @@ public:
     return traits;
   }
 
-  void setMeasurementsManager(const std::shared_ptr<MarkdownInputMeasurementManager> &measurementsManager);
+  void setMeasurementsManager(const std::shared_ptr<MarkdownTextInputMeasurementManager> &measurementsManager);
 
   void dirtyLayoutIfNeeded();
 
@@ -37,7 +37,7 @@ public:
 
 private:
   int forceHeightRecalculationCounter_{0};
-  std::shared_ptr<MarkdownInputMeasurementManager> measurementsManager_;
+  std::shared_ptr<MarkdownTextInputMeasurementManager> measurementsManager_;
 };
 
 } // namespace facebook::react

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputState.cpp
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputState.cpp
@@ -1,0 +1,9 @@
+#include "MarkdownTextInputState.h"
+
+namespace facebook::react {
+
+int MarkdownTextInputState::getForceHeightRecalculationCounter() const {
+  return forceHeightRecalculationCounter_;
+}
+
+} // namespace facebook::react

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputState.h
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/MarkdownTextInputState.h
@@ -4,11 +4,11 @@
 
 namespace facebook::react {
 
-class MarkdownInputState {
+class MarkdownTextInputState {
 public:
-  MarkdownInputState() : forceHeightRecalculationCounter_(0) {}
+  MarkdownTextInputState() : forceHeightRecalculationCounter_(0) {}
 
-  MarkdownInputState(MarkdownInputState const &previousState, folly::dynamic data)
+  MarkdownTextInputState(MarkdownTextInputState const &previousState, folly::dynamic data)
       : forceHeightRecalculationCounter_((int)data["forceHeightRecalculationCounter"].getInt()) {}
 
   folly::dynamic getDynamic() const {

--- a/ios/input/ENRMInputTextView.h
+++ b/ios/input/ENRMInputTextView.h
@@ -7,7 +7,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ENRMInputTextView : ENRMPlatformTextView
-@property (nonatomic, weak, nullable) EnrichedMarkdownTextInput *markdownInput;
+@property (nonatomic, weak, nullable) EnrichedMarkdownTextInput *markdownTextInput;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/input/ENRMInputTextView.mm
+++ b/ios/input/ENRMInputTextView.mm
@@ -20,7 +20,7 @@ static NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-ma
   }
 
   NSString *plainText = [self.text substringWithRange:selection];
-  NSString *markdown = [self.markdownInput markdownForSelectedRange];
+  NSString *markdown = [self.markdownTextInput markdownForSelectedRange];
 
   UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
   NSMutableDictionary *items = [NSMutableDictionary dictionary];
@@ -49,8 +49,8 @@ static NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-ma
     markdown = [[NSString alloc] initWithData:markdownValue encoding:NSUTF8StringEncoding];
   }
 
-  if (markdown.length > 0 && self.markdownInput != nil) {
-    [self.markdownInput pasteMarkdown:markdown];
+  if (markdown.length > 0 && self.markdownTextInput != nil) {
+    [self.markdownTextInput pasteMarkdown:markdown];
     return;
   }
 
@@ -74,8 +74,8 @@ static NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-ma
 - (void)layoutSubviews
 {
   [super layoutSubviews];
-  if (self.markdownInput != nil) {
-    [self.markdownInput scheduleRelayoutIfNeeded];
+  if (self.markdownTextInput != nil) {
+    [self.markdownTextInput scheduleRelayoutIfNeeded];
   }
 }
 
@@ -93,7 +93,7 @@ static NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-ma
   }
 
   NSString *plainText = [self.string substringWithRange:selection];
-  NSString *markdown = [self.markdownInput markdownForSelectedRange];
+  NSString *markdown = [self.markdownTextInput markdownForSelectedRange];
 
   NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
   [pasteboard clearContents];
@@ -121,8 +121,8 @@ static NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-ma
   NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
 
   NSString *markdown = [pasteboard stringForType:kENRMMarkdownPasteboardType];
-  if (markdown.length > 0 && self.markdownInput != nil) {
-    [self.markdownInput pasteMarkdown:markdown];
+  if (markdown.length > 0 && self.markdownTextInput != nil) {
+    [self.markdownTextInput pasteMarkdown:markdown];
     return;
   }
 
@@ -158,8 +158,8 @@ static NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-ma
 - (NSMenu *)menuForEvent:(NSEvent *)event
 {
   NSMenu *menu = [super menuForEvent:event];
-  if (self.markdownInput != nil) {
-    return [self.markdownInput enrichedMenuForEvent:event defaultMenu:menu textView:self];
+  if (self.markdownTextInput != nil) {
+    return [self.markdownTextInput enrichedMenuForEvent:event defaultMenu:menu textView:self];
   }
   return menu;
 }
@@ -167,8 +167,8 @@ static NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-ma
 - (void)layout
 {
   [super layout];
-  if (self.markdownInput != nil) {
-    [self.markdownInput scheduleRelayoutIfNeeded];
+  if (self.markdownTextInput != nil) {
+    [self.markdownTextInput scheduleRelayoutIfNeeded];
   }
 }
 

--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -146,9 +146,9 @@ using namespace facebook::react;
 #else
   ENRMInputTextView *inputTextView = [[ENRMInputTextView alloc] initWithFrame:CGRectZero];
 #endif
-  inputTextView.markdownInput = self;
+  inputTextView.markdownTextInput = self;
   _textView = inputTextView;
-  ENRMConfigureMarkdownInputTextView(_textView);
+  ENRMConfigureMarkdownTextInputTextView(_textView);
 #if !TARGET_OS_OSX
   _textView.adjustsFontForContentSizeCategory = YES;
   _textView.delegate = self;

--- a/ios/utils/ENRMUIKit.h
+++ b/ios/utils/ENRMUIKit.h
@@ -176,7 +176,7 @@ static inline void ENRMSetDefaultTypingAttributes(ENRMPlatformTextView *textView
 /// Applies shared configuration to a text view used for markdown input editing.
 /// Handles platform differences: scroll indicators, text container insets,
 /// drawsBackground (macOS). Sets editable=YES, scrollEnabled=YES.
-static inline void ENRMConfigureMarkdownInputTextView(ENRMPlatformTextView *textView)
+static inline void ENRMConfigureMarkdownTextInputTextView(ENRMPlatformTextView *textView)
 {
   textView.font = [UIFont systemFontOfSize:16.0];
   textView.backgroundColor = [RCTUIColor clearColor];


### PR DESCRIPTION
### What/Why?
Renames internal C++/Objective-C symbols to align with the MarkdownTextInput naming convention established in the public API rename. This covers shadow nodes, measurement managers, state classes, component name constants, and iOS utility functions/properties — ensuring consistent naming across the entire native layer.



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

