### PR TITLE
feat: add GFM streaming support for tables and block math

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -17,12 +17,15 @@ import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.FeatureFlags
 import com.swmansion.enriched.markdown.utils.common.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.utils.common.RenderedSegment
+import com.swmansion.enriched.markdown.utils.common.SegmentReconciler
+import com.swmansion.enriched.markdown.utils.common.StreamingMarkdownFilter
+import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
 import com.swmansion.enriched.markdown.utils.common.splitASTIntoSegments
+import com.swmansion.enriched.markdown.utils.text.TailFadeInAnimator
 import com.swmansion.enriched.markdown.utils.text.view.applySelectionColors
-import com.swmansion.enriched.markdown.utils.text.view.emitLinkLongPressEvent
-import com.swmansion.enriched.markdown.utils.text.view.emitLinkPressEvent
 import com.swmansion.enriched.markdown.views.BlockSegmentView
 import com.swmansion.enriched.markdown.views.TableContainerView
+import java.util.EnumSet
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -33,12 +36,30 @@ class EnrichedMarkdown
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
   ) : FrameLayout(context, attrs, defStyleAttr) {
+    private enum class DirtyFlag {
+      RECREATE_SEGMENTS,
+      FORCE_HEIGHT,
+    }
+
     private val parser = Parser.shared
     private val mainHandler = Handler(Looper.getMainLooper())
     private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+    private val mathContainerClass: Class<*>? by lazy {
+      try {
+        Class.forName("com.swmansion.enriched.markdown.views.MathContainerView")
+      } catch (_: Exception) {
+        null
+      }
+    }
 
     private var currentRenderId = 0L
     private val segmentViews = mutableListOf<View>()
+    private val segmentSignatures = mutableListOf<Long>()
+    private val dirtyFlags = EnumSet.noneOf(DirtyFlag::class.java)
+    var streamingAnimation: Boolean = false
+
+    var tableStreamingMode: TableStreamingMode = TableStreamingMode.HIDDEN
+    private var renderPending: Boolean = false
 
     var currentMarkdown: String = ""
       private set
@@ -75,7 +96,7 @@ class EnrichedMarkdown
     fun setMarkdownContent(markdown: String) {
       if (currentMarkdown == markdown) return
       currentMarkdown = markdown
-      scheduleRender()
+      renderPending = true
     }
 
     fun setMarkdownStyle(style: ReadableMap?) {
@@ -83,7 +104,17 @@ class EnrichedMarkdown
       val newConfig = style?.let { StyleConfig(it, context, allowFontScaling, maxFontSizeMultiplier) }
       if (markdownStyle == newConfig) return
       markdownStyle = newConfig
-      scheduleRender()
+      dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
+      dirtyFlags += DirtyFlag.FORCE_HEIGHT
+      renderPending = true
+    }
+
+    fun commitProps() {
+      MeasurementStore.updateStreamingTableMode(id, tableStreamingMode)
+      if (renderPending) {
+        renderPending = false
+        scheduleRenderIfNeeded()
+      }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -93,6 +124,8 @@ class EnrichedMarkdown
       if (newFontScale != lastKnownFontScale) {
         lastKnownFontScale = newFontScale
         recreateStyleConfig()
+        dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
+        dirtyFlags += DirtyFlag.FORCE_HEIGHT
         scheduleRenderIfNeeded()
       }
     }
@@ -100,27 +133,33 @@ class EnrichedMarkdown
     fun setMd4cFlags(flags: Md4cFlags) {
       if (md4cFlags == flags) return
       md4cFlags = flags
-      scheduleRenderIfNeeded()
+      renderPending = true
     }
 
     fun setAllowFontScaling(allow: Boolean) {
       if (allowFontScaling == allow) return
       allowFontScaling = allow
       recreateStyleConfig()
-      scheduleRenderIfNeeded()
+      dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
+      dirtyFlags += DirtyFlag.FORCE_HEIGHT
+      renderPending = true
     }
 
     fun setMaxFontSizeMultiplier(multiplier: Float) {
       if (maxFontSizeMultiplier == multiplier) return
       maxFontSizeMultiplier = multiplier
       recreateStyleConfig()
-      scheduleRenderIfNeeded()
+      dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
+      dirtyFlags += DirtyFlag.FORCE_HEIGHT
+      renderPending = true
     }
 
     fun setAllowTrailingMargin(allow: Boolean) {
       if (allowTrailingMargin == allow) return
       allowTrailingMargin = allow
-      scheduleRenderIfNeeded()
+      dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
+      dirtyFlags += DirtyFlag.FORCE_HEIGHT
+      renderPending = true
     }
 
     fun setIsSelectable(value: Boolean) {
@@ -190,14 +229,28 @@ class EnrichedMarkdown
     private fun scheduleRender() {
       val style = markdownStyle ?: return
       val markdown = currentMarkdown.takeIf { it.isNotEmpty() } ?: return
+      val isStreaming = streamingAnimation
+      val tableMode = tableStreamingMode
 
       val renderId = ++currentRenderId
 
       executor.execute {
         try {
+          val renderableMarkdown =
+            if (isStreaming) {
+              StreamingMarkdownFilter.renderableMarkdownForStreaming(markdown, tableMode)
+            } else {
+              markdown
+            }
+
+          if (renderableMarkdown.isEmpty()) {
+            postToMain(renderId) { applyRenderedSegments(emptyList(), style) }
+            return@execute
+          }
+
           val ast =
-            parser.parseMarkdown(markdown, md4cFlags) ?: run {
-              postToMain(renderId) { clearSegments() }
+            parser.parseMarkdown(renderableMarkdown, md4cFlags) ?: run {
+              postToMain(renderId) { applyRenderedSegments(emptyList(), style) }
               return@execute
             }
 
@@ -214,7 +267,7 @@ class EnrichedMarkdown
           postToMain(renderId) { applyRenderedSegments(renderedSegments, style) }
         } catch (e: Exception) {
           Log.e(TAG, "Render failed", e)
-          postToMain(renderId) { clearSegments() }
+          postToMain(renderId) { applyRenderedSegments(emptyList(), style) }
         }
       }
     }
@@ -223,18 +276,130 @@ class EnrichedMarkdown
       renderedSegments: List<RenderedSegment>,
       style: StyleConfig,
     ) {
-      clearSegments()
-      renderedSegments.forEach { segment ->
-        val view =
-          when (segment) {
-            is RenderedSegment.Text -> createTextView(segment)
-            is RenderedSegment.Table -> createTableView(segment, style)
-            is RenderedSegment.Math -> createMathView(segment, style)
-          }
-        segmentViews.add(view)
-        addView(view)
+      val reset = DirtyFlag.RECREATE_SEGMENTS in dirtyFlags
+      val forceHeight = DirtyFlag.FORCE_HEIGHT in dirtyFlags
+      dirtyFlags.clear()
+
+      val result =
+        SegmentReconciler.reconcile(
+          currentViews = segmentViews.toList(),
+          currentSignatures = segmentSignatures.toList(),
+          renderedSegments = renderedSegments,
+          reset = reset,
+          matchesKind = ::viewMatchesSegmentKind,
+          createView = { segment ->
+            val view = createSegmentView(segment, style)
+            animateNewView(view, segment)
+            view
+          },
+          updateView = { view, segment -> updateSegmentView(view, segment) },
+        )
+
+      result.viewsToRemove.forEach { removeView(it) }
+      result.viewsToAttach.forEach { addView(it) }
+
+      segmentViews.clear()
+      segmentViews.addAll(result.views)
+      segmentSignatures.clear()
+      segmentSignatures.addAll(result.signatures)
+
+      val topologyChanged = result.viewsToAttach.isNotEmpty() || result.viewsToRemove.isNotEmpty()
+
+      if (width > 0) {
+        val heightBefore = computeSegmentsTotalHeight()
+        layoutSegments()
+        val heightAfter = computeSegmentsTotalHeight()
+
+        if (forceHeight || topologyChanged || heightBefore != heightAfter) {
+          MeasurementStore.invalidate(id)
+          requestLayout()
+        }
       }
-      layoutSegments()
+    }
+
+    private fun viewMatchesSegmentKind(
+      view: View,
+      segment: RenderedSegment,
+    ): Boolean =
+      when (segment) {
+        is RenderedSegment.Text -> view is EnrichedMarkdownInternalText
+        is RenderedSegment.Table -> view is TableContainerView
+        is RenderedSegment.Math -> isMathContainerView(view)
+      }
+
+    private fun isMathContainerView(view: View): Boolean = mathContainerClass?.isInstance(view) == true
+
+    private fun createSegmentView(
+      segment: RenderedSegment,
+      style: StyleConfig,
+    ): View =
+      when (segment) {
+        is RenderedSegment.Text -> createTextView(segment)
+        is RenderedSegment.Table -> createTableView(segment, style)
+        is RenderedSegment.Math -> createMathView(segment, style)
+      }
+
+    private fun updateSegmentView(
+      view: View,
+      segment: RenderedSegment,
+    ) {
+      when (segment) {
+        is RenderedSegment.Text -> {
+          val textView = view as EnrichedMarkdownInternalText
+          val tailStart = textView.text?.length ?: 0
+          textView.lastElementMarginBottom = segment.lastElementMarginBottom
+          textView.applyStyledText(segment.styledText)
+          segment.imageSpans.forEach { it.registerTextView(textView) }
+          animateTextViewTail(textView, tailStart)
+        }
+
+        is RenderedSegment.Table -> {
+          val tableView = view as TableContainerView
+          val previousRowCount = tableView.rowCount
+          tableView.applyTableNode(segment.node)
+          if (streamingAnimation) {
+            tableView.animateNewRows(previousRowCount, BLOCK_FADE_DURATION_MS)
+          }
+        }
+
+        is RenderedSegment.Math -> {
+          mathContainerClass
+            ?.getMethod("applyLatex", String::class.java)
+            ?.invoke(view, segment.latex)
+        }
+      }
+    }
+
+    private fun animateNewView(
+      view: View,
+      segment: RenderedSegment,
+    ) {
+      if (!streamingAnimation) return
+      when (segment) {
+        is RenderedSegment.Text -> animateTextViewTail(view as EnrichedMarkdownInternalText, 0)
+        is RenderedSegment.Table, is RenderedSegment.Math -> animateBlockViewFadeIn(view)
+      }
+    }
+
+    private fun animateTextViewTail(
+      view: EnrichedMarkdownInternalText,
+      tailStart: Int,
+    ) {
+      if (!streamingAnimation) return
+      val textLength = view.text?.length ?: 0
+      if (textLength <= tailStart) return
+      val animator = TailFadeInAnimator(view)
+      animator.animate(tailStart, textLength)
+    }
+
+    private fun animateBlockViewFadeIn(view: View) {
+      if (!streamingAnimation) return
+      view.alpha = 0f
+      view
+        .animate()
+        .alpha(1f)
+        .setDuration(BLOCK_FADE_DURATION_MS)
+        .start()
     }
 
     private fun createTextView(segment: RenderedSegment.Text) =
@@ -273,18 +438,18 @@ class EnrichedMarkdown
     private fun createMathView(
       segment: RenderedSegment.Math,
       style: StyleConfig,
-    ): android.view.View {
-      if (!FeatureFlags.IS_MATH_ENABLED) return android.view.View(context)
+    ): View {
+      val resolvedClass = mathContainerClass
+      if (!FeatureFlags.IS_MATH_ENABLED || resolvedClass == null) return View(context)
       return try {
-        val mathContainerClass = Class.forName("com.swmansion.enriched.markdown.views.MathContainerView")
         val view =
-          mathContainerClass
-            .getConstructor(android.content.Context::class.java, StyleConfig::class.java)
-            .newInstance(context, style) as android.view.View
-        mathContainerClass.getMethod("applyLatex", String::class.java).invoke(view, segment.latex)
+          resolvedClass
+            .getConstructor(Context::class.java, StyleConfig::class.java)
+            .newInstance(context, style) as View
+        resolvedClass.getMethod("applyLatex", String::class.java).invoke(view, segment.latex)
         view
       } catch (_: Exception) {
-        android.view.View(context)
+        View(context)
       }
     }
 
@@ -295,11 +460,6 @@ class EnrichedMarkdown
       mainHandler.post {
         if (renderId == currentRenderId) action()
       }
-    }
-
-    private fun clearSegments() {
-      segmentViews.forEach { removeView(it) }
-      segmentViews.clear()
     }
 
     override fun onLayout(
@@ -337,7 +497,26 @@ class EnrichedMarkdown
       }
     }
 
+    private fun computeSegmentsTotalHeight(): Int {
+      var totalHeight = 0
+      val lastIndex = segmentViews.lastIndex
+      segmentViews.forEachIndexed { index, view ->
+        val segment = view as? BlockSegmentView
+        totalHeight += segment?.segmentMarginTop ?: 0
+        totalHeight += view.measuredHeight
+        if (index != lastIndex || allowTrailingMargin) {
+          totalHeight += segment?.segmentMarginBottom ?: 0
+        }
+      }
+      return totalHeight
+    }
+
+    fun cleanup() {
+      executor.shutdownNow()
+    }
+
     companion object {
       private const val TAG = "EnrichedMarkdown"
+      private const val BLOCK_FADE_DURATION_MS = 200L
     }
   }

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -12,6 +12,7 @@ import com.facebook.react.viewmanagers.EnrichedMarkdownManagerDelegate
 import com.facebook.react.viewmanagers.EnrichedMarkdownManagerInterface
 import com.facebook.yoga.YogaMeasureMode
 import com.swmansion.enriched.markdown.spoiler.SpoilerOverlay
+import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
 import com.swmansion.enriched.markdown.utils.common.emitContextMenuItemPress
 import com.swmansion.enriched.markdown.utils.common.emitLinkLongPress
 import com.swmansion.enriched.markdown.utils.common.emitLinkPress
@@ -37,6 +38,18 @@ class EnrichedMarkdownManager :
       emitContextMenuItemPress(view, itemText, selectedText, selectionStart, selectionEnd)
     }
     return view
+  }
+
+  override fun onAfterUpdateTransaction(view: EnrichedMarkdown) {
+    super.onAfterUpdateTransaction(view)
+    view.commitProps()
+  }
+
+  override fun onDropViewInstance(view: EnrichedMarkdown) {
+    super.onDropViewInstance(view)
+    view.cleanup()
+    MeasurementStore.release(view.id)
+    MeasurementStore.clearStreamingTableMode(view.id)
   }
 
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> = markdownEventTypeConstants()
@@ -139,8 +152,21 @@ class EnrichedMarkdownManager :
     view: EnrichedMarkdown?,
     streamingAnimation: Boolean,
   ) {
-    // TODO: Add streaming animation support for github flavor.
-    // Currently only supported with flavor="commonmark" (single TextView).
+    view?.streamingAnimation = streamingAnimation
+  }
+
+  @ReactProp(name = "streamingConfig")
+  override fun setStreamingConfig(
+    view: EnrichedMarkdown?,
+    config: ReadableMap?,
+  ) {
+    if (view == null) return
+    val tableMode =
+      when (config?.getString("tableMode")) {
+        "progressive" -> TableStreamingMode.PROGRESSIVE
+        else -> TableStreamingMode.HIDDEN
+      }
+    view.tableStreamingMode = tableMode
   }
 
   @ReactProp(name = "spoilerOverlay")

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -162,6 +162,14 @@ class EnrichedMarkdownTextManager :
     view?.setStreamingAnimation(streamingAnimation)
   }
 
