### PR TITLE
fix(web): narrow selectionColor type to string

### DIFF
--- a/src/types/MarkdownTextProps.web.ts
+++ b/src/types/MarkdownTextProps.web.ts
@@ -1,4 +1,3 @@
-import type { ColorValue } from 'react-native';
 import type { CSSProperties, HTMLAttributes } from 'react';
 import type { MarkdownStyle, Md4cFlags } from './MarkdownStyle';
 import type {
@@ -70,7 +69,7 @@ export interface EnrichedMarkdownTextProps
    * Color of the text selection highlight.
    * @platform web
    */
-  selectionColor?: ColorValue;
+  selectionColor?: string;
   /**
    * When false (default), removes trailing margin from the last element to
    * eliminate bottom spacing.

--- a/src/web/EnrichedMarkdownText.tsx
+++ b/src/web/EnrichedMarkdownText.tsx
@@ -18,7 +18,6 @@ import type { ASTNode, RendererCallbacks, RenderCapabilities } from './types';
 import { indexTaskItems, markInlineImages } from './utils';
 import { loadKaTeX } from './katex';
 import type { KaTeXInstance } from './katex';
-import { normalizeColor } from '../styleUtils';
 
 export const EnrichedMarkdownText = ({
   markdown,
@@ -103,21 +102,18 @@ export const EnrichedMarkdownText = ({
     [lastChildStyle]
   );
 
-  const wrapperStyle = useMemo<CSSProperties>(() => {
-    const selectionColorCss = selectionColor
-      ? normalizeColor(String(selectionColor))
-      : undefined;
-
-    return {
+  const wrapperStyle = useMemo<CSSProperties>(
+    () => ({
       display: 'flex',
       flexDirection: 'column',
       ...(containerStyle as CSSProperties),
       ...(selectable ? undefined : { userSelect: 'none' }),
-      ...(selectionColorCss != null
-        ? ({ ['--enrm-selection-bg']: selectionColorCss } as CSSProperties)
+      ...(selectionColor
+        ? ({ ['--enrm-selection-bg']: selectionColor } as CSSProperties)
         : null),
-    };
-  }, [containerStyle, selectable, selectionColor]);
+    }),
+    [containerStyle, selectable, selectionColor]
+  );
 
   const selectionStyle = selectionColor ? (
     <style>{`[data-enriched-markdown-text] ::selection {


### PR DESCRIPTION
### What/Why?
Narrows web selectionColor from ColorValue to string — the implementation only handles strings anyway, so processColor/PlatformColor results were silently producing invalid CSS

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

