### PR TITLE
docs: add dark mode theming guide to STYLES.md and TEXT.md

### DIFF
--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -203,6 +203,59 @@ The library provides sensible default styles for all Markdown elements out of th
 > }), []);
 > ```
 
+## Dark Mode
+
+The library ships with light-mode color defaults. It does not include a `colorScheme` prop — just like React Native's `Text`, theming is left to the consumer.
+
+To support dark mode, create `MarkdownStyle` objects for each color scheme and switch between them using `useColorScheme()`. Your values always win over the defaults — you only need to specify the colors you want to change:
+
+```tsx
+import { useColorScheme } from 'react-native';
+import { EnrichedMarkdownText } from 'react-native-enriched-markdown';
+import type { MarkdownStyle } from 'react-native-enriched-markdown';
+
+const lightMarkdownStyle: MarkdownStyle = {
+  blockquote: { backgroundColor: '#F9FAFB', borderColor: '#D1D5DB' },
+  code: { color: '#E01E5A', backgroundColor: '#FDF2F4' },
+  table: {
+    headerBackgroundColor: '#F3F4F6',
+    rowEvenBackgroundColor: '#FFFFFF',
+    rowOddBackgroundColor: '#F9FAFB',
+  },
+  // ... override any other colors for light mode
+};
+
+const darkMarkdownStyle: MarkdownStyle = {
+  paragraph: { color: '#E5E7EB' },
+  blockquote: { backgroundColor: '#1F2937', borderColor: '#4B5563' },
+  code: { color: '#F87171', backgroundColor: '#1F2937' },
+  table: {
+    headerBackgroundColor: '#1F2937',
+    rowEvenBackgroundColor: '#111827',
+    rowOddBackgroundColor: '#1A1A2E',
+    borderColor: '#374151',
+  },
+  // ... override any other colors for dark mode
+};
+
+function App() {
+  const colorScheme = useColorScheme();
+
+  return (
+    <EnrichedMarkdownText
+      markdown={content}
+      markdownStyle={colorScheme === 'dark' ? darkMarkdownStyle : lightMarkdownStyle}
+    />
+  );
+}
+```
+
+> [!TIP]
+> The palettes above are a starting point. Replace these values with your app's design-system tokens for a consistent look across your UI.
+
+> [!NOTE]
+> **Performance:** Define style objects outside the component (as shown above) or wrap them in `useMemo` so the same object reference is reused across renders.
+
 ## Style Properties Reference
 
 ### Block Styles (paragraph, h1-h6, blockquote, list, codeBlock)

--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -250,9 +250,6 @@ function App() {
 }
 ```
 
-> [!TIP]
-> The palettes above are a starting point. Replace these values with your app's design-system tokens for a consistent look across your UI.
-
 > [!NOTE]
 > **Performance:** Define style objects outside the component (as shown above) or wrap them in `useMemo` so the same object reference is reused across renders.
 

--- a/docs/TEXT.md
+++ b/docs/TEXT.md
@@ -104,3 +104,7 @@ When text is selected, `react-native-enriched-markdown` provides enhanced copy f
 ## Customizing Styles
 
 `react-native-enriched-markdown` allows customizing styles of all Markdown elements using the `markdownStyle` prop. See the [Style Properties Reference](STYLES.md) for a detailed overview of all available style properties.
+
+### Dark Mode
+
+The library uses light-mode defaults. To support dark mode, pass a dark `markdownStyle` object — your values always take priority over the defaults. See the [Dark Mode](STYLES.md#dark-mode) section in the Style Properties Reference for a ready-to-use example with `useColorScheme()`.


### PR DESCRIPTION
### What/Why?
Fixes: #257 

Adds dark mode theming documentation to STYLES.md and TEXT.md. 

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