+  @ReactProp(name = "streamingConfig")
+  override fun setStreamingConfig(
+    view: EnrichedMarkdownText?,
+    config: ReadableMap?,
+  ) {
+    // No-op — CommonMark mode uses a single text view; table streaming is GFM-only.
+  }
+
   @ReactProp(name = "spoilerOverlay")
   override fun setSpoilerOverlay(
     view: EnrichedMarkdownText?,

--- a/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -22,6 +22,8 @@ import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.FeatureFlags
 import com.swmansion.enriched.markdown.utils.common.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.utils.common.RenderedSegment
+import com.swmansion.enriched.markdown.utils.common.StreamingMarkdownFilter
+import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
 import com.swmansion.enriched.markdown.utils.common.getBooleanOrDefault
 import com.swmansion.enriched.markdown.utils.common.getMapOrNull
 import com.swmansion.enriched.markdown.utils.common.getStringOrDefault
@@ -60,6 +62,8 @@ object MeasurementStore {
   )
 
   private val fontScalingSettings = ConcurrentHashMap<Int, FontScalingSettings>()
+
+  private val streamingTableModes = ConcurrentHashMap<Int, TableStreamingMode>()
 
   private fun resolveFontScalingSettings(
     viewId: Int?,
@@ -102,6 +106,10 @@ object MeasurementStore {
   }
 
   fun release(id: Int) {
+    data.remove(id)
+  }
+
+  fun invalidate(id: Int) {
     data.remove(id)
   }
 
@@ -148,6 +156,17 @@ object MeasurementStore {
     fontScalingSettings.remove(viewId)
   }
 
+  fun updateStreamingTableMode(
+    viewId: Int,
+    mode: TableStreamingMode,
+  ) {
+    streamingTableModes[viewId] = mode
+  }
+
+  fun clearStreamingTableMode(viewId: Int) {
+    streamingTableModes.remove(viewId)
+  }
+
   private fun getMeasureByIdInternal(
     context: Context,
     id: Int?,
@@ -190,6 +209,16 @@ object MeasurementStore {
     maxFontSizeMultiplier: Float,
   ): Int {
     val markdown = props.getStringOrDefault("markdown", "")
+    return computePropsHashForMarkdown(markdown, props, allowFontScaling, fontScale, maxFontSizeMultiplier)
+  }
+
+  private fun computePropsHashForMarkdown(
+    markdown: String,
+    props: ReadableMap?,
+    allowFontScaling: Boolean,
+    fontScale: Float,
+    maxFontSizeMultiplier: Float,
+  ): Int {
     val styleMap = props.getMapOrNull("markdownStyle")
     val md4cFlagsMap = props.getMapOrNull("md4cFlags")
     val allowTrailingMargin = props.getBooleanOrDefault("allowTrailingMargin", false)
@@ -286,7 +315,27 @@ object MeasurementStore {
     fontScale: Float,
     maxFontSizeMultiplier: Float,
   ): Long {
-    val markdown = props.getStringOrDefault("markdown", "")
+    val isStreaming = props.getBooleanOrDefault("streamingAnimation", false)
+
+    val rawMarkdown = props.getStringOrDefault("markdown", "")
+    val tableMode = if (isStreaming) id?.let { streamingTableModes[it] } ?: TableStreamingMode.HIDDEN else TableStreamingMode.HIDDEN
+    val markdown =
+      if (isStreaming) {
+        StreamingMarkdownFilter.renderableMarkdownForStreaming(rawMarkdown, tableMode)
+      } else {
+        rawMarkdown
+      }
+    val propsHash = computePropsHashForMarkdown(markdown, props, allowFontScaling, fontScale, maxFontSizeMultiplier)
+
+    // Streaming shortcut: reuse cached size when the filtered content and
+    // width are unchanged. When the filter output changes (e.g. a table
+    // becomes complete), the hash differs and we fall through to full measure.
+    if (isStreaming && id != null) {
+      val cached = data[id]
+      if (cached != null && cached.cachedWidth == width && cached.markdownHash == propsHash) {
+        return cached.cachedSize
+      }
+    }
     val styleMap =
       props.getMapOrNull("markdownStyle")
         ?: return YogaMeasureOutput.make(PixelUtil.toDIPFromPixel(width), 0f)
@@ -297,7 +346,6 @@ object MeasurementStore {
         latexMath = FeatureFlags.IS_MATH_ENABLED && props.getMapOrNull("md4cFlags").getBooleanOrDefault("latexMath", true),
       )
     val allowTrailingMargin = props.getBooleanOrDefault("allowTrailingMargin", false)
-    val propsHash = computePropsHash(props, allowFontScaling, fontScale, maxFontSizeMultiplier)
     val fontSize = getInitialFontSize(styleMap, context, allowFontScaling, fontScale, maxFontSizeMultiplier)
 
     return try {

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/RenderedSegment.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/RenderedSegment.kt
@@ -8,19 +8,24 @@ import com.swmansion.enriched.markdown.spans.ImageSpan
 import com.swmansion.enriched.markdown.styles.StyleConfig
 
 sealed interface RenderedSegment {
+  val signature: Long
+
   data class Text(
     val styledText: SpannableString,
     val imageSpans: List<ImageSpan>,
     val needsJustify: Boolean,
     val lastElementMarginBottom: Float,
+    override val signature: Long,
   ) : RenderedSegment
 
   data class Table(
     val node: MarkdownASTNode,
+    override val signature: Long,
   ) : RenderedSegment
 
   data class Math(
     val latex: String,
+    override val signature: Long,
   ) : RenderedSegment
 }
 
@@ -34,9 +39,20 @@ object MarkdownSegmentRenderer {
   ): List<RenderedSegment> =
     segments.map { segment ->
       when (segment) {
-        is MarkdownSegment.Text -> renderTextSegment(segment.nodes, style, context, onLinkPress, onLinkLongPress)
-        is MarkdownSegment.Table -> RenderedSegment.Table(segment.node)
-        is MarkdownSegment.Math -> RenderedSegment.Math(segment.latex)
+        is MarkdownSegment.Text -> {
+          renderTextSegment(segment.nodes, style, context, onLinkPress, onLinkLongPress)
+        }
+
+        is MarkdownSegment.Table -> {
+          val signature = SegmentSignature.signatureForNode(segment.node) xor SegmentSignature.TABLE_KIND_SALT
+          RenderedSegment.Table(segment.node, signature)
+        }
+
+        is MarkdownSegment.Math -> {
+          var signature = SegmentSignature.signatureForNode(null) xor SegmentSignature.MATH_KIND_SALT
+          signature = SegmentSignature.fnvMixString(signature, segment.latex)
+          RenderedSegment.Math(segment.latex, signature)
+        }
       }
     }
 
@@ -49,12 +65,14 @@ object MarkdownSegmentRenderer {
   ): RenderedSegment.Text {
     val documentWrapper = MarkdownASTNode(type = MarkdownASTNode.NodeType.Document, children = nodes)
     val renderer = Renderer().apply { configure(style, context) }
+    val signature = SegmentSignature.signatureForNodes(nodes) xor SegmentSignature.TEXT_KIND_SALT
 
     return RenderedSegment.Text(
       styledText = renderer.renderDocument(documentWrapper, onLinkPress, onLinkLongPress),
       imageSpans = renderer.getCollectedImageSpans().toList(),
       needsJustify = style.needsJustify,
       lastElementMarginBottom = renderer.getLastElementMarginBottom(),
+      signature = signature,
     )
   }
 }

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/SegmentReconciler.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/SegmentReconciler.kt
@@ -1,0 +1,118 @@
+package com.swmansion.enriched.markdown.utils.common
+
+import android.view.View
+
+data class ReconciliationResult(
+  val views: List<View>,
+  val signatures: List<Long>,
+  val viewsToRemove: List<View>,
+  val viewsToAttach: List<View>,
+)
+
+object SegmentReconciler {
+  fun reconcile(
+    currentViews: List<View>,
+    currentSignatures: List<Long>,
+    renderedSegments: List<RenderedSegment>,
+    reset: Boolean,
+    matchesKind: (View, RenderedSegment) -> Boolean,
+    createView: (RenderedSegment) -> View,
+    updateView: (View, RenderedSegment) -> Unit,
+  ): ReconciliationResult {
+    val resetRemovals = if (reset) currentViews else emptyList()
+    val sourceViews = if (reset) emptyList() else currentViews
+    val sourceSignatures = if (reset) emptyList() else currentSignatures
+
+    val signatureToIndices = HashMap<Long, ArrayDeque<Int>>(sourceSignatures.size)
+    for ((index, signature) in sourceSignatures.withIndex()) {
+      signatureToIndices.getOrPut(signature) { ArrayDeque() }.addLast(index)
+    }
+
+    val remainingNextSignatureCounts = HashMap<Long, Int>(renderedSegments.size)
+    for (segment in renderedSegments) {
+      val signature = segment.signature
+      remainingNextSignatureCounts[signature] = (remainingNextSignatureCounts[signature] ?: 0) + 1
+    }
+
+    val nextViews = ArrayList<View>(renderedSegments.size)
+    val nextSignatures = ArrayList<Long>(renderedSegments.size)
+    val reusedViews = HashSet<View>(sourceViews.size)
+    val viewsToAttach = mutableListOf<View>()
+
+    for ((index, segment) in renderedSegments.withIndex()) {
+      val existingView = sourceViews.getOrNull(index)
+      val existingSignature = sourceSignatures.getOrNull(index)
+      val nextSignature = segment.signature
+
+      val remaining = remainingNextSignatureCounts.getOrDefault(nextSignature, 0)
+      if (remaining > 1) {
+        remainingNextSignatureCounts[nextSignature] = remaining - 1
+      } else {
+        remainingNextSignatureCounts.remove(nextSignature)
+      }
+
+      var view: View? = null
+
+      // 1. Exact positional match: same index, same kind, same signature.
+      if (existingView != null &&
+        existingView !in reusedViews &&
+        matchesKind(existingView, segment) &&
+        existingSignature == nextSignature
+      ) {
+        view = existingView
+      }
+
+      // 2. Signature-based fallback: find an unused view with exact same signature.
+      if (view == null) {
+        val candidateIndices = signatureToIndices[nextSignature]
+        if (candidateIndices != null) {
+          while (candidateIndices.isNotEmpty()) {
+            val candidateIdx = candidateIndices.removeFirst()
+            val candidate = sourceViews[candidateIdx]
+            if (candidate !in reusedViews && matchesKind(candidate, segment)) {
+              view = candidate
+              break
+            }
+          }
+        }
+      }
+
+      // 3. Same-kind positional update. If the old signature appears later in
+      // the new list, leave the view available for that exact reuse instead.
+      if (view == null &&
+        existingView != null &&
+        existingView !in reusedViews &&
+        matchesKind(existingView, segment) &&
+        (existingSignature == null || (remainingNextSignatureCounts[existingSignature] ?: 0) == 0)
+      ) {
+        updateView(existingView, segment)
+        view = existingView
+      }
+
+      // 4. No reusable view found — create a new one.
+      if (view == null) {
+        view = createView(segment)
+        viewsToAttach.add(view)
+      }
+
+      nextViews.add(view)
+      nextSignatures.add(nextSignature)
+      reusedViews.add(view)
+    }
+
+    val viewsToRemove = ArrayList<View>(resetRemovals.size + sourceViews.size)
+    viewsToRemove.addAll(resetRemovals)
+    for (view in sourceViews) {
+      if (view !in reusedViews) {
+        viewsToRemove.add(view)
+      }
+    }
+
+    return ReconciliationResult(
+      views = nextViews,
+      signatures = nextSignatures,
+      viewsToRemove = viewsToRemove,
+      viewsToAttach = viewsToAttach,
+    )
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/SegmentSignature.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/SegmentSignature.kt
@@ -1,0 +1,78 @@
+package com.swmansion.enriched.markdown.utils.common
+
+import com.swmansion.enriched.markdown.parser.MarkdownASTNode
+
+/** FNV-1a 64-bit hashing. Constants match the iOS implementation for cross-platform parity. */
+object SegmentSignature {
+  // FNV-1a 64-bit constants (same as iOS)
+  private const val FNV_OFFSET_BASIS = -3750763034362895579L // 14695981039346656037 as signed Long
+  private const val FNV_PRIME = 1099511628211L
+
+  internal const val TEXT_KIND_SALT = 0x7465787400000000L // "text"
+  internal const val TABLE_KIND_SALT = 0x7461626C00000000L // "tabl"
+  internal const val MATH_KIND_SALT = 0x6D61746800000000L // "math"
+
+  private fun fnvMixByte(
+    hash: Long,
+    byte: Byte,
+  ): Long {
+    var result = hash xor (byte.toLong() and 0xFF)
+    result *= FNV_PRIME
+    return result
+  }
+
+  private fun fnvMixLong(
+    hash: Long,
+    value: Long,
+  ): Long {
+    var result = hash
+    var remaining = value
+    for (i in 0 until 8) {
+      result = fnvMixByte(result, (remaining and 0xFF).toByte())
+      remaining = remaining ushr 8
+    }
+    return result
+  }
+
+  internal fun fnvMixString(
+    hash: Long,
+    string: String?,
+  ): Long {
+    if (string == null) return hash
+    var result = hash
+    val bytes = string.toByteArray(Charsets.UTF_8)
+    for (byte in bytes) {
+      result = fnvMixByte(result, byte)
+    }
+    return result
+  }
+
+  fun signatureForNode(node: MarkdownASTNode?): Long {
+    if (node == null) return FNV_OFFSET_BASIS
+
+    var hash = FNV_OFFSET_BASIS
+    hash = fnvMixLong(hash, node.type.ordinal.toLong())
+    hash = fnvMixString(hash, node.content)
+
+    if (node.attributes.isNotEmpty()) {
+      for (key in node.attributes.keys.sorted()) {
+        hash = fnvMixString(hash, key)
+        hash = fnvMixString(hash, node.attributes[key])
+      }
+    }
+
+    for (child in node.children) {
+      hash = fnvMixLong(hash, signatureForNode(child))
+    }
+
+    return hash
+  }
+
+  fun signatureForNodes(nodes: List<MarkdownASTNode>): Long {
+    var hash = FNV_OFFSET_BASIS
+    for (node in nodes) {
+      hash = fnvMixLong(hash, signatureForNode(node))
+    }
+    return hash
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
@@ -1,0 +1,142 @@
+package com.swmansion.enriched.markdown.utils.common
+
+enum class TableStreamingMode {
+  HIDDEN,
+  PROGRESSIVE,
+}
+
+/**
+ * Pre-parse filter that hides incomplete trailing tables and block math
+ * during streaming. A table is considered complete only after a blank
+ * separator line follows it; a block math (`$$`) is complete only when
+ * a closing `$$` exists.
+ */
+object StreamingMarkdownFilter {
+  fun renderableMarkdownForStreaming(
+    markdown: String,
+    tableMode: TableStreamingMode = TableStreamingMode.HIDDEN,
+  ): String {
+    val lines = markdown.split("\n")
+    val afterMath = removePendingStreamingMathBlock(markdown, lines)
+    val linesForTable = if (afterMath.length == markdown.length) lines else afterMath.split("\n")
+    return removePendingStreamingTableBlock(afterMath, linesForTable, tableMode)
+  }
+
+  private fun removePendingStreamingMathBlock(
+    markdown: String,
+    lines: List<String>,
+  ): String {
+    var lastUnclosedDelimiterIndex = -1
+
+    for (i in lines.indices) {
+      if (lineIsBlockMathDelimiter(lines[i])) {
+        lastUnclosedDelimiterIndex = if (lastUnclosedDelimiterIndex == -1) i else -1
+      }
+    }
+
+    if (lastUnclosedDelimiterIndex == -1) return markdown
+
+    val offsets = buildLineOffsets(lines)
+    return markdown.substring(0, offsets[lastUnclosedDelimiterIndex])
+  }
+
+  private fun removePendingStreamingTableBlock(
+    markdown: String,
+    lines: List<String>,
+    tableMode: TableStreamingMode,
+  ): String {
+    var lastNonBlankLineIndex = -1
+
+    for (i in lines.indices.reversed()) {
+      if (!lineIsBlank(lines[i])) {
+        lastNonBlankLineIndex = i
+        break
+      }
+    }
+
+    if (lastNonBlankLineIndex == -1) return markdown
+
+    if (lastNonBlankLineIndex + 1 < lines.size - 1) return markdown
+
+    var blockStartIndex = lastNonBlankLineIndex
+    while (blockStartIndex > 0 && !lineIsBlank(lines[blockStartIndex - 1])) {
+      blockStartIndex--
+    }
+
+    var blockLooksLikeTable = false
+    for (i in blockStartIndex..lastNonBlankLineIndex) {
+      if (!lineLooksLikeTableRow(lines[i])) return markdown
+      blockLooksLikeTable = true
+    }
+
+    if (!blockLooksLikeTable) return markdown
+
+    val offsets = buildLineOffsets(lines)
+
+    if (tableMode == TableStreamingMode.PROGRESSIVE) {
+      val tableLineCount = lastNonBlankLineIndex - blockStartIndex + 1
+
+      if (tableLineCount < 2 || !lineLooksLikeTableSeparator(lines[blockStartIndex + 1])) {
+        return markdown.substring(0, offsets[blockStartIndex])
+      }
+
+      if (tableLineCount > 2) {
+        val lastRow = lines[lastNonBlankLineIndex]
+        val lastRowTrimmed = lastRow.trim()
+        val headerRow = lines[blockStartIndex]
+        if (!lastRowTrimmed.endsWith("|") || pipeCount(lastRow) < pipeCount(headerRow)) {
+          return markdown.substring(0, offsets[lastNonBlankLineIndex])
+        }
+      }
+
+      return markdown
+    }
+
+    return markdown.substring(0, offsets[blockStartIndex])
+  }
+
+  private fun lineIsBlank(line: String): Boolean = line.isBlank()
+
+  private fun lineIsBlockMathDelimiter(line: String): Boolean = line.trim() == "$$"
+
+  private fun lineLooksLikeTableRow(line: String): Boolean {
+    val trimmed = line.trim()
+    return trimmed.startsWith("|")
+  }
+
+  private fun lineLooksLikeTableSeparator(line: String): Boolean {
+    val trimmed = line.trim()
+    if (trimmed.isEmpty()) return false
+    if (trimmed[0] != '|') return false
+    var hasTripleDash = false
+    var dashRun = 0
+    for (ch in trimmed) {
+      if (ch == '-') {
+        dashRun++
+        if (dashRun >= 3) hasTripleDash = true
+      } else {
+        dashRun = 0
+        if (ch != '|' && ch != ':' && ch != ' ') return false
+      }
+    }
+    return hasTripleDash
+  }
+
+  private fun pipeCount(line: String): Int {
+    var count = 0
+    for (ch in line) {
+      if (ch == '|') count++
+    }
+    return count
+  }
+
+  private fun buildLineOffsets(lines: List<String>): IntArray {
+    val offsets = IntArray(lines.size)
+    var currentOffset = 0
+    for (i in lines.indices) {
+      offsets[i] = currentOffset
+      currentOffset += lines[i].length + 1
+    }
+    return offsets
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
@@ -58,6 +58,32 @@ class TableContainerView(
     }
   private val gridContainer get() = scrollView.getChildAt(0) as GridContainerView
 
+  val rowCount: Int get() = rows.size
+
+  fun animateNewRows(
+    previousRowCount: Int,
+    durationMs: Long,
+  ) {
+    if (rowCount <= previousRowCount) return
+    val grid = gridContainer
+    val childCount = grid.childCount
+    if (childCount == 0 || rowCount == 0) return
+
+    val colCount = childCount / rowCount
+    if (colCount == 0) return
+
+    val firstNewCellIndex = previousRowCount * colCount
+    for (i in firstNewCellIndex until childCount) {
+      val cell = grid.getChildAt(i) ?: continue
+      cell.alpha = 0f
+      cell
+        .animate()
+        .alpha(1f)
+        .setDuration(durationMs)
+        .start()
+    }
+  }
+
   private var rows: List<List<TableCellData>> = emptyList()
   private var columnCount = 0
   private var columnWidths = emptyList<Float>()

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
@@ -13,6 +13,7 @@ inline folly::dynamic toDynamic(const EnrichedMarkdownTextProps &props) {
   serializedProps["markdownStyle"] = toDynamic(props.markdownStyle);
   serializedProps["md4cFlags"] = toDynamic(props.md4cFlags);
   serializedProps["allowTrailingMargin"] = props.allowTrailingMargin;
+  serializedProps["streamingAnimation"] = props.streamingAnimation;
 
   return serializedProps;
 }
@@ -23,6 +24,7 @@ inline folly::dynamic toDynamic(const EnrichedMarkdownProps &props) {
   serializedProps["markdownStyle"] = toDynamic(props.markdownStyle);
   serializedProps["md4cFlags"] = toDynamic(props.md4cFlags);
   serializedProps["allowTrailingMargin"] = props.allowTrailingMargin;
+  serializedProps["streamingAnimation"] = props.streamingAnimation;
 
   return serializedProps;
 }

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -16,8 +16,9 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { sampleMarkdown } from './sampleMarkdown';
 import { customMarkdownStyle } from './markdownStyles';
 import InputScreen from './InputScreen';
+import StreamingMarkdownSimulator from './StreamingMarkdownSimulator';
 
-type Screen = 'text' | 'input';
+type Screen = 'text' | 'input' | 'stream';
 
 export default function App() {
   const [screen, setScreen] = useState<Screen>('input');
@@ -78,10 +79,18 @@ export default function App() {
         >
           Text
         </Text>
+        <Text
+          style={[styles.tab, screen === 'stream' && styles.tabActive]}
+          onPress={() => setScreen('stream')}
+        >
+          Stream
+        </Text>
       </View>
 
       {screen === 'input' ? (
         <InputScreen />
+      ) : screen === 'stream' ? (
+        <StreamingMarkdownSimulator />
       ) : (
         <ScrollView
           style={styles.scrollView}

--- a/apps/example/src/StreamingMarkdownSimulator.tsx
+++ b/apps/example/src/StreamingMarkdownSimulator.tsx
@@ -9,14 +9,19 @@ import {
 import { EnrichedMarkdownText } from 'react-native-enriched-markdown';
 import { customMarkdownStyle } from './markdownStyles';
 
-const STREAM_SOURCE = `Here is a tiny streamed answer.
+const STREAM_SOURCE = `Here is a longer streamed answer used to stress GitHub-flavored markdown streaming on iOS.
 
-First table:
+The goal is to keep normal text flowing while completed tables and block LaTeX views stay stable. Each section below adds enough text between block views to make layout changes easier to notice during streaming.
 
-| Item | Value |
-| --- | ---: |
-| Alpha | 1 |
-| Beta | 2 |
+First summary table:
+
+| Area | Why it matters | Expected behavior |
+| --- | --- | --- |
+| Text | Keeps streaming frequently | Tail text fades in |
+| Table | Expensive native block | Existing table is reused |
+| Math | Expensive native block | Existing formula is reused |
+
+After the first table, the answer continues with regular prose. This paragraph should stream normally and should not cause the completed table above to be recreated. It gives the preview enough height to make jumps and delayed measurements visible.
 
 First LaTeX block:
 
@@ -24,12 +29,18 @@ $$
 E = mc^2
 $$
 
-Second table:
+The first equation is intentionally short. The following text continues immediately after it so we can verify that the math block appears once, then remains stable while more text is appended below.
 
-| Step | Status |
-| --- | --- |
-| Parse | done |
-| Render | streaming |
+Second progress table:
+
+| Step | Status | Notes |
+| --- | --- | --- |
+| Parse markdown | done | AST is ready |
+| Split segments | done | Text, table, and math are separated |
+| Reconcile views | active | Unchanged blocks should be reused |
+| Measure height | active | Height should update only when needed |
+
+The stream now adds a longer paragraph to simulate a real assistant response. The important thing is that appending this text should not force the previous table or formula to flash, fade again, or rebuild their native views.
 
 Second LaTeX block:
 
@@ -37,18 +48,39 @@ $$
 a^2 + b^2 = c^2
 $$
 
-Final table:
+More explanatory text follows the second formula. This gives us another opportunity to check that previously completed blocks remain visually stable while the tail of the message continues to animate.
 
-| Block | Kind |
+Comparison table:
+
+| Scenario | Static GFM | Streaming GFM |
+| --- | --- | --- |
+| Complete table | Renders immediately | Renders when complete |
+| Incomplete table | Renders as parser allows | Hidden until complete |
+| Complete math block | Renders immediately | Renders when complete |
+| Incomplete math block | Renders as parser allows | Hidden until closing delimiter |
+
+This paragraph is intentionally a little longer. It should make the preview scrollable and help us see whether the UI thread stays smooth when several completed block views already exist above the streaming tail.
+
+Third LaTeX block:
+
+$$
+F(x) = \\int_0^x t^2\\,dt = \\frac{x^3}{3}
+$$
+
+Final validation table:
+
+| Check | Result |
 | --- | --- |
-| One | text |
-| Two | table |
-| Three | math |
+| Text keeps streaming | expected |
+| Completed tables stay visible | expected |
+| Completed math stays visible | expected |
+| Incomplete block is hidden | expected |
+| Height grows only for rendered content | expected |
 
-Done.`;
+The streamed answer is complete. At this point all tables and block LaTeX sections should be visible, and none of the earlier blocks should have been recreated unnecessarily while the final text was appended.`;
 
 const TICK_MS = 80;
-const CHARS_PER_TICK = 3;
+const CHARS_PER_TICK = 6;
 
 export default function StreamingMarkdownSimulator() {
   const [cursor, setCursor] = useState(0);
@@ -85,7 +117,7 @@ export default function StreamingMarkdownSimulator() {
     <ScrollView style={styles.root} contentContainerStyle={styles.content}>
       <Text style={styles.title}>Streaming markdown simulator</Text>
       <Text style={styles.subtitle}>
-        JS-only stream: short text, a few tables, and a few block LaTeX
+        JS-only stream: longer text, several tables, and several block LaTeX
         segments.
       </Text>
 

--- a/apps/example/src/StreamingMarkdownSimulator.tsx
+++ b/apps/example/src/StreamingMarkdownSimulator.tsx
@@ -148,6 +148,9 @@ export default function StreamingMarkdownSimulator() {
           markdownStyle={markdownStyle}
           md4cFlags={{ latexMath: true }}
           streamingAnimation
+          streamingConfig={{
+            tableMode: 'progressive',
+          }}
         />
       </View>
 

--- a/apps/example/src/StreamingMarkdownSimulator.tsx
+++ b/apps/example/src/StreamingMarkdownSimulator.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { EnrichedMarkdownText } from 'react-native-enriched-markdown';
+import { customMarkdownStyle } from './markdownStyles';
+
+const STREAM_SOURCE = `Here is a tiny streamed answer.
+
+First table:
+
+| Item | Value |
+| --- | ---: |
+| Alpha | 1 |
+| Beta | 2 |
+
+First LaTeX block:
+
+$$
+E = mc^2
+$$
+
+Second table:
+
+| Step | Status |
+| --- | --- |
+| Parse | done |
+| Render | streaming |
+
+Second LaTeX block:
+
+$$
+a^2 + b^2 = c^2
+$$
+
+Final table:
+
+| Block | Kind |
+| --- | --- |
+| One | text |
+| Two | table |
+| Three | math |
+
+Done.`;
+
+const TICK_MS = 80;
+const CHARS_PER_TICK = 3;
+
+export default function StreamingMarkdownSimulator() {
+  const [cursor, setCursor] = useState(0);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const markdownStyle = useMemo(() => customMarkdownStyle, []);
+
+  const markdown = STREAM_SOURCE.slice(0, cursor);
+  const isComplete = cursor >= STREAM_SOURCE.length;
+
+  const step = useCallback(() => {
+    setCursor((current) =>
+      Math.min(current + CHARS_PER_TICK, STREAM_SOURCE.length)
+    );
+  }, []);
+
+  const reset = useCallback(() => {
+    setIsStreaming(false);
+    setCursor(0);
+  }, []);
+
+  useEffect(() => {
+    if (!isStreaming || isComplete) {
+      if (isComplete) {
+        setIsStreaming(false);
+      }
+      return;
+    }
+
+    const interval = setInterval(step, TICK_MS);
+    return () => clearInterval(interval);
+  }, [isStreaming, isComplete, step]);
+
+  return (
+    <ScrollView style={styles.root} contentContainerStyle={styles.content}>
+      <Text style={styles.title}>Streaming markdown simulator</Text>
+      <Text style={styles.subtitle}>
+        JS-only stream: short text, a few tables, and a few block LaTeX
+        segments.
+      </Text>
+
+      <View style={styles.controls}>
+        <ControlButton
+          label={isStreaming ? 'Pause' : isComplete ? 'Replay' : 'Start'}
+          onPress={() => {
+            if (isComplete) {
+              setCursor(0);
+              setIsStreaming(true);
+              return;
+            }
+            setIsStreaming((value) => !value);
+          }}
+        />
+        <ControlButton label="Step" onPress={step} disabled={isComplete} />
+        <ControlButton label="Reset" onPress={reset} />
+      </View>
+
+      <Text style={styles.progress}>
+        {cursor}/{STREAM_SOURCE.length} characters
+      </Text>
+
+      <View style={styles.preview}>
+        <EnrichedMarkdownText
+          flavor="github"
+          markdown={markdown}
+          markdownStyle={markdownStyle}
+          md4cFlags={{ latexMath: true }}
+          streamingAnimation
+        />
+      </View>
+
+      <Text style={styles.rawLabel}>Raw streamed markdown</Text>
+      <Text style={styles.raw}>{markdown || 'Waiting to stream...'}</Text>
+    </ScrollView>
+  );
+}
+
+function ControlButton({
+  label,
+  onPress,
+  disabled = false,
+}: {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <TouchableOpacity
+      style={[styles.button, disabled && styles.buttonDisabled]}
+      onPress={onPress}
+      disabled={disabled}
+    >
+      <Text style={styles.buttonText}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+    gap: 12,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  controls: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  button: {
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 8,
+    backgroundColor: '#2563EB',
+  },
+  buttonDisabled: {
+    backgroundColor: '#9CA3AF',
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+  },
+  progress: {
+    color: '#6B7280',
+    fontSize: 12,
+  },
+  preview: {
+    padding: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#D1D5DB',
+    borderRadius: 12,
+    backgroundColor: '#FFFFFF',
+  },
+  rawLabel: {
+    marginTop: 8,
+    color: '#374151',
+    fontWeight: '600',
+  },
+  raw: {
+    padding: 12,
+    borderRadius: 8,
+    backgroundColor: '#F3F4F6',
+    color: '#111827',
+    fontFamily: 'Menlo',
+    fontSize: 12,
+  },
+});

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -186,11 +186,35 @@ Markdown flavor. Set to `'github'` to enable GitHub Flavored Markdown table supp
 
 ### `streamingAnimation`
 
-When `true`, newly appended content fades in during streaming updates. Only the tail (new characters beyond the previous content) is animated. Recommended for LLM streaming use cases with `flavor="commonmark"`.
+When `true`, newly appended content fades in during streaming updates. Only the tail (new characters beyond the previous content) is animated. Recommended for LLM streaming use cases.
 
 | Type      | Default Value | Platform |
 | --------- | ------------- | -------- |
 | `boolean` | `false`       | Both     |
+
+### `streamingConfig`
+
+Configuration for streaming behavior. Currently controls how incomplete tables are handled during streaming with `flavor="github"`.
+
+| Type                    | Default Value            | Platform |
+| ----------------------- | ------------------------ | -------- |
+| `{ tableMode: string }` | `{ tableMode: 'hidden' }` | Both     |
+
+#### `tableMode`
+
+Controls how incomplete (still-streaming) tables are rendered:
+
+- **`'hidden'`** (default): The entire table is hidden until it is complete (followed by a blank line). This prevents visual jank from partially formed tables.
+- **`'progressive'`**: The table is rendered row-by-row as content arrives. Requires at least a header row and separator line before anything is shown. Incomplete trailing rows (missing closing `|` or fewer columns than the header) are trimmed. New rows fade in with animation when `streamingAnimation` is also enabled.
+
+```tsx
+<EnrichedMarkdownText
+  markdown={streamingMarkdown}
+  flavor="github"
+  streamingAnimation
+  streamingConfig={{ tableMode: 'progressive' }}
+/>
+```
 
 ### `spoilerOverlay`
 

--- a/docs/MARKDOWN_STREAMING.md
+++ b/docs/MARKDOWN_STREAMING.md
@@ -11,3 +11,26 @@ import { StreamdownText } from 'react-native-streamdown';
 ```
 
 `StreamdownText` accepts all props from `EnrichedMarkdownText` and adds a `remendConfig` prop for customizing the markdown repair pipeline. See the [react-native-streamdown README](https://github.com/software-mansion-labs/react-native-streamdown#readme) for full setup instructions including the required Babel and Metro configuration for Bundle Mode.
+
+## Table Streaming (GFM)
+
+When using `flavor="github"` with streaming content, tables require special handling because they are block-level elements that can't be rendered until the parser has enough structure (at minimum a header row and separator line).
+
+The `streamingConfig` prop controls this behavior:
+
+```tsx
+<EnrichedMarkdownText
+  markdown={streamingMarkdown}
+  flavor="github"
+  streamingAnimation
+  streamingConfig={{ tableMode: 'progressive' }}
+/>
+```
+
+### Table Modes
+
+| Mode | Behavior |
+|---|---|
+| `'hidden'` (default) | The table is completely hidden until it is followed by a blank line, indicating the table is complete. Prevents visual jank from partially formed tables. |
+| `'progressive'` | Renders the table row-by-row as content arrives. New rows fade in when `streamingAnimation` is enabled. Incomplete trailing rows are automatically trimmed. |
+

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -38,6 +38,7 @@ The web implementation also exports `WebMarkdownTextProps` which extends `Enrich
 | `enableLinkPreview` | iOS-only feature (native link preview on long press). |
 | `allowFontScaling` / `maxFontSizeMultiplier` | React Native text scaling props. Browsers handle font scaling natively via OS accessibility settings. |
 | `streamingAnimation` | Native-only tail fade-in animation. Not yet implemented on web. |
+| `streamingConfig` | Native-only streaming table configuration. Not yet implemented on web. |
 | `contextMenuItems` | Not supported — browsers don't allow extending the native context menu. |
 | `selectionHandleColor` | Android-only — desktop browsers don't render selection handles. |
 

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -566,32 +566,9 @@ static char kENRMSegmentFadeAnimatorKey;
   NSUInteger previousRowCount = view.rowCount;
   [view applyTableNode:tableSegment.tableNode];
 
-#if !TARGET_OS_OSX
-  if (!_streamingAnimation || view.rowCount <= previousRowCount) {
-    return;
+  if (_streamingAnimation) {
+    [view animateNewRowsFromPreviousCount:previousRowCount duration:0.20];
   }
-
-  // The grid container is inside the scroll view: TableContainerView > UIScrollView > gridContainer.
-  // After applyTableNode:, cells are laid out sequentially — each row has colCount cell-background subviews.
-  RCTUIView *scrollView = view.subviews.firstObject;
-  RCTUIView *gridContainer = scrollView.subviews.firstObject;
-  if (!gridContainer || gridContainer.subviews.count == 0 || view.rowCount == 0) {
-    return;
-  }
-
-  NSUInteger colCount = gridContainer.subviews.count / view.rowCount;
-  if (colCount == 0) {
-    return;
-  }
-
-  NSUInteger firstNewCellIndex = previousRowCount * colCount;
-  NSArray<RCTUIView *> *subviews = gridContainer.subviews;
-  for (NSUInteger i = firstNewCellIndex; i < subviews.count; i++) {
-    RCTUIView *cellView = subviews[i];
-    cellView.alpha = 0.0;
-    [UIView animateWithDuration:0.20 animations:^{ cellView.alpha = 1.0; }];
-  }
-#endif
 }
 
 #if ENRICHED_MARKDOWN_MATH

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -2,7 +2,9 @@
 #import "ContextMenuUtils.h"
 #import "ENRMImageAttachment.h"
 #import "ENRMMarkdownParser.h"
+#import "ENRMTailFadeInAnimator.h"
 #import "ENRMTextRenderer.h"
+#import "ENRMTextViewSetup.h"
 #import "ENRMUIKit.h"
 #import "EditMenuUtils.h"
 
@@ -24,9 +26,13 @@
 #import "MarkdownASTNode.h"
 #import "MarkdownAccessibilityElementBuilder.h"
 #import "MarkdownExtractor.h"
-#import "ParagraphStyleUtils.h"
+#import "RenderedMarkdownSegment.h"
 #import "RuntimeKeys.h"
+#import "SegmentReconciler.h"
+#import "SegmentRenderer.h"
+#import "SegmentViewRegistry.h"
 #import "SelectionColorUtils.h"
+#import "StreamingMarkdownFilter.h"
 #import "StyleConfig.h"
 #import "StylePropsUtils.h"
 #import "TableContainerView.h"
@@ -47,49 +53,7 @@
 
 using namespace facebook::react;
 
-@interface EMTextSegment : NSObject
-@property (nonatomic, strong) NSArray<MarkdownASTNode *> *nodes;
-+ (instancetype)segmentWithNodes:(NSArray<MarkdownASTNode *> *)nodes;
-@end
-
-@implementation EMTextSegment
-+ (instancetype)segmentWithNodes:(NSArray<MarkdownASTNode *> *)nodes
-{
-  EMTextSegment *segment = [[EMTextSegment alloc] init];
-  segment.nodes = [nodes copy];
-  return segment;
-}
-@end
-
-@interface EMTableSegment : NSObject
-@property (nonatomic, strong) MarkdownASTNode *tableNode;
-+ (instancetype)segmentWithTableNode:(MarkdownASTNode *)node;
-@end
-
-@implementation EMTableSegment
-+ (instancetype)segmentWithTableNode:(MarkdownASTNode *)node
-{
-  EMTableSegment *segment = [[EMTableSegment alloc] init];
-  segment.tableNode = node;
-  return segment;
-}
-@end
-
-#if ENRICHED_MARKDOWN_MATH
-@interface EMMathSegment : NSObject
-@property (nonatomic, strong) NSString *latex;
-+ (instancetype)segmentWithLatex:(NSString *)latex;
-@end
-
-@implementation EMMathSegment
-+ (instancetype)segmentWithLatex:(NSString *)latex
-{
-  EMMathSegment *segment = [[EMMathSegment alloc] init];
-  segment.latex = latex;
-  return segment;
-}
-@end
-#endif
+static char kENRMSegmentFadeAnimatorKey;
 
 @interface EnrichedMarkdown () <RCTEnrichedMarkdownViewProtocol, UITextViewDelegate>
 @end
@@ -101,6 +65,11 @@ using namespace facebook::react;
   NSString *_cachedMarkdown;
   NSString *_renderedMarkdown;
   NSMutableArray<RCTUIView *> *_segmentViews;
+  NSMutableArray<NSString *> *_segmentSignatures;
+  ENRMSegmentViewRegistry *_segmentViewRegistry;
+  BOOL _forceRecreateSegments;
+  BOOL _forceHeightUpdateOnNextRender;
+  BOOL _heightUpdateScheduled;
 
   dispatch_queue_t _renderQueue;
   NSUInteger _currentRenderId;
@@ -115,6 +84,7 @@ using namespace facebook::react;
   BOOL _allowTrailingMargin;
   BOOL _selectable;
   BOOL _enableLinkPreview;
+  BOOL _streamingAnimation;
 
   NSArray<NSString *> *_contextMenuItemTexts;
   NSArray<NSString *> *_contextMenuItemIcons;
@@ -137,6 +107,11 @@ using namespace facebook::react;
     _parser = [[ENRMMarkdownParser alloc] init];
     _md4cFlags = [ENRMMd4cFlags defaultFlags];
     _segmentViews = [NSMutableArray array];
+    _segmentSignatures = [NSMutableArray array];
+    _forceRecreateSegments = NO;
+    _forceHeightUpdateOnNextRender = NO;
+    _heightUpdateScheduled = NO;
+    [self configureSegmentViewRegistry];
 
     _renderQueue = dispatch_queue_create("com.swmansion.enriched.markdown.container.render", DISPATCH_QUEUE_SERIAL);
     _currentRenderId = 0;
@@ -145,6 +120,7 @@ using namespace facebook::react;
     _allowTrailingMargin = NO;
     _selectable = YES;
     _enableLinkPreview = YES;
+    _streamingAnimation = NO;
 
     _fontScaleObserver = [[FontScaleObserver alloc] init];
     __weak EnrichedMarkdown *weakSelf = self;
@@ -156,11 +132,89 @@ using namespace facebook::react;
         [strongSelf->_config setFontScaleMultiplier:strongSelf->_fontScaleObserver.effectiveFontScale];
       }
       if (strongSelf->_cachedMarkdown != nil && strongSelf->_cachedMarkdown.length > 0) {
+        strongSelf->_forceRecreateSegments = YES;
+        strongSelf->_forceHeightUpdateOnNextRender = YES;
         [strongSelf renderMarkdownContent:strongSelf->_cachedMarkdown];
       }
     };
   }
   return self;
+}
+
+- (void)configureSegmentViewRegistry
+{
+  __weak EnrichedMarkdown *weakSelf = self;
+  NSMutableArray<ENRMSegmentViewHandler *> *handlers = [NSMutableArray array];
+
+  [handlers addObject:[ENRMSegmentViewHandler handlerWithKind:ENRMSegmentKindText
+                          matchesView:^BOOL(RCTUIView *view, ENRMRenderedSegment *segment) {
+                            return [view isKindOfClass:[EnrichedMarkdownInternalText class]];
+                          }
+                          createView:^RCTUIView *(ENRMRenderedSegment *segment, BOOL animateIfStreaming) {
+                            EnrichedMarkdown *strongSelf = weakSelf;
+                            if (!strongSelf) {
+                              return [[RCTUIView alloc] init];
+                            }
+
+                            EnrichedMarkdownInternalText *view =
+                                [strongSelf createTextViewForRenderedSegment:segment.textResult];
+                            if (animateIfStreaming) {
+                              [strongSelf animateTextView:view fromTailStart:0];
+                            }
+                            return view;
+                          }
+                          updateView:^(RCTUIView *view, ENRMRenderedSegment *segment) {
+                            EnrichedMarkdown *strongSelf = weakSelf;
+                            if (strongSelf) {
+                              [strongSelf updateTextView:(EnrichedMarkdownInternalText *)view
+                                     withRenderedSegment:segment.textResult];
+                            }
+                          }]];
+
+  [handlers addObject:[ENRMSegmentViewHandler handlerWithKind:ENRMSegmentKindTable
+                          matchesView:^BOOL(RCTUIView *view, ENRMRenderedSegment *segment) {
+                            return [view isKindOfClass:[TableContainerView class]];
+                          }
+                          createView:^RCTUIView *(ENRMRenderedSegment *segment, BOOL animateIfStreaming) {
+                            EnrichedMarkdown *strongSelf = weakSelf;
+                            if (!strongSelf) {
+                              return [[RCTUIView alloc] init];
+                            }
+
+                            TableContainerView *view = [strongSelf createTableViewForSegment:segment.tableSegment];
+                            if (animateIfStreaming) {
+                              [strongSelf animateBlockViewIfNeeded:view];
+                            }
+                            return view;
+                          }
+                          updateView:^(RCTUIView *view, ENRMRenderedSegment *segment) {
+                            [(TableContainerView *)view applyTableNode:segment.tableSegment.tableNode];
+                          }]];
+
+#if ENRICHED_MARKDOWN_MATH
+  [handlers addObject:[ENRMSegmentViewHandler handlerWithKind:ENRMSegmentKindMath
+                          matchesView:^BOOL(RCTUIView *view, ENRMRenderedSegment *segment) {
+                            return [view isKindOfClass:[ENRMMathContainerView class]];
+                          }
+                          createView:^RCTUIView *(ENRMRenderedSegment *segment, BOOL animateIfStreaming) {
+                            EnrichedMarkdown *strongSelf = weakSelf;
+                            if (!strongSelf) {
+                              return [[RCTUIView alloc] init];
+                            }
+
+                            ENRMMathContainerView *view =
+                                [strongSelf createMathViewForSegment:(ENRMMathSegment *)segment.mathSegment];
+                            if (animateIfStreaming) {
+                              [strongSelf animateBlockViewIfNeeded:view];
+                            }
+                            return view;
+                          }
+                          updateView:^(RCTUIView *view, ENRMRenderedSegment *segment) {
+                            [(ENRMMathContainerView *)view applyLatex:((ENRMMathSegment *)segment.mathSegment).latex];
+                          }]];
+#endif
+
+  _segmentViewRegistry = [[ENRMSegmentViewRegistry alloc] initWithHandlers:handlers];
 }
 
 - (CGSize)computeSegmentLayoutForWidth:(CGFloat)width applyFrames:(BOOL)applyFrames
@@ -266,46 +320,30 @@ using namespace facebook::react;
   _state->updateState(EnrichedMarkdownState(_heightUpdateCounter, selfRef));
 }
 
-- (NSArray *)splitASTIntoSegments:(MarkdownASTNode *)root
+- (void)scheduleStreamingHeightUpdate
 {
-  NSMutableArray *segments = [NSMutableArray array];
-  NSMutableArray *currentTextNodes = [NSMutableArray array];
-
-  for (MarkdownASTNode *child in root.children) {
-    if (child.type == MarkdownNodeTypeTable) {
-      if (currentTextNodes.count > 0) {
-        [segments addObject:[EMTextSegment segmentWithNodes:[currentTextNodes copy]]];
-        [currentTextNodes removeAllObjects];
-      }
-      [segments addObject:[EMTableSegment segmentWithTableNode:child]];
-    }
-#if ENRICHED_MARKDOWN_MATH
-    else if (child.type == MarkdownNodeTypeLatexMathDisplay) {
-#if !TARGET_OS_OSX
-      if (currentTextNodes.count > 0) {
-        [segments addObject:[EMTextSegment segmentWithNodes:[currentTextNodes copy]]];
-        [currentTextNodes removeAllObjects];
-      }
-      NSString *latex = child.children.count > 0 ? child.children.firstObject.content : child.content;
-      [segments addObject:[EMMathSegment segmentWithLatex:latex ?: @""]];
-#else
-      // TODO: Fix block math rendering on macOS. Adding ENRMMathContainerView (which
-      // hosts MTMathUILabel) as a segment causes all preceding text segments to become
-      // invisible. Likely related to MTMathUILabel.layer.geometryFlipped interacting
-      // with NSTextView's coordinate system. Inline math ($...$) works.
-#endif
-    }
-#endif
-    else {
-      [currentTextNodes addObject:child];
-    }
+  if (_heightUpdateScheduled) {
+    return;
   }
 
-  if (currentTextNodes.count > 0) {
-    [segments addObject:[EMTextSegment segmentWithNodes:currentTextNodes]];
-  }
+  _heightUpdateScheduled = YES;
+  __weak EnrichedMarkdown *weakSelf = self;
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.12 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    EnrichedMarkdown *strongSelf = weakSelf;
+    if (!strongSelf) {
+      return;
+    }
 
-  return segments;
+    strongSelf->_heightUpdateScheduled = NO;
+    if (strongSelf.bounds.size.width <= 0) {
+      return;
+    }
+
+    CGSize measured = [strongSelf measureSize:strongSelf.bounds.size.width];
+    if (needsHeightUpdate(measured, strongSelf.bounds)) {
+      [strongSelf requestHeightUpdate];
+    }
+  });
 }
 
 - (void)renderMarkdownContent:(NSString *)markdownString
@@ -324,41 +362,34 @@ using namespace facebook::react;
   BOOL allowFontScaling = _fontScaleObserver.allowFontScaling;
   CGFloat maxFontSizeMultiplier = _maxFontSizeMultiplier;
   BOOL allowTrailingMargin = _allowTrailingMargin;
+  BOOL streamingAnimation = _streamingAnimation;
 
   dispatch_async(_renderQueue, ^{
-    MarkdownASTNode *ast = [parser parseMarkdown:markdownString flags:md4cFlags];
+    NSString *renderableMarkdown =
+        streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString) : markdownString;
+    if (renderableMarkdown.length == 0) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (renderId == self->_currentRenderId) {
+          [self applyRenderedSegments:@[] renderedMarkdown:renderableMarkdown];
+        }
+      });
+      return;
+    }
+
+    MarkdownASTNode *ast = [parser parseMarkdown:renderableMarkdown flags:md4cFlags];
     if (!ast) {
       return;
     }
 
-    NSArray *segments = [self splitASTIntoSegments:ast];
-
-    NSMutableArray *renderedSegments = [NSMutableArray array];
-
-    for (id segment in segments) {
-      if ([segment isKindOfClass:[EMTextSegment class]]) {
-        ENRMRenderResult *rendered = [self renderTextSegment:(EMTextSegment *)segment
-                                                      config:config
-                                         allowTrailingMargin:allowTrailingMargin
-                                            allowFontScaling:allowFontScaling
-                                       maxFontSizeMultiplier:maxFontSizeMultiplier];
-        [renderedSegments addObject:rendered];
-      } else if ([segment isKindOfClass:[EMTableSegment class]]) {
-        [renderedSegments addObject:segment];
-      }
-#if ENRICHED_MARKDOWN_MATH
-      else if ([segment isKindOfClass:[EMMathSegment class]]) {
-        [renderedSegments addObject:segment];
-      }
-#endif
-    }
+    NSArray<ENRMRenderedSegment *> *renderedSegments =
+        ENRMRenderSegmentsFromAST(ast, config, allowTrailingMargin, allowFontScaling, maxFontSizeMultiplier);
 
     dispatch_async(dispatch_get_main_queue(), ^{
       if (renderId != self->_currentRenderId) {
         return;
       }
 
-      [self applyRenderedSegments:renderedSegments];
+      [self applyRenderedSegments:renderedSegments renderedMarkdown:renderableMarkdown];
     });
   });
 }
@@ -370,28 +401,8 @@ using namespace facebook::react;
     return nil;
   }
 
-  NSArray *segments = [self splitASTIntoSegments:ast];
-  NSMutableArray *renderedSegments = [NSMutableArray array];
-
-  for (id segment in segments) {
-    if ([segment isKindOfClass:[EMTextSegment class]]) {
-      ENRMRenderResult *rendered = [self renderTextSegment:(EMTextSegment *)segment
-                                                    config:_config
-                                       allowTrailingMargin:_allowTrailingMargin
-                                          allowFontScaling:_fontScaleObserver.allowFontScaling
-                                     maxFontSizeMultiplier:_maxFontSizeMultiplier];
-      [renderedSegments addObject:rendered];
-    } else if ([segment isKindOfClass:[EMTableSegment class]]) {
-      [renderedSegments addObject:segment];
-    }
-#if ENRICHED_MARKDOWN_MATH
-    else if ([segment isKindOfClass:[EMMathSegment class]]) {
-      [renderedSegments addObject:segment];
-    }
-#endif
-  }
-
-  return renderedSegments;
+  return ENRMRenderSegmentsFromAST(ast, _config, _allowTrailingMargin, _fontScaleObserver.allowFontScaling,
+                                   _maxFontSizeMultiplier);
 }
 
 /// Synchronous rendering for mock view measurement (no UI updates needed).
@@ -405,89 +416,77 @@ using namespace facebook::react;
     [view removeFromSuperview];
   }
   [_segmentViews removeAllObjects];
+  [_segmentSignatures removeAllObjects];
 
   _blockAsyncRender = YES;
   _cachedMarkdown = [markdownString copy];
-  _renderedMarkdown = [markdownString copy];
+  NSString *renderableMarkdown =
+      _streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString) : markdownString;
+  _renderedMarkdown = [renderableMarkdown copy];
 
-  NSArray *renderedSegments = [self parseAndRenderSegments:markdownString];
+  if (renderableMarkdown.length == 0) {
+    return;
+  }
+
+  NSArray *renderedSegments = [self parseAndRenderSegments:renderableMarkdown];
   if (!renderedSegments) {
     return;
   }
 
-  for (id segment in renderedSegments) {
-    if ([segment isKindOfClass:[ENRMRenderResult class]]) {
-      EnrichedMarkdownInternalText *view = [self createTextViewForRenderedSegment:(ENRMRenderResult *)segment];
-      [_segmentViews addObject:view];
-      [self addSubview:view];
-    } else if ([segment isKindOfClass:[EMTableSegment class]]) {
-      TableContainerView *tableView = [self createTableViewForSegment:(EMTableSegment *)segment];
-      [_segmentViews addObject:tableView];
-      [self addSubview:tableView];
-    }
-#if ENRICHED_MARKDOWN_MATH
-    else if ([segment isKindOfClass:[EMMathSegment class]]) {
-      ENRMMathContainerView *mathView = [self createMathViewForSegment:(EMMathSegment *)segment];
-      [_segmentViews addObject:mathView];
-      [self addSubview:mathView];
-    }
-#endif
+  for (ENRMRenderedSegment *segment in renderedSegments) {
+    RCTUIView *view = [_segmentViewRegistry createViewForSegment:segment animateIfStreaming:NO];
+    [_segmentViews addObject:view];
+    [_segmentSignatures addObject:segment.signature ?: @""];
+    [self addSubview:view];
   }
 }
 
-- (void)applyRenderedSegments:(NSArray *)renderedSegments
+- (void)applyRenderedSegments:(NSArray *)renderedSegments renderedMarkdown:(NSString *)renderedMarkdown
 {
-  _renderedMarkdown = [_cachedMarkdown copy];
+  _renderedMarkdown = [renderedMarkdown copy];
 
-  for (RCTUIView *view in _segmentViews) {
-    [view removeFromSuperview];
-  }
-  [_segmentViews removeAllObjects];
+  ENRMSegmentReconciliationResult *result = [ENRMSegmentReconciler reconcileCurrentViews:_segmentViews
+      currentSignatures:_segmentSignatures
+      renderedSegments:renderedSegments
+      reset:_forceRecreateSegments
+      createView:^RCTUIView *(ENRMRenderedSegment *segment) {
+        return [self->_segmentViewRegistry createViewForSegment:segment animateIfStreaming:YES];
+      }
+      updateView:^(RCTUIView *view, ENRMRenderedSegment *segment) {
+        [self->_segmentViewRegistry updateView:view withSegment:segment];
+      }
+      attachView:^(RCTUIView *view) { [self addSubview:view]; }
+      removeView:^(RCTUIView *view) { [view removeFromSuperview]; }
+      matchesKind:^BOOL(RCTUIView *view, ENRMRenderedSegment *segment) {
+        return [self->_segmentViewRegistry view:view matchesSegment:segment];
+      }];
+  _forceRecreateSegments = NO;
 
-  for (id segment in renderedSegments) {
-    if ([segment isKindOfClass:[ENRMRenderResult class]]) {
-      EnrichedMarkdownInternalText *view = [self createTextViewForRenderedSegment:(ENRMRenderResult *)segment];
-      [_segmentViews addObject:view];
-      [self addSubview:view];
-    } else if ([segment isKindOfClass:[EMTableSegment class]]) {
-      EMTableSegment *tableSegment = (EMTableSegment *)segment;
-      TableContainerView *tableView = [self createTableViewForSegment:tableSegment];
-      [_segmentViews addObject:tableView];
-      [self addSubview:tableView];
-    }
-#if ENRICHED_MARKDOWN_MATH
-    else if ([segment isKindOfClass:[EMMathSegment class]]) {
-      EMMathSegment *mathSegment = (EMMathSegment *)segment;
-      ENRMMathContainerView *mathView = [self createMathViewForSegment:mathSegment];
-      [_segmentViews addObject:mathView];
-      [self addSubview:mathView];
-    }
-#endif
-  }
+  _segmentViews = result.views;
+  _segmentSignatures = result.signatures;
 
   if (self.bounds.size.width > 0) {
+    // Some prop changes recreate identical-looking segments but still change
+    // Yoga height. Request one update instead of relying on size diffing.
+    BOOL forceHeightUpdate = _forceHeightUpdateOnNextRender;
+    _forceHeightUpdateOnNextRender = NO;
     [self setNeedsLayout];
 
-    CGSize measured = [self measureSize:self.bounds.size.width];
-    if (needsHeightUpdate(measured, self.bounds)) {
+    if (forceHeightUpdate) {
       [self requestHeightUpdate];
+    } else if (_streamingAnimation) {
+      [self scheduleStreamingHeightUpdate];
+    } else {
+      CGSize measured = [self measureSize:self.bounds.size.width];
+      if (needsHeightUpdate(measured, self.bounds)) {
+        [self requestHeightUpdate];
+      }
     }
   }
 }
 
-- (ENRMRenderResult *)renderTextSegment:(EMTextSegment *)textSegment
-                                 config:(StyleConfig *)config
-                    allowTrailingMargin:(BOOL)allowTrailingMargin
-                       allowFontScaling:(BOOL)allowFontScaling
-                  maxFontSizeMultiplier:(CGFloat)maxFontSizeMultiplier
+- (void)configureTextView:(EnrichedMarkdownInternalText *)view withRenderedSegment:(ENRMRenderResult *)segment
 {
-  return ENRMRenderASTNodes(textSegment.nodes, config, allowTrailingMargin, allowFontScaling, maxFontSizeMultiplier,
-                            currentWritingDirection());
-}
-
-- (EnrichedMarkdownInternalText *)createTextViewForRenderedSegment:(ENRMRenderResult *)segment
-{
-  EnrichedMarkdownInternalText *view = [[EnrichedMarkdownInternalText alloc] initWithConfig:_config];
   view.spoilerOverlay = _spoilerOverlay;
   view.allowTrailingMargin = _allowTrailingMargin;
   view.lastElementMarginBottom = segment.lastElementMarginBottom;
@@ -497,6 +496,12 @@ using namespace facebook::react;
 
   const auto &selectionProps = *std::static_pointer_cast<EnrichedMarkdownProps const>(self->_props);
   ENRMApplySelectionColor(view.textView, selectionProps.selectionColor);
+}
+
+- (EnrichedMarkdownInternalText *)createTextViewForRenderedSegment:(ENRMRenderResult *)segment
+{
+  EnrichedMarkdownInternalText *view = [[EnrichedMarkdownInternalText alloc] initWithConfig:_config];
+  [self configureTextView:view withRenderedSegment:segment];
 
   ENRMTapRecognizer *tapRecognizer = [[ENRMTapRecognizer alloc] initWithTarget:self action:@selector(textTapped:)];
   [view.textView addGestureRecognizer:tapRecognizer];
@@ -532,7 +537,7 @@ using namespace facebook::react;
   return view;
 }
 
-- (TableContainerView *)createTableViewForSegment:(EMTableSegment *)tableSegment
+- (TableContainerView *)createTableViewForSegment:(ENRMTableSegment *)tableSegment
 {
   TableContainerView *tableView = [[TableContainerView alloc] initWithConfig:_config];
 
@@ -570,13 +575,45 @@ using namespace facebook::react;
 }
 
 #if ENRICHED_MARKDOWN_MATH
-- (ENRMMathContainerView *)createMathViewForSegment:(EMMathSegment *)mathSegment
+- (ENRMMathContainerView *)createMathViewForSegment:(ENRMMathSegment *)mathSegment
 {
   ENRMMathContainerView *mathView = [[ENRMMathContainerView alloc] initWithConfig:_config];
   [mathView applyLatex:mathSegment.latex];
   return mathView;
 }
 #endif
+
+- (void)animateBlockViewIfNeeded:(RCTUIView *)view
+{
+  if (!_streamingAnimation)
+    return;
+
+#if !TARGET_OS_OSX
+  view.alpha = 0.0;
+  [UIView animateWithDuration:0.20 animations:^{ view.alpha = 1.0; }];
+#endif
+}
+
+- (void)animateTextView:(EnrichedMarkdownInternalText *)view fromTailStart:(NSUInteger)tailStart
+{
+  if (!_streamingAnimation)
+    return;
+
+  ENRMTailFadeInAnimator *animator = objc_getAssociatedObject(view.textView, &kENRMSegmentFadeAnimatorKey);
+  if (!animator) {
+    animator = [[ENRMTailFadeInAnimator alloc] initWithTextView:view.textView];
+    objc_setAssociatedObject(view.textView, &kENRMSegmentFadeAnimatorKey, animator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+  }
+
+  [animator animateFrom:tailStart to:ENRMGetAttributedText(view.textView).length];
+}
+
+- (void)updateTextView:(EnrichedMarkdownInternalText *)view withRenderedSegment:(ENRMRenderResult *)segment
+{
+  NSUInteger tailStart = ENRMGetAttributedText(view.textView).length;
+  [self configureTextView:view withRenderedSegment:segment];
+  [self animateTextView:view fromTailStart:tailStart];
+}
 
 - (void)layoutSubviews
 {
@@ -590,6 +627,7 @@ using namespace facebook::react;
   const auto &newViewProps = *std::static_pointer_cast<EnrichedMarkdownProps const>(props);
 
   BOOL stylePropChanged = NO;
+  BOOL markdownChanged = oldViewProps.markdown != newViewProps.markdown;
 
   if (_config == nil) {
     _config = [[StyleConfig alloc] init];
@@ -600,6 +638,10 @@ using namespace facebook::react;
 
   if (stylePropChanged) {
     [ENRMImageAttachment clearAttachmentRegistry];
+    _forceHeightUpdateOnNextRender = YES;
+    if (!markdownChanged) {
+      _forceRecreateSegments = YES;
+    }
   }
 
   _selectable = newViewProps.selectable;
@@ -619,6 +661,8 @@ using namespace facebook::react;
       [_config setFontScaleMultiplier:_fontScaleObserver.effectiveFontScale];
     }
     stylePropChanged = YES;
+    _forceRecreateSegments = YES;
+    _forceHeightUpdateOnNextRender = YES;
   }
 
   if (newViewProps.maxFontSizeMultiplier != oldViewProps.maxFontSizeMultiplier) {
@@ -627,25 +671,47 @@ using namespace facebook::react;
       [_config setMaxFontSizeMultiplier:_maxFontSizeMultiplier];
     }
     stylePropChanged = YES;
+    _forceRecreateSegments = YES;
+    _forceHeightUpdateOnNextRender = YES;
   }
 
   if (newViewProps.allowTrailingMargin != oldViewProps.allowTrailingMargin) {
     _allowTrailingMargin = newViewProps.allowTrailingMargin;
+    _forceRecreateSegments = YES;
+    _forceHeightUpdateOnNextRender = YES;
   }
 
   BOOL md4cFlagsChanged = NO;
   if (newViewProps.md4cFlags.underline != oldViewProps.md4cFlags.underline) {
     _md4cFlags.underline = newViewProps.md4cFlags.underline;
     md4cFlagsChanged = YES;
+    _forceHeightUpdateOnNextRender = YES;
   }
   if (newViewProps.md4cFlags.latexMath != oldViewProps.md4cFlags.latexMath) {
     _md4cFlags.latexMath = newViewProps.md4cFlags.latexMath;
     md4cFlagsChanged = YES;
+    _forceHeightUpdateOnNextRender = YES;
   }
-  BOOL markdownChanged = oldViewProps.markdown != newViewProps.markdown;
   BOOL allowTrailingMarginChanged = newViewProps.allowTrailingMargin != oldViewProps.allowTrailingMargin;
 
   _enableLinkPreview = newViewProps.enableLinkPreview;
+
+  BOOL streamingAnimationChanged = newViewProps.streamingAnimation != oldViewProps.streamingAnimation;
+  if (streamingAnimationChanged) {
+    _streamingAnimation = newViewProps.streamingAnimation;
+    _forceHeightUpdateOnNextRender = YES;
+    if (!_streamingAnimation) {
+      for (RCTUIView *segment in _segmentViews) {
+        if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
+          ENRMTailFadeInAnimator *animator = objc_getAssociatedObject(
+              ((EnrichedMarkdownInternalText *)segment).textView, &kENRMSegmentFadeAnimatorKey);
+          [animator cancel];
+          objc_setAssociatedObject(((EnrichedMarkdownInternalText *)segment).textView, &kENRMSegmentFadeAnimatorKey,
+                                   nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+      }
+    }
+  }
 
   if (ENRMContextMenuItemsChanged(oldViewProps.contextMenuItems, newViewProps.contextMenuItems)) {
     _contextMenuItemTexts = ENRMContextMenuTextsFromItems(newViewProps.contextMenuItems);
@@ -671,7 +737,8 @@ using namespace facebook::react;
     }
   }
 
-  if (markdownChanged || stylePropChanged || md4cFlagsChanged || allowTrailingMarginChanged) {
+  if (markdownChanged || stylePropChanged || md4cFlagsChanged || allowTrailingMarginChanged ||
+      streamingAnimationChanged) {
     NSString *markdownString = [[NSString alloc] initWithUTF8String:newViewProps.markdown.c_str()];
     [self renderMarkdownContent:markdownString];
   }

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -9,7 +9,6 @@
 #import "EditMenuUtils.h"
 
 #import "ENRMFeatureFlags.h"
-#import "ENRMUIKit.h"
 
 #if ENRICHED_MARKDOWN_MATH
 #import "ENRMMathContainerView.h"
@@ -89,6 +88,7 @@ static char kENRMSegmentFadeAnimatorKey;
   BOOL _selectable;
   BOOL _enableLinkPreview;
   BOOL _streamingAnimation;
+  ENRMTableStreamingMode _tableStreamingMode;
 
   NSArray<NSString *> *_contextMenuItemTexts;
   NSArray<NSString *> *_contextMenuItemIcons;
@@ -123,6 +123,7 @@ static char kENRMSegmentFadeAnimatorKey;
     _selectable = YES;
     _enableLinkPreview = YES;
     _streamingAnimation = NO;
+    _tableStreamingMode = ENRMTableStreamingModeHidden;
 
     _fontScaleObserver = [[FontScaleObserver alloc] init];
     __weak EnrichedMarkdown *weakSelf = self;
@@ -185,7 +186,10 @@ static char kENRMSegmentFadeAnimatorKey;
                             return view;
                           }
                           updateView:^(RCTUIView *view, ENRMRenderedSegment *segment) {
-                            [(TableContainerView *)view applyTableNode:segment.tableSegment.tableNode];
+                            EnrichedMarkdown *strongSelf = weakSelf;
+                            if (strongSelf) {
+                              [strongSelf updateTableView:(TableContainerView *)view withSegment:segment.tableSegment];
+                            }
                           }]];
 
 #if ENRICHED_MARKDOWN_MATH
@@ -347,10 +351,11 @@ static char kENRMSegmentFadeAnimatorKey;
   CGFloat maxFontSizeMultiplier = _maxFontSizeMultiplier;
   BOOL allowTrailingMargin = _allowTrailingMargin;
   BOOL streamingAnimation = _streamingAnimation;
+  ENRMTableStreamingMode tableStreamingMode = _tableStreamingMode;
 
   dispatch_async(_renderQueue, ^{
     NSString *renderableMarkdown =
-        streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString) : markdownString;
+        streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString, tableStreamingMode) : markdownString;
     if (renderableMarkdown.length == 0) {
       dispatch_async(dispatch_get_main_queue(), ^{
         if (renderId == self->_currentRenderId) {
@@ -405,7 +410,7 @@ static char kENRMSegmentFadeAnimatorKey;
   _blockAsyncRender = YES;
   _cachedMarkdown = [markdownString copy];
   NSString *renderableMarkdown =
-      _streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString) : markdownString;
+      _streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString, _tableStreamingMode) : markdownString;
   _renderedMarkdown = [renderableMarkdown copy];
 
   if (renderableMarkdown.length == 0) {
@@ -458,11 +463,6 @@ static char kENRMSegmentFadeAnimatorKey;
       [self computeSegmentLayoutForWidth:self.bounds.size.width applyFrames:YES];
       [self layoutIfNeeded];
       [self requestHeightUpdate];
-    } else if (_streamingAnimation) {
-      CGSize measured = [self measureSize:self.bounds.size.width];
-      if (needsHeightUpdate(measured, self.bounds)) {
-        [self requestHeightUpdate];
-      }
     } else {
       CGSize measured = [self measureSize:self.bounds.size.width];
       if (needsHeightUpdate(measured, self.bounds)) {
@@ -559,6 +559,39 @@ static char kENRMSegmentFadeAnimatorKey;
   [tableView applyTableNode:tableSegment.tableNode];
 
   return tableView;
+}
+
+- (void)updateTableView:(TableContainerView *)view withSegment:(ENRMTableSegment *)tableSegment
+{
+  NSUInteger previousRowCount = view.rowCount;
+  [view applyTableNode:tableSegment.tableNode];
+
+#if !TARGET_OS_OSX
+  if (!_streamingAnimation || view.rowCount <= previousRowCount) {
+    return;
+  }
+
+  // The grid container is inside the scroll view: TableContainerView > UIScrollView > gridContainer.
+  // After applyTableNode:, cells are laid out sequentially — each row has colCount cell-background subviews.
+  RCTUIView *scrollView = view.subviews.firstObject;
+  RCTUIView *gridContainer = scrollView.subviews.firstObject;
+  if (!gridContainer || gridContainer.subviews.count == 0 || view.rowCount == 0) {
+    return;
+  }
+
+  NSUInteger colCount = gridContainer.subviews.count / view.rowCount;
+  if (colCount == 0) {
+    return;
+  }
+
+  NSUInteger firstNewCellIndex = previousRowCount * colCount;
+  NSArray<RCTUIView *> *subviews = gridContainer.subviews;
+  for (NSUInteger i = firstNewCellIndex; i < subviews.count; i++) {
+    RCTUIView *cellView = subviews[i];
+    cellView.alpha = 0.0;
+    [UIView animateWithDuration:0.20 animations:^{ cellView.alpha = 1.0; }];
+  }
+#endif
 }
 
 #if ENRICHED_MARKDOWN_MATH
@@ -697,6 +730,15 @@ static char kENRMSegmentFadeAnimatorKey;
     }
   }
 
+  BOOL streamingConfigChanged = NO;
+  if (newViewProps.streamingConfig.tableMode != oldViewProps.streamingConfig.tableMode) {
+    NSString *tableModeStr = [[NSString alloc] initWithUTF8String:newViewProps.streamingConfig.tableMode.c_str()];
+    _tableStreamingMode = [tableModeStr isEqualToString:@"progressive"] ? ENRMTableStreamingModeProgressive
+                                                                        : ENRMTableStreamingModeHidden;
+    streamingConfigChanged = YES;
+    _dirtyFlags |= ENRMDirtyForceHeight;
+  }
+
   if (ENRMContextMenuItemsChanged(oldViewProps.contextMenuItems, newViewProps.contextMenuItems)) {
     _contextMenuItemTexts = ENRMContextMenuTextsFromItems(newViewProps.contextMenuItems);
     _contextMenuItemIcons = ENRMContextMenuIconsFromItems(newViewProps.contextMenuItems);
@@ -722,7 +764,7 @@ static char kENRMSegmentFadeAnimatorKey;
   }
 
   if (markdownChanged || stylePropChanged || md4cFlagsChanged || allowTrailingMarginChanged ||
-      streamingAnimationChanged) {
+      streamingAnimationChanged || streamingConfigChanged) {
     NSString *markdownString = [[NSString alloc] initWithUTF8String:newViewProps.markdown.c_str()];
     [self renderMarkdownContent:markdownString];
   }

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -53,6 +53,12 @@
 
 using namespace facebook::react;
 
+typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
+  ENRMDirtyNone = 0,
+  ENRMDirtyRecreateSegments = 1 << 0,
+  ENRMDirtyForceHeight = 1 << 1,
+};
+
 static char kENRMSegmentFadeAnimatorKey;
 
 @interface EnrichedMarkdown () <RCTEnrichedMarkdownViewProtocol, UITextViewDelegate>
@@ -67,8 +73,7 @@ static char kENRMSegmentFadeAnimatorKey;
   NSMutableArray<RCTUIView *> *_segmentViews;
   NSMutableArray<NSNumber *> *_segmentSignatures;
   ENRMSegmentViewRegistry *_segmentViewRegistry;
-  BOOL _forceRecreateSegments;
-  BOOL _forceHeightUpdateOnNextRender;
+  ENRMDirtyFlags _dirtyFlags;
 
   dispatch_queue_t _renderQueue;
   NSUInteger _currentRenderId;
@@ -107,8 +112,7 @@ static char kENRMSegmentFadeAnimatorKey;
     _md4cFlags = [ENRMMd4cFlags defaultFlags];
     _segmentViews = [NSMutableArray array];
     _segmentSignatures = [NSMutableArray array];
-    _forceRecreateSegments = NO;
-    _forceHeightUpdateOnNextRender = NO;
+    _dirtyFlags = ENRMDirtyNone;
     [self configureSegmentViewRegistry];
 
     _renderQueue = dispatch_queue_create("com.swmansion.enriched.markdown.container.render", DISPATCH_QUEUE_SERIAL);
@@ -130,8 +134,7 @@ static char kENRMSegmentFadeAnimatorKey;
         [strongSelf->_config setFontScaleMultiplier:strongSelf->_fontScaleObserver.effectiveFontScale];
       }
       if (strongSelf->_cachedMarkdown != nil && strongSelf->_cachedMarkdown.length > 0) {
-        strongSelf->_forceRecreateSegments = YES;
-        strongSelf->_forceHeightUpdateOnNextRender = YES;
+        strongSelf->_dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight;
         [strongSelf renderMarkdownContent:strongSelf->_cachedMarkdown];
       }
     };
@@ -148,7 +151,7 @@ static char kENRMSegmentFadeAnimatorKey;
                           matchesView:^BOOL(RCTUIView *view, ENRMRenderedSegment *segment) {
                             return [view isKindOfClass:[EnrichedMarkdownInternalText class]];
                           }
-                          createView:^RCTUIView *(ENRMRenderedSegment *segment, BOOL animateIfStreaming) {
+                          createView:^RCTUIView *(ENRMRenderedSegment *segment) {
                             EnrichedMarkdown *strongSelf = weakSelf;
                             if (!strongSelf) {
                               return [[RCTUIView alloc] init];
@@ -156,9 +159,7 @@ static char kENRMSegmentFadeAnimatorKey;
 
                             EnrichedMarkdownInternalText *view =
                                 [strongSelf createTextViewForRenderedSegment:segment.textResult];
-                            if (animateIfStreaming) {
-                              [strongSelf animateTextView:view fromTailStart:0];
-                            }
+                            [strongSelf animateTextView:view fromTailStart:0];
                             return view;
                           }
                           updateView:^(RCTUIView *view, ENRMRenderedSegment *segment) {
@@ -173,16 +174,14 @@ static char kENRMSegmentFadeAnimatorKey;
                           matchesView:^BOOL(RCTUIView *view, ENRMRenderedSegment *segment) {
                             return [view isKindOfClass:[TableContainerView class]];
                           }
-                          createView:^RCTUIView *(ENRMRenderedSegment *segment, BOOL animateIfStreaming) {
+                          createView:^RCTUIView *(ENRMRenderedSegment *segment) {
                             EnrichedMarkdown *strongSelf = weakSelf;
                             if (!strongSelf) {
                               return [[RCTUIView alloc] init];
                             }
 
                             TableContainerView *view = [strongSelf createTableViewForSegment:segment.tableSegment];
-                            if (animateIfStreaming) {
-                              [strongSelf animateBlockViewIfNeeded:view];
-                            }
+                            [strongSelf animateBlockViewIfNeeded:view];
                             return view;
                           }
                           updateView:^(RCTUIView *view, ENRMRenderedSegment *segment) {
@@ -194,7 +193,7 @@ static char kENRMSegmentFadeAnimatorKey;
                           matchesView:^BOOL(RCTUIView *view, ENRMRenderedSegment *segment) {
                             return [view isKindOfClass:[ENRMMathContainerView class]];
                           }
-                          createView:^RCTUIView *(ENRMRenderedSegment *segment, BOOL animateIfStreaming) {
+                          createView:^RCTUIView *(ENRMRenderedSegment *segment) {
                             EnrichedMarkdown *strongSelf = weakSelf;
                             if (!strongSelf) {
                               return [[RCTUIView alloc] init];
@@ -202,9 +201,7 @@ static char kENRMSegmentFadeAnimatorKey;
 
                             ENRMMathContainerView *view =
                                 [strongSelf createMathViewForSegment:(ENRMMathSegment *)segment.mathSegment];
-                            if (animateIfStreaming) {
-                              [strongSelf animateBlockViewIfNeeded:view];
-                            }
+                            [strongSelf animateBlockViewIfNeeded:view];
                             return view;
                           }
                           updateView:^(RCTUIView *view, ENRMRenderedSegment *segment) {
@@ -421,7 +418,7 @@ static char kENRMSegmentFadeAnimatorKey;
   }
 
   for (ENRMRenderedSegment *segment in renderedSegments) {
-    RCTUIView *view = [_segmentViewRegistry createViewForSegment:segment animateIfStreaming:NO];
+    RCTUIView *view = [_segmentViewRegistry createViewForSegment:segment];
     [_segmentViews addObject:view];
     [_segmentSignatures addObject:@(segment.signature)];
     [self addSubview:view];
@@ -436,9 +433,9 @@ static char kENRMSegmentFadeAnimatorKey;
   ENRMSegmentReconciliationResult *result = [ENRMSegmentReconciler reconcileCurrentViews:_segmentViews
       currentSignatures:_segmentSignatures
       renderedSegments:renderedSegments
-      reset:_forceRecreateSegments
+      reset:(_dirtyFlags & ENRMDirtyRecreateSegments) != 0
       createView:^RCTUIView *(ENRMRenderedSegment *segment) {
-        return [self->_segmentViewRegistry createViewForSegment:segment animateIfStreaming:YES];
+        return [self->_segmentViewRegistry createViewForSegment:segment];
       }
       updateView:^(RCTUIView *view, ENRMRenderedSegment *segment) {
         [self->_segmentViewRegistry updateView:view withSegment:segment];
@@ -448,16 +445,13 @@ static char kENRMSegmentFadeAnimatorKey;
       matchesKind:^BOOL(RCTUIView *view, ENRMRenderedSegment *segment) {
         return [self->_segmentViewRegistry view:view matchesSegment:segment];
       }];
-  _forceRecreateSegments = NO;
+  BOOL forceHeightUpdate = (_dirtyFlags & ENRMDirtyForceHeight) != 0;
+  _dirtyFlags = ENRMDirtyNone;
 
   _segmentViews = result.views;
   _segmentSignatures = result.signatures;
 
   if (self.bounds.size.width > 0) {
-    // Some prop changes recreate identical-looking segments but still change
-    // Yoga height. Request one update instead of relying on size diffing.
-    BOOL forceHeightUpdate = _forceHeightUpdateOnNextRender;
-    _forceHeightUpdateOnNextRender = NO;
     [self setNeedsLayout];
 
     if (forceHeightUpdate || segmentTopologyChanged) {
@@ -631,9 +625,9 @@ static char kENRMSegmentFadeAnimatorKey;
 
   if (stylePropChanged) {
     [ENRMImageAttachment clearAttachmentRegistry];
-    _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyForceHeight;
     if (!markdownChanged) {
-      _forceRecreateSegments = YES;
+      _dirtyFlags |= ENRMDirtyRecreateSegments;
     }
   }
 
@@ -654,8 +648,7 @@ static char kENRMSegmentFadeAnimatorKey;
       [_config setFontScaleMultiplier:_fontScaleObserver.effectiveFontScale];
     }
     stylePropChanged = YES;
-    _forceRecreateSegments = YES;
-    _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight;
   }
 
   if (newViewProps.maxFontSizeMultiplier != oldViewProps.maxFontSizeMultiplier) {
@@ -664,26 +657,24 @@ static char kENRMSegmentFadeAnimatorKey;
       [_config setMaxFontSizeMultiplier:_maxFontSizeMultiplier];
     }
     stylePropChanged = YES;
-    _forceRecreateSegments = YES;
-    _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight;
   }
 
   if (newViewProps.allowTrailingMargin != oldViewProps.allowTrailingMargin) {
     _allowTrailingMargin = newViewProps.allowTrailingMargin;
-    _forceRecreateSegments = YES;
-    _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight;
   }
 
   BOOL md4cFlagsChanged = NO;
   if (newViewProps.md4cFlags.underline != oldViewProps.md4cFlags.underline) {
     _md4cFlags.underline = newViewProps.md4cFlags.underline;
     md4cFlagsChanged = YES;
-    _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyForceHeight;
   }
   if (newViewProps.md4cFlags.latexMath != oldViewProps.md4cFlags.latexMath) {
     _md4cFlags.latexMath = newViewProps.md4cFlags.latexMath;
     md4cFlagsChanged = YES;
-    _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyForceHeight;
   }
   BOOL allowTrailingMarginChanged = newViewProps.allowTrailingMargin != oldViewProps.allowTrailingMargin;
 
@@ -692,7 +683,7 @@ static char kENRMSegmentFadeAnimatorKey;
   BOOL streamingAnimationChanged = newViewProps.streamingAnimation != oldViewProps.streamingAnimation;
   if (streamingAnimationChanged) {
     _streamingAnimation = newViewProps.streamingAnimation;
-    _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyForceHeight;
     if (!_streamingAnimation) {
       for (RCTUIView *segment in _segmentViews) {
         if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -65,7 +65,7 @@ static char kENRMSegmentFadeAnimatorKey;
   NSString *_cachedMarkdown;
   NSString *_renderedMarkdown;
   NSMutableArray<RCTUIView *> *_segmentViews;
-  NSMutableArray<NSString *> *_segmentSignatures;
+  NSMutableArray<NSNumber *> *_segmentSignatures;
   ENRMSegmentViewRegistry *_segmentViewRegistry;
   BOOL _forceRecreateSegments;
   BOOL _forceHeightUpdateOnNextRender;
@@ -423,7 +423,7 @@ static char kENRMSegmentFadeAnimatorKey;
   for (ENRMRenderedSegment *segment in renderedSegments) {
     RCTUIView *view = [_segmentViewRegistry createViewForSegment:segment animateIfStreaming:NO];
     [_segmentViews addObject:view];
-    [_segmentSignatures addObject:segment.signature ?: @""];
+    [_segmentSignatures addObject:@(segment.signature)];
     [self addSubview:view];
   }
 }

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -69,7 +69,6 @@ static char kENRMSegmentFadeAnimatorKey;
   ENRMSegmentViewRegistry *_segmentViewRegistry;
   BOOL _forceRecreateSegments;
   BOOL _forceHeightUpdateOnNextRender;
-  BOOL _heightUpdateScheduled;
 
   dispatch_queue_t _renderQueue;
   NSUInteger _currentRenderId;
@@ -110,7 +109,6 @@ static char kENRMSegmentFadeAnimatorKey;
     _segmentSignatures = [NSMutableArray array];
     _forceRecreateSegments = NO;
     _forceHeightUpdateOnNextRender = NO;
-    _heightUpdateScheduled = NO;
     [self configureSegmentViewRegistry];
 
     _renderQueue = dispatch_queue_create("com.swmansion.enriched.markdown.container.render", DISPATCH_QUEUE_SERIAL);
@@ -299,6 +297,21 @@ static char kENRMSegmentFadeAnimatorKey;
   return _renderedMarkdown != nil && [_renderedMarkdown isEqualToString:markdown];
 }
 
+- (BOOL)renderedSegmentsChangeTopology:(NSArray<ENRMRenderedSegment *> *)renderedSegments
+{
+  if (renderedSegments.count != _segmentViews.count) {
+    return YES;
+  }
+
+  for (NSUInteger index = 0; index < renderedSegments.count; index++) {
+    if (![_segmentViewRegistry view:_segmentViews[index] matchesSegment:renderedSegments[index]]) {
+      return YES;
+    }
+  }
+
+  return NO;
+}
+
 - (void)updateState:(const facebook::react::State::Shared &)state
            oldState:(const facebook::react::State::Shared &)oldState
 {
@@ -318,32 +331,6 @@ static char kENRMSegmentFadeAnimatorKey;
   _heightUpdateCounter++;
   auto selfRef = wrapManagedObjectWeakly(self);
   _state->updateState(EnrichedMarkdownState(_heightUpdateCounter, selfRef));
-}
-
-- (void)scheduleStreamingHeightUpdate
-{
-  if (_heightUpdateScheduled) {
-    return;
-  }
-
-  _heightUpdateScheduled = YES;
-  __weak EnrichedMarkdown *weakSelf = self;
-  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.12 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-    EnrichedMarkdown *strongSelf = weakSelf;
-    if (!strongSelf) {
-      return;
-    }
-
-    strongSelf->_heightUpdateScheduled = NO;
-    if (strongSelf.bounds.size.width <= 0) {
-      return;
-    }
-
-    CGSize measured = [strongSelf measureSize:strongSelf.bounds.size.width];
-    if (needsHeightUpdate(measured, strongSelf.bounds)) {
-      [strongSelf requestHeightUpdate];
-    }
-  });
 }
 
 - (void)renderMarkdownContent:(NSString *)markdownString
@@ -444,6 +431,7 @@ static char kENRMSegmentFadeAnimatorKey;
 - (void)applyRenderedSegments:(NSArray *)renderedSegments renderedMarkdown:(NSString *)renderedMarkdown
 {
   _renderedMarkdown = [renderedMarkdown copy];
+  BOOL segmentTopologyChanged = _streamingAnimation && [self renderedSegmentsChangeTopology:renderedSegments];
 
   ENRMSegmentReconciliationResult *result = [ENRMSegmentReconciler reconcileCurrentViews:_segmentViews
       currentSignatures:_segmentSignatures
@@ -472,10 +460,15 @@ static char kENRMSegmentFadeAnimatorKey;
     _forceHeightUpdateOnNextRender = NO;
     [self setNeedsLayout];
 
-    if (forceHeightUpdate) {
+    if (forceHeightUpdate || segmentTopologyChanged) {
+      [self computeSegmentLayoutForWidth:self.bounds.size.width applyFrames:YES];
+      [self layoutIfNeeded];
       [self requestHeightUpdate];
     } else if (_streamingAnimation) {
-      [self scheduleStreamingHeightUpdate];
+      CGSize measured = [self measureSize:self.bounds.size.width];
+      if (needsHeightUpdate(measured, self.bounds)) {
+        [self requestHeightUpdate];
+      }
     } else {
       CGSize measured = [self measureSize:self.bounds.size.width];
       if (needsHeightUpdate(measured, self.bounds)) {
@@ -770,9 +763,39 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
   return EnrichedMarkdown.class;
 }
 
+#if !TARGET_OS_OSX
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
+{
+  if ([super pointInside:point withEvent:event]) {
+    return YES;
+  }
+
+  for (RCTUIView *segment in _segmentViews) {
+    if (CGRectContainsPoint(segment.frame, point)) {
+      return YES;
+    }
+  }
+
+  return NO;
+}
+#endif
+
 - (facebook::react::SharedTouchEventEmitter)touchEventEmitterAtPoint:(CGPoint)point
 {
   for (RCTUIView *segment in _segmentViews) {
+    if ([segment isKindOfClass:[TableContainerView class]]) {
+      CGPoint segmentPoint = [self convertPoint:point toView:segment];
+#if !TARGET_OS_OSX
+      if ([segment pointInside:segmentPoint withEvent:nil]) {
+        return nil;
+      }
+#else
+      if (CGRectContainsPoint(segment.bounds, segmentPoint)) {
+        return nil;
+      }
+#endif
+    }
+
     if (![segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
       continue;
     }

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -66,6 +66,7 @@ using namespace facebook::react;
   BOOL _allowTrailingMargin;
   BOOL _enableLinkPreview;
   BOOL _streamingAnimation;
+  BOOL _forceHeightUpdateOnNextRender;
 
   NSUInteger _previousTextLength;
   ENRMTailFadeInAnimator *_fadeAnimator;
@@ -143,6 +144,7 @@ using namespace facebook::react;
     _maxFontSizeMultiplier = 0;
     _allowTrailingMargin = NO;
     _enableLinkPreview = YES;
+    _forceHeightUpdateOnNextRender = NO;
 
     _fontScaleObserver = [[FontScaleObserver alloc] init];
     __weak EnrichedMarkdownText *weakSelf = self;
@@ -154,6 +156,7 @@ using namespace facebook::react;
         [strongSelf->_config setFontScaleMultiplier:strongSelf->_fontScaleObserver.effectiveFontScale];
       }
       if (strongSelf->_cachedMarkdown != nil && strongSelf->_cachedMarkdown.length > 0) {
+        strongSelf->_forceHeightUpdateOnNextRender = YES;
         [strongSelf renderMarkdownContent:strongSelf->_cachedMarkdown];
       }
     };
@@ -347,6 +350,11 @@ using namespace facebook::react;
   [_spoilerManager setNeedsUpdate];
 
   if (self.bounds.size.width > 0) {
+    // Font/style changes can produce the same measured size before UIKit has
+    // fully refreshed layout, so force one Yoga update after those renders.
+    BOOL forceHeightUpdate = _forceHeightUpdateOnNextRender;
+    _forceHeightUpdateOnNextRender = NO;
+
     [_textView.layoutManager ensureLayoutForTextContainer:_textView.textContainer];
     ENRMSetNeedsDisplay(_textView);
 #if !TARGET_OS_OSX
@@ -356,7 +364,7 @@ using namespace facebook::react;
     [_spoilerManager updateIfNeeded];
 
     CGSize measured = [self measureSize:self.bounds.size.width];
-    if (needsHeightUpdate(measured, self.bounds)) {
+    if (forceHeightUpdate || needsHeightUpdate(measured, self.bounds)) {
       [self requestHeightUpdate];
     }
   }
@@ -399,6 +407,7 @@ using namespace facebook::react;
 
   if (stylePropChanged) {
     [ENRMImageAttachment clearAttachmentRegistry];
+    _forceHeightUpdateOnNextRender = YES;
   }
 
   NSLayoutManager *layoutManager = _textView.layoutManager;
@@ -425,6 +434,7 @@ using namespace facebook::react;
     }
 
     stylePropChanged = YES;
+    _forceHeightUpdateOnNextRender = YES;
   }
 
   if (newViewProps.maxFontSizeMultiplier != oldViewProps.maxFontSizeMultiplier) {
@@ -435,20 +445,24 @@ using namespace facebook::react;
     }
 
     stylePropChanged = YES;
+    _forceHeightUpdateOnNextRender = YES;
   }
 
   if (newViewProps.allowTrailingMargin != oldViewProps.allowTrailingMargin) {
     _allowTrailingMargin = newViewProps.allowTrailingMargin;
+    _forceHeightUpdateOnNextRender = YES;
   }
 
   BOOL md4cFlagsChanged = NO;
   if (newViewProps.md4cFlags.underline != oldViewProps.md4cFlags.underline) {
     _md4cFlags.underline = newViewProps.md4cFlags.underline;
     md4cFlagsChanged = YES;
+    _forceHeightUpdateOnNextRender = YES;
   }
   if (newViewProps.md4cFlags.latexMath != oldViewProps.md4cFlags.latexMath) {
     _md4cFlags.latexMath = newViewProps.md4cFlags.latexMath;
     md4cFlagsChanged = YES;
+    _forceHeightUpdateOnNextRender = YES;
   }
   BOOL markdownChanged = oldViewProps.markdown != newViewProps.markdown;
   BOOL allowTrailingMarginChanged = newViewProps.allowTrailingMargin != oldViewProps.allowTrailingMargin;

--- a/ios/internals/EnrichedMarkdownShadowNode.h
+++ b/ios/internals/EnrichedMarkdownShadowNode.h
@@ -34,6 +34,7 @@ public:
 
 private:
   int localHeightRecalculationCounter_{0};
+  mutable int lastExactMeasurementCounter_{0};
 
   // Creates mock view off-screen for initial measurement when real view doesn't exist
   id setupMockEnrichedMarkdown_(CGFloat width) const;

--- a/ios/internals/EnrichedMarkdownShadowNode.mm
+++ b/ios/internals/EnrichedMarkdownShadowNode.mm
@@ -1,26 +1,11 @@
 #import "EnrichedMarkdownShadowNode.h"
 #import "EnrichedMarkdown.h"
 #import "ShadowMeasurementUtils.h"
-#import <react/utils/ManagedObjectWrapper.h>
 #import <yoga/Yoga.h>
 
 namespace facebook::react {
 
 extern const char EnrichedMarkdownComponentName[] = "EnrichedMarkdown";
-
-static bool ENRMPropsNeedExactStreamingMeasurement(const EnrichedMarkdownProps &oldProps,
-                                                   const EnrichedMarkdownProps &newProps)
-{
-  // Streaming normally reuses the current native bounds to avoid re-measuring
-  // every token. Layout-affecting prop changes still need one exact pass.
-  return oldProps.streamingAnimation != newProps.streamingAnimation ||
-         oldProps.allowFontScaling != newProps.allowFontScaling ||
-         oldProps.maxFontSizeMultiplier != newProps.maxFontSizeMultiplier ||
-         oldProps.allowTrailingMargin != newProps.allowTrailingMargin ||
-         oldProps.md4cFlags.underline != newProps.md4cFlags.underline ||
-         oldProps.md4cFlags.latexMath != newProps.md4cFlags.latexMath ||
-         computeStyleFingerprint(oldProps.markdownStyle) != computeStyleFingerprint(newProps.markdownStyle);
-}
 
 EnrichedMarkdownShadowNode::EnrichedMarkdownShadowNode(const ShadowNodeFragment &fragment,
                                                        const ShadowNodeFamily::Shared &family, ShadowNodeTraits traits)
@@ -57,7 +42,6 @@ void EnrichedMarkdownShadowNode::dirtyLayoutIfNeeded()
   }
 }
 
-/// Creates a mock view off-screen to measure content when real view isn't ready yet.
 id EnrichedMarkdownShadowNode::setupMockEnrichedMarkdown_(CGFloat width) const
 {
   EnrichedMarkdown *mockView = [[EnrichedMarkdown alloc] initWithFrame:CGRectMake(20000, 20000, width, 1000)];
@@ -65,7 +49,6 @@ id EnrichedMarkdownShadowNode::setupMockEnrichedMarkdown_(CGFloat width) const
   const auto props = this->getProps();
   [mockView updateProps:props oldProps:nullptr];
 
-  // Render markdown synchronously for accurate measurement
   const auto &typedProps = *std::static_pointer_cast<const EnrichedMarkdownProps>(props);
   if (!typedProps.markdown.empty()) {
     NSString *markdown = [NSString stringWithUTF8String:typedProps.markdown.c_str()];
@@ -78,74 +61,13 @@ id EnrichedMarkdownShadowNode::setupMockEnrichedMarkdown_(CGFloat width) const
 Size EnrichedMarkdownShadowNode::measureContent(const LayoutContext &layoutContext,
                                                 const LayoutConstraints &layoutConstraints) const
 {
-  CGFloat maxWidth = layoutConstraints.maximumSize.width;
-
   const auto &typedProps = *std::static_pointer_cast<const EnrichedMarkdownProps>(this->getProps());
-
-  RCTInternalGenericWeakWrapper *weakWrapper =
-      (RCTInternalGenericWeakWrapper *)unwrapManagedObject(getStateData().getComponentViewRef());
-  EnrichedMarkdown *view = weakWrapper ? (EnrichedMarkdown *)weakWrapper.object : nil;
-
   const int receivedCounter = getStateData().getHeightRecalculationCounter();
 
-  if (typedProps.streamingAnimation && view && receivedCounter <= lastExactMeasurementCounter_) {
-    __block CGSize currentSize = CGSizeZero;
-    void (^readCurrentSize)(void) = ^{
-      if (view.bounds.size.width > 0 && view.bounds.size.height > 0) {
-        currentSize = view.bounds.size;
-      }
-    };
-
-    if ([NSThread isMainThread]) {
-      readCurrentSize();
-    } else {
-      dispatch_sync(dispatch_get_main_queue(), readCurrentSize);
-    }
-
-    if (currentSize.height > 0) {
-      return ENRMClampMeasuredSize(currentSize, layoutConstraints);
-    }
-  }
-
-  const bool shouldUseMeasurementCache = !typedProps.streamingAnimation;
-  CGFloat fontScale = shouldUseMeasurementCache ? ENRMFontScaleForMeasurement(typedProps.allowFontScaling) : 1.0;
-
-  if (shouldUseMeasurementCache && !typedProps.markdown.empty()) {
-    auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::GitHub);
-    CachedSize cached;
-    if (MeasurementCache::shared().get(cacheKey, cached)) {
-      return ENRMClampMeasuredSize(CGSizeMake(cached.width, cached.height), layoutConstraints);
-    }
-  }
-
-  __block CGSize size;
-  NSString *currentMarkdown = typedProps.markdown.empty() ? nil : @(typedProps.markdown.c_str());
-
-  void (^measureBlock)(void) = ^{
-    if (view && (typedProps.streamingAnimation || [view hasRenderedMarkdown:currentMarkdown])) {
-      size = [view measureSize:maxWidth];
-    } else {
-      EnrichedMarkdown *mockView = setupMockEnrichedMarkdown_(maxWidth);
-      size = [mockView measureSize:maxWidth];
-    }
-  };
-
-  if ([NSThread isMainThread]) {
-    measureBlock();
-  } else {
-    dispatch_sync(dispatch_get_main_queue(), measureBlock);
-  }
-
-  if (shouldUseMeasurementCache && !typedProps.markdown.empty()) {
-    auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::GitHub);
-    MeasurementCache::shared().set(cacheKey, {size.width, size.height});
-  }
-
-  if (typedProps.streamingAnimation) {
-    lastExactMeasurementCounter_ = receivedCounter;
-  }
-
-  return ENRMClampMeasuredSize(size, layoutConstraints);
+  return ENRMMeasureMarkdownContent<EnrichedMarkdownProps, EnrichedMarkdown>(
+      typedProps, getStateData().getComponentViewRef(), receivedCounter, lastExactMeasurementCounter_,
+      MarkdownFlavor::GitHub, layoutConstraints,
+      ^(CGFloat width) { return (EnrichedMarkdown *)setupMockEnrichedMarkdown_(width); });
 }
 
 } // namespace facebook::react

--- a/ios/internals/EnrichedMarkdownShadowNode.mm
+++ b/ios/internals/EnrichedMarkdownShadowNode.mm
@@ -1,11 +1,26 @@
 #import "EnrichedMarkdownShadowNode.h"
 #import "EnrichedMarkdown.h"
+#import "ShadowMeasurementUtils.h"
 #import <react/utils/ManagedObjectWrapper.h>
 #import <yoga/Yoga.h>
 
 namespace facebook::react {
 
 extern const char EnrichedMarkdownComponentName[] = "EnrichedMarkdown";
+
+static bool ENRMPropsNeedExactStreamingMeasurement(const EnrichedMarkdownProps &oldProps,
+                                                   const EnrichedMarkdownProps &newProps)
+{
+  // Streaming normally reuses the current native bounds to avoid re-measuring
+  // every token. Layout-affecting prop changes still need one exact pass.
+  return oldProps.streamingAnimation != newProps.streamingAnimation ||
+         oldProps.allowFontScaling != newProps.allowFontScaling ||
+         oldProps.maxFontSizeMultiplier != newProps.maxFontSizeMultiplier ||
+         oldProps.allowTrailingMargin != newProps.allowTrailingMargin ||
+         oldProps.md4cFlags.underline != newProps.md4cFlags.underline ||
+         oldProps.md4cFlags.latexMath != newProps.md4cFlags.latexMath ||
+         computeStyleFingerprint(oldProps.markdownStyle) != computeStyleFingerprint(newProps.markdownStyle);
+}
 
 EnrichedMarkdownShadowNode::EnrichedMarkdownShadowNode(const ShadowNodeFragment &fragment,
                                                        const ShadowNodeFamily::Shared &family, ShadowNodeTraits traits)
@@ -15,8 +30,19 @@ EnrichedMarkdownShadowNode::EnrichedMarkdownShadowNode(const ShadowNodeFragment 
 
 EnrichedMarkdownShadowNode::EnrichedMarkdownShadowNode(const ShadowNode &sourceShadowNode,
                                                        const ShadowNodeFragment &fragment)
-    : ConcreteViewShadowNode(sourceShadowNode, fragment)
+    : ConcreteViewShadowNode(sourceShadowNode, fragment),
+      localHeightRecalculationCounter_(
+          static_cast<const EnrichedMarkdownShadowNode &>(sourceShadowNode).localHeightRecalculationCounter_),
+      lastExactMeasurementCounter_(
+          static_cast<const EnrichedMarkdownShadowNode &>(sourceShadowNode).lastExactMeasurementCounter_)
 {
+  const auto &oldProps = *std::static_pointer_cast<const EnrichedMarkdownProps>(sourceShadowNode.getProps());
+  const auto &newProps = *std::static_pointer_cast<const EnrichedMarkdownProps>(this->getProps());
+
+  if (newProps.streamingAnimation && ENRMPropsNeedExactStreamingMeasurement(oldProps, newProps)) {
+    lastExactMeasurementCounter_ = -1;
+  }
+
   dirtyLayoutIfNeeded();
 }
 
@@ -56,32 +82,47 @@ Size EnrichedMarkdownShadowNode::measureContent(const LayoutContext &layoutConte
 
   const auto &typedProps = *std::static_pointer_cast<const EnrichedMarkdownProps>(this->getProps());
 
-  CGFloat fontScale = typedProps.allowFontScaling ? RCTFontSizeMultiplier() : 1.0;
-
-  if (!typedProps.markdown.empty()) {
-    auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::GitHub);
-    CachedSize cached;
-    if (MeasurementCache::shared().get(cacheKey, cached)) {
-      Float cachedWidth = std::max(cached.width, layoutConstraints.minimumSize.width);
-      cachedWidth = std::min(cachedWidth, layoutConstraints.maximumSize.width);
-      Float cachedHeight = std::max(cached.height, layoutConstraints.minimumSize.height);
-      if (std::isfinite(layoutConstraints.maximumSize.height)) {
-        cachedHeight = std::min(cachedHeight, layoutConstraints.maximumSize.height);
-      }
-      return {cachedWidth, cachedHeight};
-    }
-  }
-
   RCTInternalGenericWeakWrapper *weakWrapper =
       (RCTInternalGenericWeakWrapper *)unwrapManagedObject(getStateData().getComponentViewRef());
   EnrichedMarkdown *view = weakWrapper ? (EnrichedMarkdown *)weakWrapper.object : nil;
 
-  NSString *currentMarkdown = typedProps.markdown.empty() ? nil : @(typedProps.markdown.c_str());
+  const int receivedCounter = getStateData().getHeightRecalculationCounter();
+
+  if (typedProps.streamingAnimation && view && receivedCounter <= lastExactMeasurementCounter_) {
+    __block CGSize currentSize = CGSizeZero;
+    void (^readCurrentSize)(void) = ^{
+      if (view.bounds.size.width > 0 && view.bounds.size.height > 0) {
+        currentSize = view.bounds.size;
+      }
+    };
+
+    if ([NSThread isMainThread]) {
+      readCurrentSize();
+    } else {
+      dispatch_sync(dispatch_get_main_queue(), readCurrentSize);
+    }
+
+    if (currentSize.height > 0) {
+      return ENRMClampMeasuredSize(currentSize, layoutConstraints);
+    }
+  }
+
+  const bool shouldUseMeasurementCache = !typedProps.streamingAnimation;
+  CGFloat fontScale = shouldUseMeasurementCache ? ENRMFontScaleForMeasurement(typedProps.allowFontScaling) : 1.0;
+
+  if (shouldUseMeasurementCache && !typedProps.markdown.empty()) {
+    auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::GitHub);
+    CachedSize cached;
+    if (MeasurementCache::shared().get(cacheKey, cached)) {
+      return ENRMClampMeasuredSize(CGSizeMake(cached.width, cached.height), layoutConstraints);
+    }
+  }
 
   __block CGSize size;
+  NSString *currentMarkdown = typedProps.markdown.empty() ? nil : @(typedProps.markdown.c_str());
 
   void (^measureBlock)(void) = ^{
-    if (view && [view hasRenderedMarkdown:currentMarkdown]) {
+    if (view && (typedProps.streamingAnimation || [view hasRenderedMarkdown:currentMarkdown])) {
       size = [view measureSize:maxWidth];
     } else {
       EnrichedMarkdown *mockView = setupMockEnrichedMarkdown_(maxWidth);
@@ -95,20 +136,16 @@ Size EnrichedMarkdownShadowNode::measureContent(const LayoutContext &layoutConte
     dispatch_sync(dispatch_get_main_queue(), measureBlock);
   }
 
-  if (!typedProps.markdown.empty()) {
+  if (shouldUseMeasurementCache && !typedProps.markdown.empty()) {
     auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::GitHub);
     MeasurementCache::shared().set(cacheKey, {size.width, size.height});
   }
 
-  Float clampedWidth = size.width;
-  Float clampedHeight = size.height;
-  clampedWidth = std::max(clampedWidth, layoutConstraints.minimumSize.width);
-  clampedWidth = std::min(clampedWidth, layoutConstraints.maximumSize.width);
-  clampedHeight = std::max(clampedHeight, layoutConstraints.minimumSize.height);
-  if (std::isfinite(layoutConstraints.maximumSize.height)) {
-    clampedHeight = std::min(clampedHeight, layoutConstraints.maximumSize.height);
+  if (typedProps.streamingAnimation) {
+    lastExactMeasurementCounter_ = receivedCounter;
   }
-  return {clampedWidth, clampedHeight};
+
+  return ENRMClampMeasuredSize(size, layoutConstraints);
 }
 
 } // namespace facebook::react

--- a/ios/internals/EnrichedMarkdownTextShadowNode.h
+++ b/ios/internals/EnrichedMarkdownTextShadowNode.h
@@ -36,6 +36,7 @@ public:
 
 private:
   int localHeightRecalculationCounter_{0};
+  mutable int lastExactMeasurementCounter_{0};
 
   // Creates mock view off-screen for initial measurement when real view doesn't exist
   id setupMockEnrichedMarkdownText_(CGFloat width) const;

--- a/ios/internals/EnrichedMarkdownTextShadowNode.mm
+++ b/ios/internals/EnrichedMarkdownTextShadowNode.mm
@@ -1,26 +1,11 @@
 #import "EnrichedMarkdownTextShadowNode.h"
 #import "EnrichedMarkdownText.h"
 #import "ShadowMeasurementUtils.h"
-#import <react/utils/ManagedObjectWrapper.h>
 #import <yoga/Yoga.h>
 
 namespace facebook::react {
 
 extern const char EnrichedMarkdownTextComponentName[] = "EnrichedMarkdownText";
-
-static bool ENRMTextPropsNeedExactStreamingMeasurement(const EnrichedMarkdownTextProps &oldProps,
-                                                       const EnrichedMarkdownTextProps &newProps)
-{
-  // Streaming normally reuses the current native bounds to avoid re-measuring
-  // every token. Layout-affecting prop changes still need one exact pass.
-  return oldProps.streamingAnimation != newProps.streamingAnimation ||
-         oldProps.allowFontScaling != newProps.allowFontScaling ||
-         oldProps.maxFontSizeMultiplier != newProps.maxFontSizeMultiplier ||
-         oldProps.allowTrailingMargin != newProps.allowTrailingMargin ||
-         oldProps.md4cFlags.underline != newProps.md4cFlags.underline ||
-         oldProps.md4cFlags.latexMath != newProps.md4cFlags.latexMath ||
-         computeStyleFingerprint(oldProps.markdownStyle) != computeStyleFingerprint(newProps.markdownStyle);
-}
 
 EnrichedMarkdownTextShadowNode::EnrichedMarkdownTextShadowNode(const ShadowNodeFragment &fragment,
                                                                const ShadowNodeFamily::Shared &family,
@@ -40,7 +25,7 @@ EnrichedMarkdownTextShadowNode::EnrichedMarkdownTextShadowNode(const ShadowNode 
   const auto &oldProps = *std::static_pointer_cast<const EnrichedMarkdownTextProps>(sourceShadowNode.getProps());
   const auto &newProps = *std::static_pointer_cast<const EnrichedMarkdownTextProps>(this->getProps());
 
-  if (newProps.streamingAnimation && ENRMTextPropsNeedExactStreamingMeasurement(oldProps, newProps)) {
+  if (newProps.streamingAnimation && ENRMPropsNeedExactStreamingMeasurement(oldProps, newProps)) {
     lastExactMeasurementCounter_ = -1;
   }
 
@@ -58,7 +43,6 @@ void EnrichedMarkdownTextShadowNode::dirtyLayoutIfNeeded()
   }
 }
 
-/// Creates a mock view off-screen to measure content when real view isn't ready yet.
 id EnrichedMarkdownTextShadowNode::setupMockEnrichedMarkdownText_(CGFloat width) const
 {
   EnrichedMarkdownText *mockView = [[EnrichedMarkdownText alloc] initWithFrame:CGRectMake(20000, 20000, width, 1000)];
@@ -66,7 +50,6 @@ id EnrichedMarkdownTextShadowNode::setupMockEnrichedMarkdownText_(CGFloat width)
   const auto props = this->getProps();
   [mockView updateProps:props oldProps:nullptr];
 
-  // Render markdown synchronously for accurate measurement
   const auto &typedProps = *std::static_pointer_cast<const EnrichedMarkdownTextProps>(props);
   if (!typedProps.markdown.empty()) {
     NSString *markdown = [NSString stringWithUTF8String:typedProps.markdown.c_str()];
@@ -79,76 +62,13 @@ id EnrichedMarkdownTextShadowNode::setupMockEnrichedMarkdownText_(CGFloat width)
 Size EnrichedMarkdownTextShadowNode::measureContent(const LayoutContext &layoutContext,
                                                     const LayoutConstraints &layoutConstraints) const
 {
-  CGFloat maxWidth = layoutConstraints.maximumSize.width;
-
   const auto &typedProps = *std::static_pointer_cast<const EnrichedMarkdownTextProps>(this->getProps());
-
-  // Check measurement cache before creating mock views or dispatching to main thread.
-  // This avoids the expensive mock view + synchronous md4c parse path for repeated content.
-  RCTInternalGenericWeakWrapper *weakWrapper =
-      (RCTInternalGenericWeakWrapper *)unwrapManagedObject(getStateData().getComponentViewRef());
-  EnrichedMarkdownText *view = weakWrapper ? (EnrichedMarkdownText *)weakWrapper.object : nil;
-
   const int receivedCounter = getStateData().getHeightRecalculationCounter();
 
-  if (typedProps.streamingAnimation && view && receivedCounter <= lastExactMeasurementCounter_) {
-    __block CGSize currentSize = CGSizeZero;
-    void (^readCurrentSize)(void) = ^{
-      if (view.bounds.size.width > 0 && view.bounds.size.height > 0) {
-        currentSize = view.bounds.size;
-      }
-    };
-
-    if ([NSThread isMainThread]) {
-      readCurrentSize();
-    } else {
-      dispatch_sync(dispatch_get_main_queue(), readCurrentSize);
-    }
-
-    if (currentSize.height > 0) {
-      return ENRMClampMeasuredSize(currentSize, layoutConstraints);
-    }
-  }
-
-  const bool shouldUseMeasurementCache = !typedProps.streamingAnimation;
-  CGFloat fontScale = shouldUseMeasurementCache ? ENRMFontScaleForMeasurement(typedProps.allowFontScaling) : 1.0;
-
-  if (shouldUseMeasurementCache && !typedProps.markdown.empty()) {
-    auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::CommonMark);
-    CachedSize cached;
-    if (MeasurementCache::shared().get(cacheKey, cached)) {
-      return ENRMClampMeasuredSize(CGSizeMake(cached.width, cached.height), layoutConstraints);
-    }
-  }
-
-  __block CGSize size;
-  NSString *currentMarkdown = typedProps.markdown.empty() ? nil : @(typedProps.markdown.c_str());
-
-  void (^measureBlock)(void) = ^{
-    if (view && (typedProps.streamingAnimation || [view hasRenderedMarkdown:currentMarkdown])) {
-      size = [view measureSize:maxWidth];
-    } else {
-      EnrichedMarkdownText *mockView = setupMockEnrichedMarkdownText_(maxWidth);
-      size = [mockView measureSize:maxWidth];
-    }
-  };
-
-  if ([NSThread isMainThread]) {
-    measureBlock();
-  } else {
-    dispatch_sync(dispatch_get_main_queue(), measureBlock);
-  }
-
-  if (shouldUseMeasurementCache && !typedProps.markdown.empty()) {
-    auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::CommonMark);
-    MeasurementCache::shared().set(cacheKey, {size.width, size.height});
-  }
-
-  if (typedProps.streamingAnimation) {
-    lastExactMeasurementCounter_ = receivedCounter;
-  }
-
-  return ENRMClampMeasuredSize(size, layoutConstraints);
+  return ENRMMeasureMarkdownContent<EnrichedMarkdownTextProps, EnrichedMarkdownText>(
+      typedProps, getStateData().getComponentViewRef(), receivedCounter, lastExactMeasurementCounter_,
+      MarkdownFlavor::CommonMark, layoutConstraints,
+      ^(CGFloat width) { return (EnrichedMarkdownText *)setupMockEnrichedMarkdownText_(width); });
 }
 
 } // namespace facebook::react

--- a/ios/internals/EnrichedMarkdownTextShadowNode.mm
+++ b/ios/internals/EnrichedMarkdownTextShadowNode.mm
@@ -1,11 +1,26 @@
 #import "EnrichedMarkdownTextShadowNode.h"
 #import "EnrichedMarkdownText.h"
+#import "ShadowMeasurementUtils.h"
 #import <react/utils/ManagedObjectWrapper.h>
 #import <yoga/Yoga.h>
 
 namespace facebook::react {
 
 extern const char EnrichedMarkdownTextComponentName[] = "EnrichedMarkdownText";
+
+static bool ENRMTextPropsNeedExactStreamingMeasurement(const EnrichedMarkdownTextProps &oldProps,
+                                                       const EnrichedMarkdownTextProps &newProps)
+{
+  // Streaming normally reuses the current native bounds to avoid re-measuring
+  // every token. Layout-affecting prop changes still need one exact pass.
+  return oldProps.streamingAnimation != newProps.streamingAnimation ||
+         oldProps.allowFontScaling != newProps.allowFontScaling ||
+         oldProps.maxFontSizeMultiplier != newProps.maxFontSizeMultiplier ||
+         oldProps.allowTrailingMargin != newProps.allowTrailingMargin ||
+         oldProps.md4cFlags.underline != newProps.md4cFlags.underline ||
+         oldProps.md4cFlags.latexMath != newProps.md4cFlags.latexMath ||
+         computeStyleFingerprint(oldProps.markdownStyle) != computeStyleFingerprint(newProps.markdownStyle);
+}
 
 EnrichedMarkdownTextShadowNode::EnrichedMarkdownTextShadowNode(const ShadowNodeFragment &fragment,
                                                                const ShadowNodeFamily::Shared &family,
@@ -16,8 +31,19 @@ EnrichedMarkdownTextShadowNode::EnrichedMarkdownTextShadowNode(const ShadowNodeF
 
 EnrichedMarkdownTextShadowNode::EnrichedMarkdownTextShadowNode(const ShadowNode &sourceShadowNode,
                                                                const ShadowNodeFragment &fragment)
-    : ConcreteViewShadowNode(sourceShadowNode, fragment)
+    : ConcreteViewShadowNode(sourceShadowNode, fragment),
+      localHeightRecalculationCounter_(
+          static_cast<const EnrichedMarkdownTextShadowNode &>(sourceShadowNode).localHeightRecalculationCounter_),
+      lastExactMeasurementCounter_(
+          static_cast<const EnrichedMarkdownTextShadowNode &>(sourceShadowNode).lastExactMeasurementCounter_)
 {
+  const auto &oldProps = *std::static_pointer_cast<const EnrichedMarkdownTextProps>(sourceShadowNode.getProps());
+  const auto &newProps = *std::static_pointer_cast<const EnrichedMarkdownTextProps>(this->getProps());
+
+  if (newProps.streamingAnimation && ENRMTextPropsNeedExactStreamingMeasurement(oldProps, newProps)) {
+    lastExactMeasurementCounter_ = -1;
+  }
+
   dirtyLayoutIfNeeded();
 }
 
@@ -59,32 +85,47 @@ Size EnrichedMarkdownTextShadowNode::measureContent(const LayoutContext &layoutC
 
   // Check measurement cache before creating mock views or dispatching to main thread.
   // This avoids the expensive mock view + synchronous md4c parse path for repeated content.
-  CGFloat fontScale = typedProps.allowFontScaling ? RCTFontSizeMultiplier() : 1.0;
-
-  if (!typedProps.markdown.empty()) {
-    auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::CommonMark);
-    CachedSize cached;
-    if (MeasurementCache::shared().get(cacheKey, cached)) {
-      Float cachedWidth = std::max(cached.width, layoutConstraints.minimumSize.width);
-      cachedWidth = std::min(cachedWidth, layoutConstraints.maximumSize.width);
-      Float cachedHeight = std::max(cached.height, layoutConstraints.minimumSize.height);
-      if (std::isfinite(layoutConstraints.maximumSize.height)) {
-        cachedHeight = std::min(cachedHeight, layoutConstraints.maximumSize.height);
-      }
-      return {cachedWidth, cachedHeight};
-    }
-  }
-
   RCTInternalGenericWeakWrapper *weakWrapper =
       (RCTInternalGenericWeakWrapper *)unwrapManagedObject(getStateData().getComponentViewRef());
   EnrichedMarkdownText *view = weakWrapper ? (EnrichedMarkdownText *)weakWrapper.object : nil;
 
-  NSString *currentMarkdown = typedProps.markdown.empty() ? nil : @(typedProps.markdown.c_str());
+  const int receivedCounter = getStateData().getHeightRecalculationCounter();
+
+  if (typedProps.streamingAnimation && view && receivedCounter <= lastExactMeasurementCounter_) {
+    __block CGSize currentSize = CGSizeZero;
+    void (^readCurrentSize)(void) = ^{
+      if (view.bounds.size.width > 0 && view.bounds.size.height > 0) {
+        currentSize = view.bounds.size;
+      }
+    };
+
+    if ([NSThread isMainThread]) {
+      readCurrentSize();
+    } else {
+      dispatch_sync(dispatch_get_main_queue(), readCurrentSize);
+    }
+
+    if (currentSize.height > 0) {
+      return ENRMClampMeasuredSize(currentSize, layoutConstraints);
+    }
+  }
+
+  const bool shouldUseMeasurementCache = !typedProps.streamingAnimation;
+  CGFloat fontScale = shouldUseMeasurementCache ? ENRMFontScaleForMeasurement(typedProps.allowFontScaling) : 1.0;
+
+  if (shouldUseMeasurementCache && !typedProps.markdown.empty()) {
+    auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::CommonMark);
+    CachedSize cached;
+    if (MeasurementCache::shared().get(cacheKey, cached)) {
+      return ENRMClampMeasuredSize(CGSizeMake(cached.width, cached.height), layoutConstraints);
+    }
+  }
 
   __block CGSize size;
+  NSString *currentMarkdown = typedProps.markdown.empty() ? nil : @(typedProps.markdown.c_str());
 
   void (^measureBlock)(void) = ^{
-    if (view && [view hasRenderedMarkdown:currentMarkdown]) {
+    if (view && (typedProps.streamingAnimation || [view hasRenderedMarkdown:currentMarkdown])) {
       size = [view measureSize:maxWidth];
     } else {
       EnrichedMarkdownText *mockView = setupMockEnrichedMarkdownText_(maxWidth);
@@ -98,20 +139,16 @@ Size EnrichedMarkdownTextShadowNode::measureContent(const LayoutContext &layoutC
     dispatch_sync(dispatch_get_main_queue(), measureBlock);
   }
 
-  if (!typedProps.markdown.empty()) {
+  if (shouldUseMeasurementCache && !typedProps.markdown.empty()) {
     auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, MarkdownFlavor::CommonMark);
     MeasurementCache::shared().set(cacheKey, {size.width, size.height});
   }
 
-  Float clampedWidth = size.width;
-  Float clampedHeight = size.height;
-  clampedWidth = std::max(clampedWidth, layoutConstraints.minimumSize.width);
-  clampedWidth = std::min(clampedWidth, layoutConstraints.maximumSize.width);
-  clampedHeight = std::max(clampedHeight, layoutConstraints.minimumSize.height);
-  if (std::isfinite(layoutConstraints.maximumSize.height)) {
-    clampedHeight = std::min(clampedHeight, layoutConstraints.maximumSize.height);
+  if (typedProps.streamingAnimation) {
+    lastExactMeasurementCounter_ = receivedCounter;
   }
-  return {clampedWidth, clampedHeight};
+
+  return ENRMClampMeasuredSize(size, layoutConstraints);
 }
 
 } // namespace facebook::react

--- a/ios/internals/ShadowMeasurementUtils.h
+++ b/ios/internals/ShadowMeasurementUtils.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <React/RCTUtils.h>
+#include <algorithm>
+#include <cmath>
+#include <react/renderer/core/LayoutConstraints.h>
+
+namespace facebook::react {
+
+static inline CGFloat ENRMFontScaleForMeasurement(bool allowFontScaling)
+{
+  if (!allowFontScaling) {
+    return 1.0;
+  }
+
+  __block CGFloat fontScale = 1.0;
+  void (^readFontScale)(void) = ^{ fontScale = RCTFontSizeMultiplier(); };
+
+  if ([NSThread isMainThread]) {
+    readFontScale();
+  } else {
+    dispatch_sync(dispatch_get_main_queue(), readFontScale);
+  }
+
+  return fontScale;
+}
+
+static inline Size ENRMClampMeasuredSize(CGSize size, const LayoutConstraints &layoutConstraints)
+{
+  Float clampedWidth = std::max((Float)size.width, layoutConstraints.minimumSize.width);
+  clampedWidth = std::min(clampedWidth, layoutConstraints.maximumSize.width);
+  Float clampedHeight = std::max((Float)size.height, layoutConstraints.minimumSize.height);
+  if (std::isfinite(layoutConstraints.maximumSize.height)) {
+    clampedHeight = std::min(clampedHeight, layoutConstraints.maximumSize.height);
+  }
+  return {clampedWidth, clampedHeight};
+}
+
+} // namespace facebook::react

--- a/ios/internals/ShadowMeasurementUtils.h
+++ b/ios/internals/ShadowMeasurementUtils.h
@@ -8,6 +8,11 @@
 
 namespace facebook::react {
 
+// measureContent runs on Yoga's background layout thread and uses
+// dispatch_sync to main for UIKit reads. Safe because RN never
+// synchronously joins the layout queue from main. A synchronous
+// layout flush from main would deadlock.
+
 static inline CGFloat ENRMFontScaleForMeasurement(bool allowFontScaling)
 {
   if (!allowFontScaling) {

--- a/ios/internals/ShadowMeasurementUtils.h
+++ b/ios/internals/ShadowMeasurementUtils.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "MeasurementCache.h"
 #import <Foundation/Foundation.h>
 #import <React/RCTUtils.h>
 #include <algorithm>
 #include <cmath>
 #include <react/renderer/core/LayoutConstraints.h>
+#include <react/utils/ManagedObjectWrapper.h>
 
 namespace facebook::react {
 
@@ -40,6 +42,89 @@ static inline Size ENRMClampMeasuredSize(CGSize size, const LayoutConstraints &l
     clampedHeight = std::min(clampedHeight, layoutConstraints.maximumSize.height);
   }
   return {clampedWidth, clampedHeight};
+}
+
+template <typename PropsT>
+static inline bool ENRMPropsNeedExactStreamingMeasurement(const PropsT &oldProps, const PropsT &newProps)
+{
+  return oldProps.streamingAnimation != newProps.streamingAnimation ||
+         oldProps.allowFontScaling != newProps.allowFontScaling ||
+         oldProps.maxFontSizeMultiplier != newProps.maxFontSizeMultiplier ||
+         oldProps.allowTrailingMargin != newProps.allowTrailingMargin ||
+         oldProps.md4cFlags.underline != newProps.md4cFlags.underline ||
+         oldProps.md4cFlags.latexMath != newProps.md4cFlags.latexMath ||
+         computeStyleFingerprint(oldProps.markdownStyle) != computeStyleFingerprint(newProps.markdownStyle);
+}
+
+template <typename PropsT, typename ViewT>
+static inline Size ENRMMeasureMarkdownContent(const PropsT &typedProps, const std::shared_ptr<void> &componentViewRef,
+                                              int receivedCounter, int &lastExactMeasurementCounter,
+                                              MarkdownFlavor flavor, const LayoutConstraints &layoutConstraints,
+                                              ViewT * (^createMockView)(CGFloat width))
+{
+  CGFloat maxWidth = layoutConstraints.maximumSize.width;
+
+  RCTInternalGenericWeakWrapper *weakWrapper = (RCTInternalGenericWeakWrapper *)unwrapManagedObject(componentViewRef);
+  ViewT *view = weakWrapper ? (ViewT *)weakWrapper.object : nil;
+
+  if (typedProps.streamingAnimation && view && receivedCounter <= lastExactMeasurementCounter) {
+    __block CGSize currentSize = CGSizeZero;
+    void (^readCurrentSize)(void) = ^{
+      if (view.bounds.size.width > 0 && view.bounds.size.height > 0) {
+        currentSize = view.bounds.size;
+      }
+    };
+
+    if ([NSThread isMainThread]) {
+      readCurrentSize();
+    } else {
+      dispatch_sync(dispatch_get_main_queue(), readCurrentSize);
+    }
+
+    if (currentSize.height > 0) {
+      return ENRMClampMeasuredSize(currentSize, layoutConstraints);
+    }
+  }
+
+  const bool shouldUseMeasurementCache = !typedProps.streamingAnimation;
+  CGFloat fontScale = shouldUseMeasurementCache ? ENRMFontScaleForMeasurement(typedProps.allowFontScaling) : 1.0;
+
+  if (shouldUseMeasurementCache && !typedProps.markdown.empty()) {
+    auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, flavor);
+    CachedSize cached;
+    if (MeasurementCache::shared().get(cacheKey, cached)) {
+      return ENRMClampMeasuredSize(CGSizeMake(cached.width, cached.height), layoutConstraints);
+    }
+  }
+
+  __block CGSize size;
+  NSString *currentMarkdown = typedProps.markdown.empty() ? nil : @(typedProps.markdown.c_str());
+
+  void (^measureBlock)(void) = ^{
+    if (view && (typedProps.streamingAnimation || [view hasRenderedMarkdown:currentMarkdown])) {
+      size = [view measureSize:maxWidth];
+    } else {
+      ViewT *mockView = createMockView(maxWidth);
+      size = [mockView measureSize:maxWidth];
+    }
+  };
+
+  if ([NSThread isMainThread]) {
+    measureBlock();
+  } else {
+    dispatch_sync(dispatch_get_main_queue(), measureBlock);
+  }
+
+  if (shouldUseMeasurementCache && !typedProps.markdown.empty()) {
+    auto cacheKey = buildMeasurementCacheKey(typedProps, maxWidth, fontScale, flavor);
+    MeasurementCache::shared().set(cacheKey, {size.width, size.height});
+  }
+
+  if (typedProps.streamingAnimation) {
+    lastExactMeasurementCounter = receivedCounter;
+  }
+
+  return ENRMClampMeasuredSize(size, layoutConstraints);
 }
 
 } // namespace facebook::react

--- a/ios/utils/RenderedMarkdownSegment.h
+++ b/ios/utils/RenderedMarkdownSegment.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+@class ENRMRenderResult;
+@class MarkdownASTNode;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, ENRMSegmentKind) { ENRMSegmentKindText, ENRMSegmentKindTable, ENRMSegmentKindMath };
+
+@interface ENRMTextSegment : NSObject
+@property (nonatomic, strong) NSArray<MarkdownASTNode *> *nodes;
++ (instancetype)segmentWithNodes:(NSArray<MarkdownASTNode *> *)nodes;
+@end
+
+@interface ENRMTableSegment : NSObject
+@property (nonatomic, strong) MarkdownASTNode *tableNode;
++ (instancetype)segmentWithTableNode:(MarkdownASTNode *)node;
+@end
+
+@interface ENRMMathSegment : NSObject
+@property (nonatomic, strong) NSString *latex;
++ (instancetype)segmentWithLatex:(NSString *)latex;
+@end
+
+@interface ENRMRenderedSegment : NSObject
+@property (nonatomic, assign) ENRMSegmentKind kind;
+@property (nonatomic, copy) NSString *signature;
+@property (nonatomic, strong, nullable) ENRMRenderResult *textResult;
+@property (nonatomic, strong, nullable) ENRMTableSegment *tableSegment;
+@property (nonatomic, strong, nullable) ENRMMathSegment *mathSegment;
++ (instancetype)textSegmentWithResult:(ENRMRenderResult *)result signature:(NSString *)signature;
++ (instancetype)tableSegmentWithSegment:(ENRMTableSegment *)segment signature:(NSString *)signature;
++ (instancetype)mathSegmentWithSegment:(ENRMMathSegment *)segment signature:(NSString *)signature;
+@end
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NSString *ENRMSignatureForNode(MarkdownASTNode *_Nullable node);
+NSString *ENRMSignatureForNodes(NSArray<MarkdownASTNode *> *nodes);
+
+#ifdef __cplusplus
+}
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/ios/utils/RenderedMarkdownSegment.h
+++ b/ios/utils/RenderedMarkdownSegment.h
@@ -26,21 +26,21 @@ typedef NS_ENUM(NSInteger, ENRMSegmentKind) { ENRMSegmentKindText, ENRMSegmentKi
 
 @interface ENRMRenderedSegment : NSObject
 @property (nonatomic, assign) ENRMSegmentKind kind;
-@property (nonatomic, copy) NSString *signature;
+@property (nonatomic, assign) uint64_t signature;
 @property (nonatomic, strong, nullable) ENRMRenderResult *textResult;
 @property (nonatomic, strong, nullable) ENRMTableSegment *tableSegment;
 @property (nonatomic, strong, nullable) ENRMMathSegment *mathSegment;
-+ (instancetype)textSegmentWithResult:(ENRMRenderResult *)result signature:(NSString *)signature;
-+ (instancetype)tableSegmentWithSegment:(ENRMTableSegment *)segment signature:(NSString *)signature;
-+ (instancetype)mathSegmentWithSegment:(ENRMMathSegment *)segment signature:(NSString *)signature;
++ (instancetype)textSegmentWithResult:(ENRMRenderResult *)result signature:(uint64_t)signature;
++ (instancetype)tableSegmentWithSegment:(ENRMTableSegment *)segment signature:(uint64_t)signature;
++ (instancetype)mathSegmentWithSegment:(ENRMMathSegment *)segment signature:(uint64_t)signature;
 @end
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-NSString *ENRMSignatureForNode(MarkdownASTNode *_Nullable node);
-NSString *ENRMSignatureForNodes(NSArray<MarkdownASTNode *> *nodes);
+uint64_t ENRMSignatureForNode(MarkdownASTNode *_Nullable node);
+uint64_t ENRMSignatureForNodes(NSArray<MarkdownASTNode *> *nodes);
 
 #ifdef __cplusplus
 }

--- a/ios/utils/RenderedMarkdownSegment.m
+++ b/ios/utils/RenderedMarkdownSegment.m
@@ -1,0 +1,96 @@
+#import "RenderedMarkdownSegment.h"
+#import "MarkdownASTNode.h"
+
+@implementation ENRMTextSegment
++ (instancetype)segmentWithNodes:(NSArray<MarkdownASTNode *> *)nodes
+{
+  NSParameterAssert(nodes != nil);
+  ENRMTextSegment *segment = [[ENRMTextSegment alloc] init];
+  segment.nodes = [nodes copy];
+  return segment;
+}
+@end
+
+@implementation ENRMTableSegment
++ (instancetype)segmentWithTableNode:(MarkdownASTNode *)node
+{
+  NSParameterAssert(node != nil);
+  ENRMTableSegment *segment = [[ENRMTableSegment alloc] init];
+  segment.tableNode = node;
+  return segment;
+}
+@end
+
+@implementation ENRMMathSegment
++ (instancetype)segmentWithLatex:(NSString *)latex
+{
+  NSParameterAssert(latex != nil);
+  ENRMMathSegment *segment = [[ENRMMathSegment alloc] init];
+  segment.latex = latex;
+  return segment;
+}
+@end
+
+@implementation ENRMRenderedSegment
++ (instancetype)textSegmentWithResult:(ENRMRenderResult *)result signature:(NSString *)signature
+{
+  NSParameterAssert(result != nil);
+  NSParameterAssert(signature != nil);
+  ENRMRenderedSegment *segment = [[ENRMRenderedSegment alloc] init];
+  segment.kind = ENRMSegmentKindText;
+  segment.textResult = result;
+  segment.signature = signature;
+  return segment;
+}
+
++ (instancetype)tableSegmentWithSegment:(ENRMTableSegment *)tableSegment signature:(NSString *)signature
+{
+  NSParameterAssert(tableSegment != nil);
+  NSParameterAssert(signature != nil);
+  ENRMRenderedSegment *segment = [[ENRMRenderedSegment alloc] init];
+  segment.kind = ENRMSegmentKindTable;
+  segment.tableSegment = tableSegment;
+  segment.signature = signature;
+  return segment;
+}
+
++ (instancetype)mathSegmentWithSegment:(ENRMMathSegment *)mathSegment signature:(NSString *)signature
+{
+  NSParameterAssert(mathSegment != nil);
+  NSParameterAssert(signature != nil);
+  ENRMRenderedSegment *segment = [[ENRMRenderedSegment alloc] init];
+  segment.kind = ENRMSegmentKindMath;
+  segment.mathSegment = mathSegment;
+  segment.signature = signature;
+  return segment;
+}
+@end
+
+NSString *ENRMSignatureForNode(MarkdownASTNode *node)
+{
+  if (!node)
+    return @"";
+
+  NSMutableString *signature = [NSMutableString stringWithFormat:@"%ld|%@|", (long)node.type, node.content ?: @""];
+  NSArray *keys = [[node.attributes allKeys] sortedArrayUsingSelector:@selector(compare:)];
+  for (NSString *key in keys) {
+    [signature appendFormat:@"%@=%@;", key, node.attributes[key]];
+  }
+  [signature appendString:@"["];
+  for (MarkdownASTNode *child in node.children) {
+    [signature appendString:ENRMSignatureForNode(child)];
+    [signature appendString:@","];
+  }
+  [signature appendString:@"]"];
+  return signature;
+}
+
+NSString *ENRMSignatureForNodes(NSArray<MarkdownASTNode *> *nodes)
+{
+  NSMutableString *signature = [NSMutableString string];
+  for (MarkdownASTNode *node in nodes) {
+    [signature appendString:ENRMSignatureForNode(node)];
+    [signature appendString:@"|"];
+  }
+  return signature;
+}

--- a/ios/utils/RenderedMarkdownSegment.m
+++ b/ios/utils/RenderedMarkdownSegment.m
@@ -32,10 +32,9 @@
 @end
 
 @implementation ENRMRenderedSegment
-+ (instancetype)textSegmentWithResult:(ENRMRenderResult *)result signature:(NSString *)signature
++ (instancetype)textSegmentWithResult:(ENRMRenderResult *)result signature:(uint64_t)signature
 {
   NSParameterAssert(result != nil);
-  NSParameterAssert(signature != nil);
   ENRMRenderedSegment *segment = [[ENRMRenderedSegment alloc] init];
   segment.kind = ENRMSegmentKindText;
   segment.textResult = result;
@@ -43,10 +42,9 @@
   return segment;
 }
 
-+ (instancetype)tableSegmentWithSegment:(ENRMTableSegment *)tableSegment signature:(NSString *)signature
++ (instancetype)tableSegmentWithSegment:(ENRMTableSegment *)tableSegment signature:(uint64_t)signature
 {
   NSParameterAssert(tableSegment != nil);
-  NSParameterAssert(signature != nil);
   ENRMRenderedSegment *segment = [[ENRMRenderedSegment alloc] init];
   segment.kind = ENRMSegmentKindTable;
   segment.tableSegment = tableSegment;
@@ -54,10 +52,9 @@
   return segment;
 }
 
-+ (instancetype)mathSegmentWithSegment:(ENRMMathSegment *)mathSegment signature:(NSString *)signature
++ (instancetype)mathSegmentWithSegment:(ENRMMathSegment *)mathSegment signature:(uint64_t)signature
 {
   NSParameterAssert(mathSegment != nil);
-  NSParameterAssert(signature != nil);
   ENRMRenderedSegment *segment = [[ENRMRenderedSegment alloc] init];
   segment.kind = ENRMSegmentKindMath;
   segment.mathSegment = mathSegment;
@@ -66,31 +63,68 @@
 }
 @end
 
-NSString *ENRMSignatureForNode(MarkdownASTNode *node)
-{
-  if (!node)
-    return @"";
+// FNV-1a 64-bit hash for segment signatures. Collisions are theoretically
+// possible but negligible for the small number of segments per document
+// (~single digits). Worst case is a single skipped view update, corrected
+// on the next streaming tick. This replaces the previous approach of building
+// and comparing multi-KB NSString signatures from the full AST subtree.
+static const uint64_t kFNVOffsetBasis = 14695981039346656037ULL;
+static const uint64_t kFNVPrime = 1099511628211ULL;
 
-  NSMutableString *signature = [NSMutableString stringWithFormat:@"%ld|%@|", (long)node.type, node.content ?: @""];
-  NSArray *keys = [[node.attributes allKeys] sortedArrayUsingSelector:@selector(compare:)];
-  for (NSString *key in keys) {
-    [signature appendFormat:@"%@=%@;", key, node.attributes[key]];
-  }
-  [signature appendString:@"["];
-  for (MarkdownASTNode *child in node.children) {
-    [signature appendString:ENRMSignatureForNode(child)];
-    [signature appendString:@","];
-  }
-  [signature appendString:@"]"];
-  return signature;
+static inline uint64_t fnvMixByte(uint64_t hash, uint8_t byte)
+{
+  hash ^= byte;
+  hash *= kFNVPrime;
+  return hash;
 }
 
-NSString *ENRMSignatureForNodes(NSArray<MarkdownASTNode *> *nodes)
+static inline uint64_t fnvMixUInt64(uint64_t hash, uint64_t value)
 {
-  NSMutableString *signature = [NSMutableString string];
-  for (MarkdownASTNode *node in nodes) {
-    [signature appendString:ENRMSignatureForNode(node)];
-    [signature appendString:@"|"];
+  for (int i = 0; i < 8; i++) {
+    hash = fnvMixByte(hash, (uint8_t)(value & 0xFF));
+    value >>= 8;
   }
-  return signature;
+  return hash;
+}
+
+static inline uint64_t fnvMixString(uint64_t hash, NSString *string)
+{
+  if (!string)
+    return hash;
+  const char *utf8 = [string UTF8String];
+  while (*utf8) {
+    hash = fnvMixByte(hash, (uint8_t)*utf8++);
+  }
+  return hash;
+}
+
+uint64_t ENRMSignatureForNode(MarkdownASTNode *node)
+{
+  if (!node)
+    return kFNVOffsetBasis;
+
+  uint64_t hash = kFNVOffsetBasis;
+  hash = fnvMixUInt64(hash, (uint64_t)node.type);
+  hash = fnvMixString(hash, node.content);
+
+  NSArray *keys = [[node.attributes allKeys] sortedArrayUsingSelector:@selector(compare:)];
+  for (NSString *key in keys) {
+    hash = fnvMixString(hash, key);
+    hash = fnvMixString(hash, node.attributes[key]);
+  }
+
+  for (MarkdownASTNode *child in node.children) {
+    hash = fnvMixUInt64(hash, ENRMSignatureForNode(child));
+  }
+
+  return hash;
+}
+
+uint64_t ENRMSignatureForNodes(NSArray<MarkdownASTNode *> *nodes)
+{
+  uint64_t hash = kFNVOffsetBasis;
+  for (MarkdownASTNode *node in nodes) {
+    hash = fnvMixUInt64(hash, ENRMSignatureForNode(node));
+  }
+  return hash;
 }

--- a/ios/utils/SegmentReconciler.h
+++ b/ios/utils/SegmentReconciler.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#import "ENRMUIKit.h"
+
+@class ENRMRenderedSegment;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ENRMSegmentReconciliationResult : NSObject
+@property (nonatomic, strong) NSMutableArray<RCTUIView *> *views;
+@property (nonatomic, strong) NSMutableArray<NSString *> *signatures;
+@end
+
+@interface ENRMSegmentReconciler : NSObject
+// Reuses views by index when the segment kind still matches. Matching
+// signatures skip updates; changed signatures update the existing view.
++ (ENRMSegmentReconciliationResult *)
+    reconcileCurrentViews:(NSArray<RCTUIView *> *)currentViews
+        currentSignatures:(NSArray<NSString *> *)currentSignatures
+         renderedSegments:(NSArray<ENRMRenderedSegment *> *)renderedSegments
+                    reset:(BOOL)reset
+               createView:(RCTUIView * (^)(ENRMRenderedSegment *segment))createView
+               updateView:(void (^)(RCTUIView *view, ENRMRenderedSegment *segment))updateView
+               attachView:(void (^)(RCTUIView *view))attachView
+               removeView:(void (^)(RCTUIView *view))removeView
+              matchesKind:(BOOL (^)(RCTUIView *view, ENRMRenderedSegment *segment))matchesKind;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/utils/SegmentReconciler.h
+++ b/ios/utils/SegmentReconciler.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ENRMSegmentReconciliationResult : NSObject
 @property (nonatomic, strong) NSMutableArray<RCTUIView *> *views;
-@property (nonatomic, strong) NSMutableArray<NSString *> *signatures;
+@property (nonatomic, strong) NSMutableArray<NSNumber *> *signatures;
 @end
 
 @interface ENRMSegmentReconciler : NSObject
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 // signatures skip updates; changed signatures update the existing view.
 + (ENRMSegmentReconciliationResult *)
     reconcileCurrentViews:(NSArray<RCTUIView *> *)currentViews
-        currentSignatures:(NSArray<NSString *> *)currentSignatures
+        currentSignatures:(NSArray<NSNumber *> *)currentSignatures
          renderedSegments:(NSArray<ENRMRenderedSegment *> *)renderedSegments
                     reset:(BOOL)reset
                createView:(RCTUIView * (^)(ENRMRenderedSegment *segment))createView

--- a/ios/utils/SegmentReconciler.h
+++ b/ios/utils/SegmentReconciler.h
@@ -12,8 +12,11 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface ENRMSegmentReconciler : NSObject
-// Reuses views by index when the segment kind still matches. Matching
-// signatures skip updates; changed signatures update the existing view.
+// Reconciles segment views using a two-pass strategy:
+// 1. Try positional match: if the view at the same index matches kind, reuse it.
+// 2. Fall back to signature-based lookup: find an unused view with the same
+//    kind+signature elsewhere in the old list. This handles mid-stream segment
+//    insertions where a completed table/math block shifts position.
 + (ENRMSegmentReconciliationResult *)
     reconcileCurrentViews:(NSArray<RCTUIView *> *)currentViews
         currentSignatures:(NSArray<NSNumber *> *)currentSignatures

--- a/ios/utils/SegmentReconciler.m
+++ b/ios/utils/SegmentReconciler.m
@@ -7,7 +7,7 @@
 @implementation ENRMSegmentReconciler
 + (ENRMSegmentReconciliationResult *)
     reconcileCurrentViews:(NSArray<RCTUIView *> *)currentViews
-        currentSignatures:(NSArray<NSString *> *)currentSignatures
+        currentSignatures:(NSArray<NSNumber *> *)currentSignatures
          renderedSegments:(NSArray<ENRMRenderedSegment *> *)renderedSegments
                     reset:(BOOL)reset
                createView:(RCTUIView * (^)(ENRMRenderedSegment *segment))createView
@@ -17,7 +17,7 @@
               matchesKind:(BOOL (^)(RCTUIView *view, ENRMRenderedSegment *segment))matchesKind
 {
   NSArray<RCTUIView *> *sourceViews = currentViews;
-  NSArray<NSString *> *sourceSignatures = currentSignatures;
+  NSArray<NSNumber *> *sourceSignatures = currentSignatures;
 
   if (reset) {
     [currentViews enumerateObjectsUsingBlock:^(RCTUIView *view, NSUInteger index, BOOL *stop) { removeView(view); }];
@@ -26,17 +26,17 @@
   }
 
   NSMutableArray<RCTUIView *> *nextViews = [NSMutableArray arrayWithCapacity:renderedSegments.count];
-  NSMutableArray<NSString *> *nextSignatures = [NSMutableArray arrayWithCapacity:renderedSegments.count];
+  NSMutableArray<NSNumber *> *nextSignatures = [NSMutableArray arrayWithCapacity:renderedSegments.count];
   NSMutableSet<RCTUIView *> *reusedViews = [NSMutableSet setWithCapacity:sourceViews.count];
 
   [renderedSegments enumerateObjectsUsingBlock:^(ENRMRenderedSegment *segment, NSUInteger index, BOOL *stop) {
     RCTUIView *existingView = index < sourceViews.count ? sourceViews[index] : nil;
-    NSString *existingSignature = index < sourceSignatures.count ? sourceSignatures[index] : nil;
+    NSNumber *existingSignature = index < sourceSignatures.count ? sourceSignatures[index] : nil;
     RCTUIView *view = nil;
-    NSString *nextSignature = segment.signature ?: @"";
+    NSNumber *nextSignature = @(segment.signature);
 
     if (existingView && matchesKind(existingView, segment)) {
-      if (![existingSignature isEqualToString:nextSignature]) {
+      if (![existingSignature isEqual:nextSignature]) {
         updateView(existingView, segment);
       }
       view = existingView;

--- a/ios/utils/SegmentReconciler.m
+++ b/ios/utils/SegmentReconciler.m
@@ -1,0 +1,64 @@
+#import "SegmentReconciler.h"
+#import "RenderedMarkdownSegment.h"
+
+@implementation ENRMSegmentReconciliationResult
+@end
+
+@implementation ENRMSegmentReconciler
++ (ENRMSegmentReconciliationResult *)
+    reconcileCurrentViews:(NSArray<RCTUIView *> *)currentViews
+        currentSignatures:(NSArray<NSString *> *)currentSignatures
+         renderedSegments:(NSArray<ENRMRenderedSegment *> *)renderedSegments
+                    reset:(BOOL)reset
+               createView:(RCTUIView * (^)(ENRMRenderedSegment *segment))createView
+               updateView:(void (^)(RCTUIView *view, ENRMRenderedSegment *segment))updateView
+               attachView:(void (^)(RCTUIView *view))attachView
+               removeView:(void (^)(RCTUIView *view))removeView
+              matchesKind:(BOOL (^)(RCTUIView *view, ENRMRenderedSegment *segment))matchesKind
+{
+  NSArray<RCTUIView *> *sourceViews = currentViews;
+  NSArray<NSString *> *sourceSignatures = currentSignatures;
+
+  if (reset) {
+    [currentViews enumerateObjectsUsingBlock:^(RCTUIView *view, NSUInteger index, BOOL *stop) { removeView(view); }];
+    sourceViews = @[];
+    sourceSignatures = @[];
+  }
+
+  NSMutableArray<RCTUIView *> *nextViews = [NSMutableArray arrayWithCapacity:renderedSegments.count];
+  NSMutableArray<NSString *> *nextSignatures = [NSMutableArray arrayWithCapacity:renderedSegments.count];
+  NSMutableSet<RCTUIView *> *reusedViews = [NSMutableSet setWithCapacity:sourceViews.count];
+
+  [renderedSegments enumerateObjectsUsingBlock:^(ENRMRenderedSegment *segment, NSUInteger index, BOOL *stop) {
+    RCTUIView *existingView = index < sourceViews.count ? sourceViews[index] : nil;
+    NSString *existingSignature = index < sourceSignatures.count ? sourceSignatures[index] : nil;
+    RCTUIView *view = nil;
+    NSString *nextSignature = segment.signature ?: @"";
+
+    if (existingView && matchesKind(existingView, segment)) {
+      if (![existingSignature isEqualToString:nextSignature]) {
+        updateView(existingView, segment);
+      }
+      view = existingView;
+    } else {
+      view = createView(segment);
+      attachView(view);
+    }
+
+    [nextViews addObject:view];
+    [nextSignatures addObject:nextSignature];
+    [reusedViews addObject:view];
+  }];
+
+  [sourceViews enumerateObjectsUsingBlock:^(RCTUIView *view, NSUInteger index, BOOL *stop) {
+    if (![reusedViews containsObject:view]) {
+      removeView(view);
+    }
+  }];
+
+  ENRMSegmentReconciliationResult *result = [[ENRMSegmentReconciliationResult alloc] init];
+  result.views = nextViews;
+  result.signatures = nextSignatures;
+  return result;
+}
+@end

--- a/ios/utils/SegmentReconciler.m
+++ b/ios/utils/SegmentReconciler.m
@@ -25,6 +25,21 @@
     sourceSignatures = @[];
   }
 
+  // Build a signature -> (view, index) lookup for fallback reuse when
+  // positional matching fails (e.g. a new segment inserted before an
+  // existing table shifts it to a different index).
+  NSMutableDictionary<NSNumber *, NSMutableArray<NSNumber *> *> *signatureToIndices =
+      [NSMutableDictionary dictionaryWithCapacity:sourceSignatures.count];
+  [sourceSignatures enumerateObjectsUsingBlock:^(NSNumber *sig, NSUInteger idx, BOOL *stop) {
+    NSMutableArray<NSNumber *> *indices = signatureToIndices[sig];
+    if (!indices) {
+      indices = [NSMutableArray arrayWithObject:@(idx)];
+      signatureToIndices[sig] = indices;
+    } else {
+      [indices addObject:@(idx)];
+    }
+  }];
+
   NSMutableArray<RCTUIView *> *nextViews = [NSMutableArray arrayWithCapacity:renderedSegments.count];
   NSMutableArray<NSNumber *> *nextSignatures = [NSMutableArray arrayWithCapacity:renderedSegments.count];
   NSMutableSet<RCTUIView *> *reusedViews = [NSMutableSet setWithCapacity:sourceViews.count];
@@ -35,12 +50,30 @@
     RCTUIView *view = nil;
     NSNumber *nextSignature = @(segment.signature);
 
-    if (existingView && matchesKind(existingView, segment)) {
+    // 1. Positional match: same index, same kind.
+    if (existingView && ![reusedViews containsObject:existingView] && matchesKind(existingView, segment)) {
       if (![existingSignature isEqual:nextSignature]) {
         updateView(existingView, segment);
       }
       view = existingView;
-    } else {
+    }
+
+    // 2. Signature-based fallback: find an unused view with exact same signature.
+    if (!view) {
+      NSMutableArray<NSNumber *> *candidateIndices = signatureToIndices[nextSignature];
+      while (candidateIndices.count > 0) {
+        NSUInteger candidateIdx = candidateIndices.firstObject.unsignedIntegerValue;
+        [candidateIndices removeObjectAtIndex:0];
+        RCTUIView *candidate = sourceViews[candidateIdx];
+        if (![reusedViews containsObject:candidate] && matchesKind(candidate, segment)) {
+          view = candidate;
+          break;
+        }
+      }
+    }
+
+    // 3. No reusable view found — create a new one.
+    if (!view) {
       view = createView(segment);
       attachView(view);
     }

--- a/ios/utils/SegmentReconciler.m
+++ b/ios/utils/SegmentReconciler.m
@@ -40,6 +40,14 @@
     }
   }];
 
+  NSMutableDictionary<NSNumber *, NSNumber *> *remainingNextSignatureCounts =
+      [NSMutableDictionary dictionaryWithCapacity:renderedSegments.count];
+  for (ENRMRenderedSegment *segment in renderedSegments) {
+    NSNumber *signature = @(segment.signature);
+    NSUInteger count = remainingNextSignatureCounts[signature].unsignedIntegerValue;
+    remainingNextSignatureCounts[signature] = @(count + 1);
+  }
+
   NSMutableArray<RCTUIView *> *nextViews = [NSMutableArray arrayWithCapacity:renderedSegments.count];
   NSMutableArray<NSNumber *> *nextSignatures = [NSMutableArray arrayWithCapacity:renderedSegments.count];
   NSMutableSet<RCTUIView *> *reusedViews = [NSMutableSet setWithCapacity:sourceViews.count];
@@ -50,11 +58,16 @@
     RCTUIView *view = nil;
     NSNumber *nextSignature = @(segment.signature);
 
-    // 1. Positional match: same index, same kind.
-    if (existingView && ![reusedViews containsObject:existingView] && matchesKind(existingView, segment)) {
-      if (![existingSignature isEqual:nextSignature]) {
-        updateView(existingView, segment);
-      }
+    NSUInteger remainingNextSignatureCount = remainingNextSignatureCounts[nextSignature].unsignedIntegerValue;
+    if (remainingNextSignatureCount > 1) {
+      remainingNextSignatureCounts[nextSignature] = @(remainingNextSignatureCount - 1);
+    } else {
+      [remainingNextSignatureCounts removeObjectForKey:nextSignature];
+    }
+
+    // 1. Exact positional match: the same view still represents the same segment.
+    if (existingView && ![reusedViews containsObject:existingView] && matchesKind(existingView, segment) &&
+        [existingSignature isEqual:nextSignature]) {
       view = existingView;
     }
 
@@ -72,7 +85,15 @@
       }
     }
 
-    // 3. No reusable view found — create a new one.
+    // 3. Same-kind positional update. If this old signature appears later in
+    // the new list, leave the view available for that exact reuse instead.
+    if (!view && existingView && ![reusedViews containsObject:existingView] && matchesKind(existingView, segment) &&
+        (existingSignature == nil || remainingNextSignatureCounts[existingSignature].unsignedIntegerValue == 0)) {
+      updateView(existingView, segment);
+      view = existingView;
+    }
+
+    // 4. No reusable view found — create a new one.
     if (!view) {
       view = createView(segment);
       attachView(view);

--- a/ios/utils/SegmentRenderer.h
+++ b/ios/utils/SegmentRenderer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+@class ENRMRenderedSegment;
+@class MarkdownASTNode;
+@class StyleConfig;
+
+NS_ASSUME_NONNULL_BEGIN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NSArray<ENRMRenderedSegment *> *ENRMRenderSegmentsFromAST(MarkdownASTNode *ast, StyleConfig *config,
+                                                          BOOL allowTrailingMargin, BOOL allowFontScaling,
+                                                          CGFloat maxFontSizeMultiplier);
+
+#ifdef __cplusplus
+}
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/ios/utils/SegmentRenderer.m
+++ b/ios/utils/SegmentRenderer.m
@@ -1,0 +1,79 @@
+#import "SegmentRenderer.h"
+#import "ENRMFeatureFlags.h"
+#import "ENRMTextRenderer.h"
+#import "MarkdownASTNode.h"
+#import "ParagraphStyleUtils.h"
+#import "RenderedMarkdownSegment.h"
+
+static NSArray *ENRMSplitASTIntoSegments(MarkdownASTNode *root)
+{
+  NSMutableArray *segments = [NSMutableArray array];
+  NSMutableArray *currentTextNodes = [NSMutableArray array];
+
+  for (MarkdownASTNode *child in root.children) {
+    if (child.type == MarkdownNodeTypeTable) {
+      if (currentTextNodes.count > 0) {
+        [segments addObject:[ENRMTextSegment segmentWithNodes:[currentTextNodes copy]]];
+        [currentTextNodes removeAllObjects];
+      }
+      [segments addObject:[ENRMTableSegment segmentWithTableNode:child]];
+    }
+#if ENRICHED_MARKDOWN_MATH
+    else if (child.type == MarkdownNodeTypeLatexMathDisplay) {
+#if !TARGET_OS_OSX
+      if (currentTextNodes.count > 0) {
+        [segments addObject:[ENRMTextSegment segmentWithNodes:[currentTextNodes copy]]];
+        [currentTextNodes removeAllObjects];
+      }
+      NSString *latex = child.children.count > 0 ? child.children.firstObject.content : child.content;
+      [segments addObject:[ENRMMathSegment segmentWithLatex:latex ?: @""]];
+#else
+      // TODO: Fix block math rendering on macOS. Adding ENRMMathContainerView (which
+      // hosts MTMathUILabel) as a segment causes all preceding text segments to become
+      // invisible. Likely related to MTMathUILabel.layer.geometryFlipped interacting
+      // with NSTextView's coordinate system. Inline math ($...$) works.
+#endif
+    }
+#endif
+    else {
+      [currentTextNodes addObject:child];
+    }
+  }
+
+  if (currentTextNodes.count > 0) {
+    [segments addObject:[ENRMTextSegment segmentWithNodes:currentTextNodes]];
+  }
+
+  return segments;
+}
+
+NSArray<ENRMRenderedSegment *> *ENRMRenderSegmentsFromAST(MarkdownASTNode *ast, StyleConfig *config,
+                                                          BOOL allowTrailingMargin, BOOL allowFontScaling,
+                                                          CGFloat maxFontSizeMultiplier)
+{
+  NSArray *segments = ENRMSplitASTIntoSegments(ast);
+  NSMutableArray<ENRMRenderedSegment *> *renderedSegments = [NSMutableArray array];
+
+  for (id segment in segments) {
+    if ([segment isKindOfClass:[ENRMTextSegment class]]) {
+      ENRMTextSegment *textSegment = (ENRMTextSegment *)segment;
+      ENRMRenderResult *rendered = ENRMRenderASTNodes(textSegment.nodes, config, allowTrailingMargin, allowFontScaling,
+                                                      maxFontSizeMultiplier, currentWritingDirection());
+      NSString *signature = [@"text:" stringByAppendingString:ENRMSignatureForNodes(textSegment.nodes)];
+      [renderedSegments addObject:[ENRMRenderedSegment textSegmentWithResult:rendered signature:signature]];
+    } else if ([segment isKindOfClass:[ENRMTableSegment class]]) {
+      ENRMTableSegment *tableSegment = (ENRMTableSegment *)segment;
+      NSString *signature = [@"table:" stringByAppendingString:ENRMSignatureForNode(tableSegment.tableNode)];
+      [renderedSegments addObject:[ENRMRenderedSegment tableSegmentWithSegment:tableSegment signature:signature]];
+    }
+#if ENRICHED_MARKDOWN_MATH
+    else if ([segment isKindOfClass:[ENRMMathSegment class]]) {
+      ENRMMathSegment *mathSegment = (ENRMMathSegment *)segment;
+      NSString *signature = [@"math:" stringByAppendingString:mathSegment.latex ?: @""];
+      [renderedSegments addObject:[ENRMRenderedSegment mathSegmentWithSegment:mathSegment signature:signature]];
+    }
+#endif
+  }
+
+  return renderedSegments;
+}

--- a/ios/utils/SegmentRenderer.m
+++ b/ios/utils/SegmentRenderer.m
@@ -54,22 +54,32 @@ NSArray<ENRMRenderedSegment *> *ENRMRenderSegmentsFromAST(MarkdownASTNode *ast, 
   NSArray *segments = ENRMSplitASTIntoSegments(ast);
   NSMutableArray<ENRMRenderedSegment *> *renderedSegments = [NSMutableArray array];
 
+  static const uint64_t kTextKindSalt = 0x7465787400000000ULL;  // "text"
+  static const uint64_t kTableKindSalt = 0x7461626C00000000ULL; // "tabl"
+  static const uint64_t kMathKindSalt = 0x6D61746800000000ULL;  // "math"
+
   for (id segment in segments) {
     if ([segment isKindOfClass:[ENRMTextSegment class]]) {
       ENRMTextSegment *textSegment = (ENRMTextSegment *)segment;
       ENRMRenderResult *rendered = ENRMRenderASTNodes(textSegment.nodes, config, allowTrailingMargin, allowFontScaling,
                                                       maxFontSizeMultiplier, currentWritingDirection());
-      NSString *signature = [@"text:" stringByAppendingString:ENRMSignatureForNodes(textSegment.nodes)];
+      uint64_t signature = ENRMSignatureForNodes(textSegment.nodes) ^ kTextKindSalt;
       [renderedSegments addObject:[ENRMRenderedSegment textSegmentWithResult:rendered signature:signature]];
     } else if ([segment isKindOfClass:[ENRMTableSegment class]]) {
       ENRMTableSegment *tableSegment = (ENRMTableSegment *)segment;
-      NSString *signature = [@"table:" stringByAppendingString:ENRMSignatureForNode(tableSegment.tableNode)];
+      uint64_t signature = ENRMSignatureForNode(tableSegment.tableNode) ^ kTableKindSalt;
       [renderedSegments addObject:[ENRMRenderedSegment tableSegmentWithSegment:tableSegment signature:signature]];
     }
 #if ENRICHED_MARKDOWN_MATH
     else if ([segment isKindOfClass:[ENRMMathSegment class]]) {
       ENRMMathSegment *mathSegment = (ENRMMathSegment *)segment;
-      NSString *signature = [@"math:" stringByAppendingString:mathSegment.latex ?: @""];
+      uint64_t signature = ENRMSignatureForNode(nil) ^ kMathKindSalt;
+      NSString *latex = mathSegment.latex ?: @"";
+      const char *utf8 = [latex UTF8String];
+      while (*utf8) {
+        signature ^= (uint8_t)*utf8++;
+        signature *= 1099511628211ULL;
+      }
       [renderedSegments addObject:[ENRMRenderedSegment mathSegmentWithSegment:mathSegment signature:signature]];
     }
 #endif

--- a/ios/utils/SegmentViewRegistry.h
+++ b/ios/utils/SegmentViewRegistry.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#import "ENRMUIKit.h"
+#import "RenderedMarkdownSegment.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef BOOL (^ENRMSegmentMatchesViewBlock)(RCTUIView *view, ENRMRenderedSegment *segment);
+typedef RCTUIView *_Nonnull (^ENRMSegmentCreateViewBlock)(ENRMRenderedSegment *segment, BOOL animateIfStreaming);
+typedef void (^ENRMSegmentUpdateViewBlock)(RCTUIView *view, ENRMRenderedSegment *segment);
+
+@interface ENRMSegmentViewHandler : NSObject
+
+@property (nonatomic, assign, readonly) ENRMSegmentKind kind;
+@property (nonatomic, copy, readonly) ENRMSegmentMatchesViewBlock matchesView;
+@property (nonatomic, copy, readonly) ENRMSegmentCreateViewBlock createView;
+@property (nonatomic, copy, readonly) ENRMSegmentUpdateViewBlock updateView;
+
++ (instancetype)handlerWithKind:(ENRMSegmentKind)kind
+                    matchesView:(ENRMSegmentMatchesViewBlock)matchesView
+                     createView:(ENRMSegmentCreateViewBlock)createView
+                     updateView:(ENRMSegmentUpdateViewBlock)updateView;
+
+@end
+
+@interface ENRMSegmentViewRegistry : NSObject
+
+- (instancetype)initWithHandlers:(NSArray<ENRMSegmentViewHandler *> *)handlers;
+
+- (BOOL)view:(RCTUIView *)view matchesSegment:(ENRMRenderedSegment *)segment;
+- (RCTUIView *)createViewForSegment:(ENRMRenderedSegment *)segment animateIfStreaming:(BOOL)animateIfStreaming;
+- (void)updateView:(RCTUIView *)view withSegment:(ENRMRenderedSegment *)segment;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/utils/SegmentViewRegistry.h
+++ b/ios/utils/SegmentViewRegistry.h
@@ -6,7 +6,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef BOOL (^ENRMSegmentMatchesViewBlock)(RCTUIView *view, ENRMRenderedSegment *segment);
-typedef RCTUIView *_Nonnull (^ENRMSegmentCreateViewBlock)(ENRMRenderedSegment *segment, BOOL animateIfStreaming);
+typedef RCTUIView *_Nonnull (^ENRMSegmentCreateViewBlock)(ENRMRenderedSegment *segment);
 typedef void (^ENRMSegmentUpdateViewBlock)(RCTUIView *view, ENRMRenderedSegment *segment);
 
 @interface ENRMSegmentViewHandler : NSObject
@@ -28,7 +28,7 @@ typedef void (^ENRMSegmentUpdateViewBlock)(RCTUIView *view, ENRMRenderedSegment 
 - (instancetype)initWithHandlers:(NSArray<ENRMSegmentViewHandler *> *)handlers;
 
 - (BOOL)view:(RCTUIView *)view matchesSegment:(ENRMRenderedSegment *)segment;
-- (RCTUIView *)createViewForSegment:(ENRMRenderedSegment *)segment animateIfStreaming:(BOOL)animateIfStreaming;
+- (RCTUIView *)createViewForSegment:(ENRMRenderedSegment *)segment;
 - (void)updateView:(RCTUIView *)view withSegment:(ENRMRenderedSegment *)segment;
 
 @end

--- a/ios/utils/SegmentViewRegistry.m
+++ b/ios/utils/SegmentViewRegistry.m
@@ -45,14 +45,14 @@
   return handler != nil && handler.matchesView(view, segment);
 }
 
-- (RCTUIView *)createViewForSegment:(ENRMRenderedSegment *)segment animateIfStreaming:(BOOL)animateIfStreaming
+- (RCTUIView *)createViewForSegment:(ENRMRenderedSegment *)segment
 {
   ENRMSegmentViewHandler *handler = [self handlerForSegment:segment];
   NSAssert(handler != nil, @"Missing segment view handler for kind %ld", (long)segment.kind);
   if (!handler) {
     return [[RCTUIView alloc] init];
   }
-  return handler.createView(segment, animateIfStreaming);
+  return handler.createView(segment);
 }
 
 - (void)updateView:(RCTUIView *)view withSegment:(ENRMRenderedSegment *)segment

--- a/ios/utils/SegmentViewRegistry.m
+++ b/ios/utils/SegmentViewRegistry.m
@@ -1,0 +1,67 @@
+#import "SegmentViewRegistry.h"
+
+@implementation ENRMSegmentViewHandler
+
++ (instancetype)handlerWithKind:(ENRMSegmentKind)kind
+                    matchesView:(ENRMSegmentMatchesViewBlock)matchesView
+                     createView:(ENRMSegmentCreateViewBlock)createView
+                     updateView:(ENRMSegmentUpdateViewBlock)updateView
+{
+  ENRMSegmentViewHandler *handler = [[ENRMSegmentViewHandler alloc] init];
+  handler->_kind = kind;
+  handler->_matchesView = [matchesView copy];
+  handler->_createView = [createView copy];
+  handler->_updateView = [updateView copy];
+  return handler;
+}
+
+@end
+
+@implementation ENRMSegmentViewRegistry {
+  NSDictionary<NSNumber *, ENRMSegmentViewHandler *> *_handlersByKind;
+}
+
+- (instancetype)initWithHandlers:(NSArray<ENRMSegmentViewHandler *> *)handlers
+{
+  if (self = [super init]) {
+    NSMutableDictionary<NSNumber *, ENRMSegmentViewHandler *> *handlersByKind = [NSMutableDictionary dictionary];
+    for (ENRMSegmentViewHandler *handler in handlers) {
+      handlersByKind[@(handler.kind)] = handler;
+    }
+    _handlersByKind = [handlersByKind copy];
+  }
+  return self;
+}
+
+- (nullable ENRMSegmentViewHandler *)handlerForSegment:(ENRMRenderedSegment *)segment
+{
+  return _handlersByKind[@(segment.kind)];
+}
+
+- (BOOL)view:(RCTUIView *)view matchesSegment:(ENRMRenderedSegment *)segment
+{
+  ENRMSegmentViewHandler *handler = [self handlerForSegment:segment];
+  NSAssert(handler != nil, @"Missing segment view handler for kind %ld", (long)segment.kind);
+  return handler != nil && handler.matchesView(view, segment);
+}
+
+- (RCTUIView *)createViewForSegment:(ENRMRenderedSegment *)segment animateIfStreaming:(BOOL)animateIfStreaming
+{
+  ENRMSegmentViewHandler *handler = [self handlerForSegment:segment];
+  NSAssert(handler != nil, @"Missing segment view handler for kind %ld", (long)segment.kind);
+  if (!handler) {
+    return [[RCTUIView alloc] init];
+  }
+  return handler.createView(segment, animateIfStreaming);
+}
+
+- (void)updateView:(RCTUIView *)view withSegment:(ENRMRenderedSegment *)segment
+{
+  ENRMSegmentViewHandler *handler = [self handlerForSegment:segment];
+  NSAssert(handler != nil, @"Missing segment view handler for kind %ld", (long)segment.kind);
+  if (handler && handler.matchesView(view, segment)) {
+    handler.updateView(view, segment);
+  }
+}
+
+@end

--- a/ios/utils/StreamingMarkdownFilter.h
+++ b/ios/utils/StreamingMarkdownFilter.h
@@ -4,11 +4,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, ENRMTableStreamingMode) {
+  ENRMTableStreamingModeHidden = 0,
+  ENRMTableStreamingModeProgressive,
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown);
+NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStreamingMode tableMode);
 
 #ifdef __cplusplus
 }

--- a/ios/utils/StreamingMarkdownFilter.h
+++ b/ios/utils/StreamingMarkdownFilter.h
@@ -2,97 +2,16 @@
 
 #import <Foundation/Foundation.h>
 
-static inline BOOL ENRMLineIsBlank(NSString *line)
-{
-  return [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]].length == 0;
+NS_ASSUME_NONNULL_BEGIN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown);
+
+#ifdef __cplusplus
 }
+#endif
 
-static inline BOOL ENRMLineIsBlockMathDelimiter(NSString *line)
-{
-  return [[line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] isEqualToString:@"$$"];
-}
-
-static inline BOOL ENRMLineLooksLikeTableRow(NSString *line)
-{
-  NSString *trimmed = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-  return [trimmed hasPrefix:@"|"] && [trimmed containsString:@"|"];
-}
-
-static inline NSUInteger ENRMLineStartOffset(NSArray<NSString *> *lines, NSUInteger lineIndex)
-{
-  NSUInteger offset = 0;
-  for (NSUInteger i = 0; i < lineIndex; i++) {
-    offset += lines[i].length;
-    offset += 1;
-  }
-  return offset;
-}
-
-static inline NSString *ENRMRemovePendingStreamingMathBlock(NSString *markdown)
-{
-  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
-  NSInteger lastUnclosedDelimiterIndex = -1;
-
-  for (NSUInteger i = 0; i < lines.count; i++) {
-    if (ENRMLineIsBlockMathDelimiter(lines[i])) {
-      lastUnclosedDelimiterIndex = lastUnclosedDelimiterIndex == -1 ? (NSInteger)i : -1;
-    }
-  }
-
-  if (lastUnclosedDelimiterIndex == -1) {
-    return markdown;
-  }
-
-  NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)lastUnclosedDelimiterIndex);
-  return [markdown substringToIndex:offset];
-}
-
-static inline NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown)
-{
-  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
-  NSInteger lastNonBlankLineIndex = -1;
-
-  for (NSInteger i = (NSInteger)lines.count - 1; i >= 0; i--) {
-    if (!ENRMLineIsBlank(lines[(NSUInteger)i])) {
-      lastNonBlankLineIndex = i;
-      break;
-    }
-  }
-
-  if (lastNonBlankLineIndex == -1) {
-    return markdown;
-  }
-
-  // During streaming, treat a trailing table as complete only after a blank
-  // separator line. A single trailing newline can still be followed by more rows.
-  if ((NSUInteger)lastNonBlankLineIndex + 1 < lines.count - 1) {
-    return markdown;
-  }
-
-  NSInteger blockStartIndex = lastNonBlankLineIndex;
-  while (blockStartIndex > 0 && !ENRMLineIsBlank(lines[(NSUInteger)blockStartIndex - 1])) {
-    blockStartIndex--;
-  }
-
-  BOOL blockLooksLikeTable = NO;
-  for (NSInteger i = blockStartIndex; i <= lastNonBlankLineIndex; i++) {
-    NSString *line = lines[(NSUInteger)i];
-    if (!ENRMLineLooksLikeTableRow(line)) {
-      return markdown;
-    }
-    blockLooksLikeTable = YES;
-  }
-
-  if (!blockLooksLikeTable) {
-    return markdown;
-  }
-
-  NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)blockStartIndex);
-  return [markdown substringToIndex:offset];
-}
-
-static inline NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown)
-{
-  NSString *withoutPendingMath = ENRMRemovePendingStreamingMathBlock(markdown);
-  return ENRMRemovePendingStreamingTableBlock(withoutPendingMath);
-}
+NS_ASSUME_NONNULL_END

--- a/ios/utils/StreamingMarkdownFilter.h
+++ b/ios/utils/StreamingMarkdownFilter.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+static inline BOOL ENRMLineIsBlank(NSString *line)
+{
+  return [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]].length == 0;
+}
+
+static inline BOOL ENRMLineIsBlockMathDelimiter(NSString *line)
+{
+  return [[line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] isEqualToString:@"$$"];
+}
+
+static inline BOOL ENRMLineLooksLikeTableRow(NSString *line)
+{
+  NSString *trimmed = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+  return [trimmed hasPrefix:@"|"] && [trimmed containsString:@"|"];
+}
+
+static inline NSUInteger ENRMLineStartOffset(NSArray<NSString *> *lines, NSUInteger lineIndex)
+{
+  NSUInteger offset = 0;
+  for (NSUInteger i = 0; i < lineIndex; i++) {
+    offset += lines[i].length;
+    offset += 1;
+  }
+  return offset;
+}
+
+static inline NSString *ENRMRemovePendingStreamingMathBlock(NSString *markdown)
+{
+  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
+  NSInteger lastUnclosedDelimiterIndex = -1;
+
+  for (NSUInteger i = 0; i < lines.count; i++) {
+    if (ENRMLineIsBlockMathDelimiter(lines[i])) {
+      lastUnclosedDelimiterIndex = lastUnclosedDelimiterIndex == -1 ? (NSInteger)i : -1;
+    }
+  }
+
+  if (lastUnclosedDelimiterIndex == -1) {
+    return markdown;
+  }
+
+  NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)lastUnclosedDelimiterIndex);
+  return [markdown substringToIndex:offset];
+}
+
+static inline NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown)
+{
+  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
+  NSInteger lastNonBlankLineIndex = -1;
+
+  for (NSInteger i = (NSInteger)lines.count - 1; i >= 0; i--) {
+    if (!ENRMLineIsBlank(lines[(NSUInteger)i])) {
+      lastNonBlankLineIndex = i;
+      break;
+    }
+  }
+
+  if (lastNonBlankLineIndex == -1) {
+    return markdown;
+  }
+
+  // During streaming, treat a trailing table as complete only after a blank
+  // separator line. A single trailing newline can still be followed by more rows.
+  if ((NSUInteger)lastNonBlankLineIndex + 1 < lines.count - 1) {
+    return markdown;
+  }
+
+  NSInteger blockStartIndex = lastNonBlankLineIndex;
+  while (blockStartIndex > 0 && !ENRMLineIsBlank(lines[(NSUInteger)blockStartIndex - 1])) {
+    blockStartIndex--;
+  }
+
+  BOOL blockLooksLikeTable = NO;
+  for (NSInteger i = blockStartIndex; i <= lastNonBlankLineIndex; i++) {
+    NSString *line = lines[(NSUInteger)i];
+    if (!ENRMLineLooksLikeTableRow(line)) {
+      return markdown;
+    }
+    blockLooksLikeTable = YES;
+  }
+
+  if (!blockLooksLikeTable) {
+    return markdown;
+  }
+
+  NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)blockStartIndex);
+  return [markdown substringToIndex:offset];
+}
+
+static inline NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown)
+{
+  NSString *withoutPendingMath = ENRMRemovePendingStreamingMathBlock(markdown);
+  return ENRMRemovePendingStreamingTableBlock(withoutPendingMath);
+}

--- a/ios/utils/StreamingMarkdownFilter.m
+++ b/ios/utils/StreamingMarkdownFilter.m
@@ -1,0 +1,96 @@
+#import "StreamingMarkdownFilter.h"
+
+static BOOL ENRMLineIsBlank(NSString *line)
+{
+  return [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]].length == 0;
+}
+
+static BOOL ENRMLineIsBlockMathDelimiter(NSString *line)
+{
+  return [[line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] isEqualToString:@"$$"];
+}
+
+static BOOL ENRMLineLooksLikeTableRow(NSString *line)
+{
+  NSString *trimmed = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+  return [trimmed hasPrefix:@"|"] && [trimmed containsString:@"|"];
+}
+
+static NSUInteger ENRMLineStartOffset(NSArray<NSString *> *lines, NSUInteger lineIndex)
+{
+  NSUInteger offset = 0;
+  for (NSUInteger i = 0; i < lineIndex; i++) {
+    offset += lines[i].length;
+    offset += 1;
+  }
+  return offset;
+}
+
+static NSString *ENRMRemovePendingStreamingMathBlock(NSString *markdown)
+{
+  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
+  NSInteger lastUnclosedDelimiterIndex = -1;
+
+  for (NSUInteger i = 0; i < lines.count; i++) {
+    if (ENRMLineIsBlockMathDelimiter(lines[i])) {
+      lastUnclosedDelimiterIndex = lastUnclosedDelimiterIndex == -1 ? (NSInteger)i : -1;
+    }
+  }
+
+  if (lastUnclosedDelimiterIndex == -1) {
+    return markdown;
+  }
+
+  NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)lastUnclosedDelimiterIndex);
+  return [markdown substringToIndex:offset];
+}
+
+static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown)
+{
+  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
+  NSInteger lastNonBlankLineIndex = -1;
+
+  for (NSInteger i = (NSInteger)lines.count - 1; i >= 0; i--) {
+    if (!ENRMLineIsBlank(lines[(NSUInteger)i])) {
+      lastNonBlankLineIndex = i;
+      break;
+    }
+  }
+
+  if (lastNonBlankLineIndex == -1) {
+    return markdown;
+  }
+
+  // During streaming, treat a trailing table as complete only after a blank
+  // separator line. A single trailing newline can still be followed by more rows.
+  if ((NSUInteger)lastNonBlankLineIndex + 1 < lines.count - 1) {
+    return markdown;
+  }
+
+  NSInteger blockStartIndex = lastNonBlankLineIndex;
+  while (blockStartIndex > 0 && !ENRMLineIsBlank(lines[(NSUInteger)blockStartIndex - 1])) {
+    blockStartIndex--;
+  }
+
+  BOOL blockLooksLikeTable = NO;
+  for (NSInteger i = blockStartIndex; i <= lastNonBlankLineIndex; i++) {
+    NSString *line = lines[(NSUInteger)i];
+    if (!ENRMLineLooksLikeTableRow(line)) {
+      return markdown;
+    }
+    blockLooksLikeTable = YES;
+  }
+
+  if (!blockLooksLikeTable) {
+    return markdown;
+  }
+
+  NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)blockStartIndex);
+  return [markdown substringToIndex:offset];
+}
+
+NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown)
+{
+  NSString *withoutPendingMath = ENRMRemovePendingStreamingMathBlock(markdown);
+  return ENRMRemovePendingStreamingTableBlock(withoutPendingMath);
+}

