### PR TITLE
refactor(ios): centralize selectionColor application into ENRMApplySelectionColor

### DIFF
--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -26,6 +26,7 @@
 #import "MarkdownExtractor.h"
 #import "ParagraphStyleUtils.h"
 #import "RuntimeKeys.h"
+#import "SelectionColorUtils.h"
 #import "StyleConfig.h"
 #import "StylePropsUtils.h"
 #import "TableContainerView.h"
@@ -91,7 +92,6 @@ using namespace facebook::react;
 #endif
 
 @interface EnrichedMarkdown () <RCTEnrichedMarkdownViewProtocol, UITextViewDelegate>
-- (void)applySelectionColor:(const EnrichedMarkdownProps &)props toTextView:(ENRMPlatformTextView *)textView;
 @end
 
 @implementation EnrichedMarkdown {
@@ -496,7 +496,7 @@ using namespace facebook::react;
   [view applyAttributedText:segment.attributedText context:segment.context];
 
   const auto &selectionProps = *std::static_pointer_cast<EnrichedMarkdownProps const>(self->_props);
-  [self applySelectionColor:selectionProps toTextView:view.textView];
+  ENRMApplySelectionColor(view.textView, selectionProps.selectionColor);
 
   ENRMTapRecognizer *tapRecognizer = [[ENRMTapRecognizer alloc] initWithTarget:self action:@selector(textTapped:)];
   [view.textView addGestureRecognizer:tapRecognizer];
@@ -663,14 +663,12 @@ using namespace facebook::react;
   }
 
   if (newViewProps.selectionColor != oldViewProps.selectionColor) {
-#if !TARGET_OS_OSX
     for (RCTUIView *segment in _segmentViews) {
       if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
         ENRMPlatformTextView *tv = ((EnrichedMarkdownInternalText *)segment).textView;
-        [self applySelectionColor:newViewProps toTextView:tv];
+        ENRMApplySelectionColor(tv, newViewProps.selectionColor);
       }
     }
-#endif
   }
 
   if (markdownChanged || stylePropChanged || md4cFlagsChanged || allowTrailingMarginChanged) {
@@ -895,16 +893,5 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
   return [MarkdownAccessibilityElementBuilder buildRotorsFromElements:[self accessibilityElements]];
 }
 #endif
-
-- (void)applySelectionColor:(const EnrichedMarkdownProps &)props toTextView:(ENRMPlatformTextView *)textView
-{
-#if !TARGET_OS_OSX
-  if (isColorMeaningful(props.selectionColor)) {
-    ENRMSetSelectionColor(textView, RCTUIColorFromSharedColor(props.selectionColor));
-  } else {
-    ENRMSetSelectionColor(textView, nil);
-  }
-#endif
-}
 
 @end

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -20,6 +20,7 @@
 #import "MarkdownExtractor.h"
 #import "ParagraphStyleUtils.h"
 #import "RuntimeKeys.h"
+#import "SelectionColorUtils.h"
 #import "StylePropsUtils.h"
 #import "TaskListTapUtils.h"
 
@@ -413,13 +414,7 @@ using namespace facebook::react;
   }
 
   if (newViewProps.selectionColor != oldViewProps.selectionColor) {
-#if !TARGET_OS_OSX
-    if (isColorMeaningful(newViewProps.selectionColor)) {
-      ENRMSetSelectionColor(_textView, RCTUIColorFromSharedColor(newViewProps.selectionColor));
-    } else {
-      ENRMSetSelectionColor(_textView, nil);
-    }
-#endif
+    ENRMApplySelectionColor(_textView, newViewProps.selectionColor);
   }
 
   if (newViewProps.allowFontScaling != oldViewProps.allowFontScaling) {

--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -15,6 +15,7 @@
 #import "ENRMStyleMergingConfig.h"
 #import "ENRMUIKit.h"
 #import "InputStylePropsUtils.h"
+#import "SelectionColorUtils.h"
 #if TARGET_OS_OSX
 #import <React/RCTBackedTextInputDelegate.h>
 #endif
@@ -290,11 +291,7 @@ using namespace facebook::react;
   }
 
   if (newViewProps.selectionColor != oldViewProps.selectionColor) {
-    if (isColorMeaningful(newViewProps.selectionColor)) {
-      ENRMSetSelectionColor(_textView, RCTUIColorFromSharedColor(newViewProps.selectionColor));
-    } else {
-      ENRMSetSelectionColor(_textView, nil);
-    }
+    ENRMApplySelectionColor(_textView, newViewProps.selectionColor);
   }
 
   _emitMarkdown = newViewProps.isOnChangeMarkdownSet;

--- a/ios/utils/SelectionColorUtils.h
+++ b/ios/utils/SelectionColorUtils.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#import "ENRMUIKit.h"
+#import <React/RCTConversions.h>
+
+/// Applies a codegen `selectionColor` to `textView`, falling back to the
+/// system tint when the color is unset. Obj-C++ only — `.mm` consumers only.
+static inline void ENRMApplySelectionColor(ENRMPlatformTextView *textView, const facebook::react::SharedColor &color) {
+  if (isColorMeaningful(color)) {
+    ENRMSetSelectionColor(textView, RCTUIColorFromSharedColor(color));
+  } else {
+    ENRMSetSelectionColor(textView, nil);
+  }
+}


### PR DESCRIPTION
### What/Why?
Centralizes the iOS selectionColor application logic into a single shared helper, removing duplication introduced by #250.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

