### PR TITLE
refactor(android): guard selection color setters against no-op writes

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -132,11 +132,13 @@ class EnrichedMarkdown
     }
 
     fun setSelectionColor(color: Int?) {
+      if (selectionColor == color) return
       selectionColor = color
       applySelectionColorsToSegments()
     }
 
     fun setSelectionHandleColor(color: Int?) {
+      if (selectionHandleColor == color) return
       selectionHandleColor = color
       applySelectionColorsToSegments()
     }

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -265,11 +265,13 @@ class EnrichedMarkdownText
     }
 
     fun setSelectionColor(color: Int?) {
+      if (selectionColor == color) return
       selectionColor = color
       applySelectionColors(selectionColor, selectionHandleColor)
     }
 
     fun setSelectionHandleColor(color: Int?) {
+      if (selectionHandleColor == color) return
       selectionHandleColor = color
       applySelectionColors(selectionColor, selectionHandleColor)
     }


### PR DESCRIPTION
### What/Why?
Adds `if (field == newValue) return` guards to `setSelectionColor` / `setSelectionHandleColor` in `EnrichedMarkdown.kt` and `EnrichedMarkdownText.kt` to match the pattern already used by every other setter in those files (`setMd4cFlags`, `setAllowFontScaling`, etc.) and skip a redundant handle-drawable re-tint when the color hasn't changed.


### Testing
<!-- How to test changed code? What testing has been done? -->


<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