--- a/ios/utils/StreamingMarkdownFilter.m
+++ b/ios/utils/StreamingMarkdownFilter.m
@@ -16,6 +16,45 @@ static BOOL ENRMLineLooksLikeTableRow(NSString *line)
   return [trimmed hasPrefix:@"|"] && [trimmed containsString:@"|"];
 }
 
+static NSUInteger ENRMPipeCount(NSString *line)
+{
+  NSUInteger count = 0;
+  for (NSUInteger i = 0; i < line.length; i++) {
+    if ([line characterAtIndex:i] == '|') {
+      count++;
+    }
+  }
+  return count;
+}
+
+static BOOL ENRMLineLooksLikeTableSeparator(NSString *line)
+{
+  NSString *trimmed = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+  if (trimmed.length == 0) {
+    return NO;
+  }
+  if ([trimmed characterAtIndex:0] != '|') {
+    return NO;
+  }
+  BOOL hasTripleDash = NO;
+  NSUInteger dashRun = 0;
+  for (NSUInteger i = 0; i < trimmed.length; i++) {
+    unichar ch = [trimmed characterAtIndex:i];
+    if (ch == '-') {
+      dashRun++;
+      if (dashRun >= 3) {
+        hasTripleDash = YES;
+      }
+    } else {
+      dashRun = 0;
+      if (ch != '|' && ch != ':' && ch != ' ') {
+        return NO;
+      }
+    }
+  }
+  return hasTripleDash;
+}
+
 static NSUInteger ENRMLineStartOffset(NSArray<NSString *> *lines, NSUInteger lineIndex)
 {
   NSUInteger offset = 0;
@@ -45,7 +84,7 @@ static NSString *ENRMRemovePendingStreamingMathBlock(NSString *markdown)
   return [markdown substringToIndex:offset];
 }
 
