### PR TITLE
feat(macos): support selectionColor via NSTextView.selectedTextAttributes

### DIFF
--- a/apps/macos-example/src/App.tsx
+++ b/apps/macos-example/src/App.tsx
@@ -83,6 +83,7 @@ export default function App() {
               onLinkPress={handleLinkPress}
               markdownStyle={markdownStyle}
               contextMenuItems={contextMenuItems}
+              selectionColor="#DCDDFE"
             />
           </ScrollView>
           {lastLink != null && (

--- a/ios/utils/ENRMUIKit.h
+++ b/ios/utils/ENRMUIKit.h
@@ -203,12 +203,16 @@ static inline void ENRMSetCursorColor(ENRMPlatformTextView *textView, RCTUIColor
 #endif
 }
 
-/// Cross-platform selection color: iOS uses tintColor (affects both cursor and selection);
-/// macOS selection highlight is managed by the system and not directly settable.
+/// Cross-platform selection color: iOS uses tintColor (also affects the caret
+/// and selection handles); macOS sets the selection background via
+/// `selectedTextAttributes`. Pass `nil` to restore the system default.
 static inline void ENRMSetSelectionColor(ENRMPlatformTextView *textView, RCTUIColor *color)
 {
 #if !TARGET_OS_OSX
   textView.tintColor = color;
+#else
+  RCTUIColor *resolved = color ?: [NSColor selectedTextBackgroundColor];
+  textView.selectedTextAttributes = @{NSBackgroundColorAttributeName : resolved};
 #endif
 }
 

--- a/src/EnrichedMarkdownNativeComponent.ts
+++ b/src/EnrichedMarkdownNativeComponent.ts
@@ -277,9 +277,10 @@ export interface NativeProps extends ViewProps {
    * Color of the text selection highlight.
    *
    * On iOS, this also affects the caret and selection handle colors
-   * (they share a single tint).
+   * (they share a single tint). On macOS, only the selection background
+   * is affected.
    *
-   * @platform ios, android, web
+   * @platform ios, android, macos, web
    */
   selectionColor?: ColorValue;
   /**

--- a/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/src/EnrichedMarkdownTextNativeComponent.ts
@@ -277,9 +277,10 @@ export interface NativeProps extends ViewProps {
    * Color of the text selection highlight.
    *
    * On iOS, this also affects the caret and selection handle colors
-   * (they share a single tint).
+   * (they share a single tint). On macOS, only the selection background
+   * is affected.
    *
-   * @platform ios, android, web
+   * @platform ios, android, macos, web
    */
   selectionColor?: ColorValue;
   /**

--- a/src/types/MarkdownTextProps.ts
+++ b/src/types/MarkdownTextProps.ts
@@ -95,9 +95,10 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    * Color of the text selection highlight.
    *
    * On iOS, this also affects the caret and selection handle colors
-   * (they share a single tint).
+   * (they share a single tint). On macOS, only the selection background
+   * is affected.
    *
-   * @platform ios, android, web
+   * @platform ios, android, macos, web
    */
   selectionColor?: ColorValue;
   /**


### PR DESCRIPTION
### What/Why?
Extends ENRMSetSelectionColor with an NSTextView.selectedTextAttributes branch so selectionColor is no longer a silent no-op on react-native-macos.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