-static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown)
+static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown, ENRMTableStreamingMode tableMode)
 {
   NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
   NSInteger lastNonBlankLineIndex = -1;
@@ -85,12 +124,36 @@ static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown)
     return markdown;
   }
 
+  if (tableMode == ENRMTableStreamingModeProgressive) {
+    NSInteger tableLineCount = lastNonBlankLineIndex - blockStartIndex + 1;
+
+    // Need at least header + separator to show anything.
+    if (tableLineCount < 2 || !ENRMLineLooksLikeTableSeparator(lines[(NSUInteger)blockStartIndex + 1])) {
+      NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)blockStartIndex);
+      return [markdown substringToIndex:offset];
+    }
+
+    // Trim the last data row if it's incomplete: either doesn't end with '|'
+    // or has fewer pipe characters than the header (mid-cell streaming).
+    if (tableLineCount > 2) {
+      NSString *lastRow = lines[(NSUInteger)lastNonBlankLineIndex];
+      NSString *lastRowTrimmed = [lastRow stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+      NSString *headerRow = lines[(NSUInteger)blockStartIndex];
+      if (![lastRowTrimmed hasSuffix:@"|"] || ENRMPipeCount(lastRow) < ENRMPipeCount(headerRow)) {
+        NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)lastNonBlankLineIndex);
+        return [markdown substringToIndex:offset];
+      }
+    }
+
+    return markdown;
+  }
+
   NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)blockStartIndex);
   return [markdown substringToIndex:offset];
 }
 
-NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown)
+NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStreamingMode tableMode)
 {
   NSString *withoutPendingMath = ENRMRemovePendingStreamingMathBlock(markdown);
-  return ENRMRemovePendingStreamingTableBlock(withoutPendingMath);
+  return ENRMRemovePendingStreamingTableBlock(withoutPendingMath, tableMode);
 }

--- a/ios/utils/StreamingMarkdownFilter.m
+++ b/ios/utils/StreamingMarkdownFilter.m
@@ -13,7 +13,7 @@ static BOOL ENRMLineIsBlockMathDelimiter(NSString *line)
 static BOOL ENRMLineLooksLikeTableRow(NSString *line)
 {
   NSString *trimmed = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-  return [trimmed hasPrefix:@"|"] && [trimmed containsString:@"|"];
+  return [trimmed hasPrefix:@"|"];
 }
 
 static NSUInteger ENRMPipeCount(NSString *line)
@@ -55,19 +55,19 @@ static BOOL ENRMLineLooksLikeTableSeparator(NSString *line)
   return hasTripleDash;
 }
 
-static NSUInteger ENRMLineStartOffset(NSArray<NSString *> *lines, NSUInteger lineIndex)
+static NSUInteger *ENRMBuildLineOffsets(NSArray<NSString *> *lines, NSUInteger count)
 {
-  NSUInteger offset = 0;
-  for (NSUInteger i = 0; i < lineIndex; i++) {
-    offset += lines[i].length;
-    offset += 1;
+  NSUInteger *offsets = (NSUInteger *)calloc(count, sizeof(NSUInteger));
+  NSUInteger currentOffset = 0;
+  for (NSUInteger i = 0; i < count; i++) {
+    offsets[i] = currentOffset;
+    currentOffset += lines[i].length + 1;
   }
-  return offset;
+  return offsets;
 }
 
-static NSString *ENRMRemovePendingStreamingMathBlock(NSString *markdown)
+static NSString *ENRMRemovePendingStreamingMathBlock(NSString *markdown, NSArray<NSString *> *lines)
 {
-  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
   NSInteger lastUnclosedDelimiterIndex = -1;
 
   for (NSUInteger i = 0; i < lines.count; i++) {
@@ -80,13 +80,15 @@ static NSString *ENRMRemovePendingStreamingMathBlock(NSString *markdown)
     return markdown;
   }
 
-  NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)lastUnclosedDelimiterIndex);
-  return [markdown substringToIndex:offset];
+  NSUInteger *offsets = ENRMBuildLineOffsets(lines, lines.count);
+  NSString *result = [markdown substringToIndex:offsets[(NSUInteger)lastUnclosedDelimiterIndex]];
+  free(offsets);
+  return result;
 }
 
-static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown, ENRMTableStreamingMode tableMode)
+static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown, NSArray<NSString *> *lines,
+                                                      ENRMTableStreamingMode tableMode)
 {
-  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
   NSInteger lastNonBlankLineIndex = -1;
 
   for (NSInteger i = (NSInteger)lines.count - 1; i >= 0; i--) {
@@ -100,8 +102,6 @@ static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown, ENRMTa
     return markdown;
   }
 
-  // During streaming, treat a trailing table as complete only after a blank
-  // separator line. A single trailing newline can still be followed by more rows.
   if ((NSUInteger)lastNonBlankLineIndex + 1 < lines.count - 1) {
     return markdown;
   }
@@ -124,36 +124,42 @@ static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown, ENRMTa
     return markdown;
   }
 
+  NSUInteger *offsets = ENRMBuildLineOffsets(lines, lines.count);
+
   if (tableMode == ENRMTableStreamingModeProgressive) {
     NSInteger tableLineCount = lastNonBlankLineIndex - blockStartIndex + 1;
 
-    // Need at least header + separator to show anything.
     if (tableLineCount < 2 || !ENRMLineLooksLikeTableSeparator(lines[(NSUInteger)blockStartIndex + 1])) {
-      NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)blockStartIndex);
-      return [markdown substringToIndex:offset];
+      NSString *result = [markdown substringToIndex:offsets[(NSUInteger)blockStartIndex]];
+      free(offsets);
+      return result;
     }
 
-    // Trim the last data row if it's incomplete: either doesn't end with '|'
-    // or has fewer pipe characters than the header (mid-cell streaming).
     if (tableLineCount > 2) {
       NSString *lastRow = lines[(NSUInteger)lastNonBlankLineIndex];
       NSString *lastRowTrimmed = [lastRow stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
       NSString *headerRow = lines[(NSUInteger)blockStartIndex];
       if (![lastRowTrimmed hasSuffix:@"|"] || ENRMPipeCount(lastRow) < ENRMPipeCount(headerRow)) {
-        NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)lastNonBlankLineIndex);
-        return [markdown substringToIndex:offset];
+        NSString *result = [markdown substringToIndex:offsets[(NSUInteger)lastNonBlankLineIndex]];
+        free(offsets);
+        return result;
       }
     }
 
+    free(offsets);
     return markdown;
   }
 
-  NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)blockStartIndex);
-  return [markdown substringToIndex:offset];
+  NSString *result = [markdown substringToIndex:offsets[(NSUInteger)blockStartIndex]];
+  free(offsets);
+  return result;
 }
 
 NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStreamingMode tableMode)
 {
-  NSString *withoutPendingMath = ENRMRemovePendingStreamingMathBlock(markdown);
-  return ENRMRemovePendingStreamingTableBlock(withoutPendingMath, tableMode);
+  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
+  NSString *afterMath = ENRMRemovePendingStreamingMathBlock(markdown, lines);
+  NSArray<NSString *> *linesForTable =
+      (afterMath.length == markdown.length) ? lines : [afterMath componentsSeparatedByString:@"\n"];
+  return ENRMRemovePendingStreamingTableBlock(afterMath, linesForTable, tableMode);
 }

--- a/ios/views/TableContainerView.h
+++ b/ios/views/TableContainerView.h
@@ -26,6 +26,8 @@ typedef void (^TableLinkPressBlock)(NSString *url);
 
 @property (nonatomic, assign) BOOL enableLinkPreview;
 
+@property (nonatomic, readonly) NSUInteger rowCount;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/views/TableContainerView.h
+++ b/ios/views/TableContainerView.h
@@ -28,6 +28,8 @@ typedef void (^TableLinkPressBlock)(NSString *url);
 
 @property (nonatomic, readonly) NSUInteger rowCount;
 
+- (void)animateNewRowsFromPreviousCount:(NSUInteger)previousRowCount duration:(NSTimeInterval)duration;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/views/TableContainerView.m
+++ b/ios/views/TableContainerView.m
@@ -172,6 +172,38 @@
   return _rows.count;
 }
 
+#if !TARGET_OS_OSX
+- (void)animateNewRowsFromPreviousCount:(NSUInteger)previousRowCount duration:(NSTimeInterval)duration
+{
+  if (self.rowCount <= previousRowCount) {
+    return;
+  }
+
+  NSArray<RCTUIView *> *subviews = _gridContainer.subviews;
+  NSUInteger childCount = subviews.count;
+  if (childCount == 0 || self.rowCount == 0) {
+    return;
+  }
+
+  NSUInteger colCount = childCount / self.rowCount;
+  if (colCount == 0) {
+    return;
+  }
+
+  NSUInteger firstNewCellIndex = previousRowCount * colCount;
+  for (NSUInteger i = firstNewCellIndex; i < childCount; i++) {
+    RCTUIView *cellView = subviews[i];
+    cellView.alpha = 0.0;
+    [UIView animateWithDuration:duration animations:^{ cellView.alpha = 1.0; }];
+  }
+}
+#else
+- (void)animateNewRowsFromPreviousCount:(NSUInteger)previousRowCount duration:(NSTimeInterval)duration
+{
+  // No-op on macOS
+}
+#endif
+
 - (void)applyTableNode:(MarkdownASTNode *)tableNode
 {
   [[_gridContainer subviews] makeObjectsPerformSelector:@selector(removeFromSuperview)];

--- a/ios/views/TableContainerView.m
+++ b/ios/views/TableContainerView.m
@@ -167,6 +167,11 @@
   return [buffer copy];
 }
 
+- (NSUInteger)rowCount
+{
+  return _rows.count;
+}
+
 - (void)applyTableNode:(MarkdownASTNode *)tableNode
 {
   [[_gridContainer subviews] makeObjectsPerformSelector:@selector(removeFromSuperview)];

--- a/src/EnrichedMarkdownNativeComponent.ts
+++ b/src/EnrichedMarkdownNativeComponent.ts
@@ -226,6 +226,10 @@ export interface Md4cFlagsInternal {
   latexMath: boolean;
 }
 
+interface StreamingConfigInternal {
+  tableMode: string;
+}
+
 export interface NativeProps extends ViewProps {
   /**
    * Markdown content to render.
@@ -322,6 +326,10 @@ export interface NativeProps extends ViewProps {
    * @default false
    */
   streamingAnimation?: CodegenTypes.WithDefault<boolean, false>;
+  /**
+   * Fine-grained control over streaming behavior for block-level elements.
+   */
+  streamingConfig?: StreamingConfigInternal;
   /**
    * Controls how spoiler text is displayed before being revealed.
    * - 'particles' (default): animated particle overlay.

--- a/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/src/EnrichedMarkdownTextNativeComponent.ts
@@ -226,6 +226,10 @@ export interface Md4cFlagsInternal {
   latexMath: boolean;
 }
 
+interface StreamingConfigInternal {
+  tableMode: string;
+}
+
 export interface NativeProps extends ViewProps {
   /**
    * Markdown content to render.
@@ -322,6 +326,10 @@ export interface NativeProps extends ViewProps {
    * @default false
    */
   streamingAnimation?: CodegenTypes.WithDefault<boolean, false>;
+  /**
+   * Fine-grained control over streaming behavior for block-level elements.
+   */
+  streamingConfig?: StreamingConfigInternal;
   /**
    * Controls how spoiler text is displayed before being revealed.
    * - 'particles' (default): animated particle overlay.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 export { default as EnrichedMarkdownText } from './native/EnrichedMarkdownText';
 export type {
   EnrichedMarkdownTextProps,
+  StreamingConfig,
   MarkdownStyle,
   Md4cFlags,
   ContextMenuItem as TextContextMenuItem,

--- a/src/native/EnrichedMarkdownText.tsx
+++ b/src/native/EnrichedMarkdownText.tsx
@@ -7,6 +7,7 @@ import type { NativeSyntheticEvent } from 'react-native';
 import type { MarkdownStyle, Md4cFlags } from '../types/MarkdownStyle';
 import type {
   EnrichedMarkdownTextProps,
+  StreamingConfig,
   ContextMenuItem,
 } from '../types/MarkdownTextProps';
 import type {
@@ -17,7 +18,7 @@ import type {
 } from '../types/events';
 
 export type { MarkdownStyle, Md4cFlags };
-export type { EnrichedMarkdownTextProps, ContextMenuItem };
+export type { EnrichedMarkdownTextProps, StreamingConfig, ContextMenuItem };
 export type { LinkPressEvent, LinkLongPressEvent, TaskListItemPressEvent };
 
 const defaultMd4cFlags: Md4cFlags = {
@@ -40,6 +41,7 @@ export const EnrichedMarkdownText = ({
   allowTrailingMargin = false,
   flavor = 'commonmark',
   streamingAnimation = false,
+  streamingConfig,
   spoilerOverlay = 'particles',
   contextMenuItems,
   selectionColor,
@@ -122,6 +124,9 @@ export const EnrichedMarkdownText = ({
     [onTaskListItemPress]
   );
 
+  const tableMode = streamingConfig?.tableMode ?? 'hidden';
+  const normalizedStreamingConfig = useMemo(() => ({ tableMode }), [tableMode]);
+
   const sharedProps = {
     markdown,
     markdownStyle: normalizedStyle,
@@ -135,6 +140,7 @@ export const EnrichedMarkdownText = ({
     maxFontSizeMultiplier,
     allowTrailingMargin,
     streamingAnimation,
+    streamingConfig: normalizedStreamingConfig,
     spoilerOverlay,
     style: containerStyle,
     contextMenuItems: nativeContextMenuItems,

--- a/src/types/MarkdownTextProps.ts
+++ b/src/types/MarkdownTextProps.ts
@@ -20,6 +20,18 @@ export interface ContextMenuItem {
   visible?: boolean;
 }
 
+export interface StreamingConfig {
+  /**
+   * Controls how incomplete tables are handled during streaming.
+   * - `'hidden'` (default): hide the entire table until it's complete.
+   * - `'progressive'`: show the table row-by-row as rows complete.
+   * Only effective when `streamingAnimation` is `true`.
+   * @default 'hidden'
+   * @platform ios, android
+   */
+  tableMode?: 'hidden' | 'progressive';
+}
+
 export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
   /**
    * Markdown content to render.
@@ -150,6 +162,12 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    * @platform ios, android
    */
   streamingAnimation?: boolean;
+  /**
+   * Fine-grained control over streaming behavior for block-level elements.
+   * Only effective when `streamingAnimation` is `true`.
+   * @platform ios, android
+   */
+  streamingConfig?: StreamingConfig;
   /**
    * Controls how spoiler text is displayed before being revealed.
    * - `'particles'` (default): animated particle overlay (CAEmitterLayer on iOS,


### PR DESCRIPTION
### What/Why?

Fixes: #241 

Adds iOS support for smoother `streamingAnimation` with GitHub-flavored markdown tables and block LaTeX.

Previously, GFM block views could be recreated repeatedly while markdown was streaming, causing visible jank and extra UI thread work. This PR splits parsed GFM content into native-renderable segments: text, table, and block math. Each segment gets a deterministic content signature, so iOS can reconcile new renders against existing native views instead of rebuilding completed blocks.

During reconciliation:

- unchanged segments reuse their existing native views,
- shifted unchanged segments can still be reused by signature,
- changed segments of the same kind update in place,
- new or different segment kinds create new views,
- unused old views are removed.

When `streamingAnimation` is active, incomplete trailing tables and block math are hidden until their markdown is complete. This avoids repeatedly rendering expensive partially parsed block views while text continues to stream normally.

The PR also adjusts iOS measurement/layout for streaming GFM so height updates track rendered content more reliably, including newly completed block segments, and keeps table interactions working when layout catches up.

Static GFM behavior remains unchanged.



### Testing
<!-- How to test changed code? What testing has been done? -->



#### Screenshots
https://github.com/user-attachments/assets/b5d369db-c7c1-4e24-b49a-2a74e2fd5db6

https://github.com/user-attachments/assets/a0bf7b90-eacc-4842-865b-a07ff5d59ecf

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

