### PR TITLE
feat(android): add GFM streaming support for tables and block math

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -19,6 +19,7 @@ import com.swmansion.enriched.markdown.utils.common.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.utils.common.RenderedSegment
 import com.swmansion.enriched.markdown.utils.common.SegmentReconciler
 import com.swmansion.enriched.markdown.utils.common.StreamingMarkdownFilter
+import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
 import com.swmansion.enriched.markdown.utils.common.splitASTIntoSegments
 import com.swmansion.enriched.markdown.utils.text.TailFadeInAnimator
 import com.swmansion.enriched.markdown.utils.text.view.applySelectionColors
@@ -57,6 +58,9 @@ class EnrichedMarkdown
     private val dirtyFlags = EnumSet.noneOf(DirtyFlag::class.java)
     var streamingAnimation: Boolean = false
 
+    var tableStreamingMode: TableStreamingMode = TableStreamingMode.HIDDEN
+    private var renderPending: Boolean = false
+
     var currentMarkdown: String = ""
       private set
 
@@ -92,7 +96,7 @@ class EnrichedMarkdown
     fun setMarkdownContent(markdown: String) {
       if (currentMarkdown == markdown) return
       currentMarkdown = markdown
-      scheduleRender()
+      renderPending = true
     }
 
     fun setMarkdownStyle(style: ReadableMap?) {
@@ -102,7 +106,15 @@ class EnrichedMarkdown
       markdownStyle = newConfig
       dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
       dirtyFlags += DirtyFlag.FORCE_HEIGHT
-      scheduleRender()
+      renderPending = true
+    }
+
+    fun commitProps() {
+      MeasurementStore.updateStreamingTableMode(id, tableStreamingMode)
+      if (renderPending) {
+        renderPending = false
+        scheduleRenderIfNeeded()
+      }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -121,7 +133,7 @@ class EnrichedMarkdown
     fun setMd4cFlags(flags: Md4cFlags) {
       if (md4cFlags == flags) return
       md4cFlags = flags
-      scheduleRenderIfNeeded()
+      renderPending = true
     }
 
     fun setAllowFontScaling(allow: Boolean) {
@@ -130,7 +142,7 @@ class EnrichedMarkdown
       recreateStyleConfig()
       dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
       dirtyFlags += DirtyFlag.FORCE_HEIGHT
-      scheduleRenderIfNeeded()
+      renderPending = true
     }
 
     fun setMaxFontSizeMultiplier(multiplier: Float) {
@@ -139,7 +151,7 @@ class EnrichedMarkdown
       recreateStyleConfig()
       dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
       dirtyFlags += DirtyFlag.FORCE_HEIGHT
-      scheduleRenderIfNeeded()
+      renderPending = true
     }
 
     fun setAllowTrailingMargin(allow: Boolean) {
@@ -147,7 +159,7 @@ class EnrichedMarkdown
       allowTrailingMargin = allow
       dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
       dirtyFlags += DirtyFlag.FORCE_HEIGHT
-      scheduleRenderIfNeeded()
+      renderPending = true
     }
 
     fun setIsSelectable(value: Boolean) {
@@ -218,6 +230,7 @@ class EnrichedMarkdown
       val style = markdownStyle ?: return
       val markdown = currentMarkdown.takeIf { it.isNotEmpty() } ?: return
       val isStreaming = streamingAnimation
+      val tableMode = tableStreamingMode
 
       val renderId = ++currentRenderId
 
@@ -225,7 +238,7 @@ class EnrichedMarkdown
         try {
           val renderableMarkdown =
             if (isStreaming) {
-              StreamingMarkdownFilter.renderableMarkdownForStreaming(markdown)
+              StreamingMarkdownFilter.renderableMarkdownForStreaming(markdown, tableMode)
             } else {
               markdown
             }
@@ -341,7 +354,12 @@ class EnrichedMarkdown
         }
 
         is RenderedSegment.Table -> {
-          (view as TableContainerView).applyTableNode(segment.node)
+          val tableView = view as TableContainerView
+          val previousRowCount = tableView.rowCount
+          tableView.applyTableNode(segment.node)
+          if (streamingAnimation) {
+            tableView.animateNewRows(previousRowCount, BLOCK_FADE_DURATION_MS)
+          }
         }
 
         is RenderedSegment.Math -> {
@@ -491,6 +509,10 @@ class EnrichedMarkdown
         }
       }
       return totalHeight
+    }
+
+    fun cleanup() {
+      executor.shutdownNow()
     }
 
     companion object {

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -17,12 +17,14 @@ import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.FeatureFlags
 import com.swmansion.enriched.markdown.utils.common.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.utils.common.RenderedSegment
+import com.swmansion.enriched.markdown.utils.common.SegmentReconciler
+import com.swmansion.enriched.markdown.utils.common.StreamingMarkdownFilter
 import com.swmansion.enriched.markdown.utils.common.splitASTIntoSegments
+import com.swmansion.enriched.markdown.utils.text.TailFadeInAnimator
 import com.swmansion.enriched.markdown.utils.text.view.applySelectionColors
-import com.swmansion.enriched.markdown.utils.text.view.emitLinkLongPressEvent
-import com.swmansion.enriched.markdown.utils.text.view.emitLinkPressEvent
 import com.swmansion.enriched.markdown.views.BlockSegmentView
 import com.swmansion.enriched.markdown.views.TableContainerView
+import java.util.EnumSet
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -33,12 +35,27 @@ class EnrichedMarkdown
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
   ) : FrameLayout(context, attrs, defStyleAttr) {
+    private enum class DirtyFlag {
+      RECREATE_SEGMENTS,
+      FORCE_HEIGHT,
+    }
+
     private val parser = Parser.shared
     private val mainHandler = Handler(Looper.getMainLooper())
     private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+    private val mathContainerClass: Class<*>? by lazy {
+      try {
+        Class.forName("com.swmansion.enriched.markdown.views.MathContainerView")
+      } catch (_: Exception) {
+        null
+      }
+    }
 
     private var currentRenderId = 0L
     private val segmentViews = mutableListOf<View>()
+    private val segmentSignatures = mutableListOf<Long>()
+    private val dirtyFlags = EnumSet.noneOf(DirtyFlag::class.java)
+    var streamingAnimation: Boolean = false
 
     var currentMarkdown: String = ""
       private set
@@ -83,6 +100,8 @@ class EnrichedMarkdown
       val newConfig = style?.let { StyleConfig(it, context, allowFontScaling, maxFontSizeMultiplier) }
       if (markdownStyle == newConfig) return
       markdownStyle = newConfig
+      dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
+      dirtyFlags += DirtyFlag.FORCE_HEIGHT
       scheduleRender()
     }
 
@@ -93,6 +112,8 @@ class EnrichedMarkdown
       if (newFontScale != lastKnownFontScale) {
         lastKnownFontScale = newFontScale
         recreateStyleConfig()
+        dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
+        dirtyFlags += DirtyFlag.FORCE_HEIGHT
         scheduleRenderIfNeeded()
       }
     }
@@ -107,6 +128,8 @@ class EnrichedMarkdown
       if (allowFontScaling == allow) return
       allowFontScaling = allow
       recreateStyleConfig()
+      dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
+      dirtyFlags += DirtyFlag.FORCE_HEIGHT
       scheduleRenderIfNeeded()
     }
 
@@ -114,12 +137,16 @@ class EnrichedMarkdown
       if (maxFontSizeMultiplier == multiplier) return
       maxFontSizeMultiplier = multiplier
       recreateStyleConfig()
+      dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
+      dirtyFlags += DirtyFlag.FORCE_HEIGHT
       scheduleRenderIfNeeded()
     }
 
     fun setAllowTrailingMargin(allow: Boolean) {
       if (allowTrailingMargin == allow) return
       allowTrailingMargin = allow
+      dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
+      dirtyFlags += DirtyFlag.FORCE_HEIGHT
       scheduleRenderIfNeeded()
     }
 
@@ -190,14 +217,27 @@ class EnrichedMarkdown
     private fun scheduleRender() {
       val style = markdownStyle ?: return
       val markdown = currentMarkdown.takeIf { it.isNotEmpty() } ?: return
+      val isStreaming = streamingAnimation
 
       val renderId = ++currentRenderId
 
       executor.execute {
         try {
+          val renderableMarkdown =
+            if (isStreaming) {
+              StreamingMarkdownFilter.renderableMarkdownForStreaming(markdown)
+            } else {
+              markdown
+            }
+
+          if (renderableMarkdown.isEmpty()) {
+            postToMain(renderId) { applyRenderedSegments(emptyList(), style) }
+            return@execute
+          }
+
           val ast =
-            parser.parseMarkdown(markdown, md4cFlags) ?: run {
-              postToMain(renderId) { clearSegments() }
+            parser.parseMarkdown(renderableMarkdown, md4cFlags) ?: run {
+              postToMain(renderId) { applyRenderedSegments(emptyList(), style) }
               return@execute
             }
 
@@ -214,7 +254,7 @@ class EnrichedMarkdown
           postToMain(renderId) { applyRenderedSegments(renderedSegments, style) }
         } catch (e: Exception) {
           Log.e(TAG, "Render failed", e)
-          postToMain(renderId) { clearSegments() }
+          postToMain(renderId) { applyRenderedSegments(emptyList(), style) }
         }
       }
     }
@@ -223,18 +263,125 @@ class EnrichedMarkdown
       renderedSegments: List<RenderedSegment>,
       style: StyleConfig,
     ) {
-      clearSegments()
-      renderedSegments.forEach { segment ->
-        val view =
-          when (segment) {
-            is RenderedSegment.Text -> createTextView(segment)
-            is RenderedSegment.Table -> createTableView(segment, style)
-            is RenderedSegment.Math -> createMathView(segment, style)
-          }
-        segmentViews.add(view)
-        addView(view)
+      val reset = DirtyFlag.RECREATE_SEGMENTS in dirtyFlags
+      val forceHeight = DirtyFlag.FORCE_HEIGHT in dirtyFlags
+      dirtyFlags.clear()
+
+      val result =
+        SegmentReconciler.reconcile(
+          currentViews = segmentViews.toList(),
+          currentSignatures = segmentSignatures.toList(),
+          renderedSegments = renderedSegments,
+          reset = reset,
+          matchesKind = ::viewMatchesSegmentKind,
+          createView = { segment ->
+            val view = createSegmentView(segment, style)
+            animateNewView(view, segment)
+            view
+          },
+          updateView = { view, segment -> updateSegmentView(view, segment) },
+        )
+
+      result.viewsToRemove.forEach { removeView(it) }
+      result.viewsToAttach.forEach { addView(it) }
+
+      segmentViews.clear()
+      segmentViews.addAll(result.views)
+      segmentSignatures.clear()
+      segmentSignatures.addAll(result.signatures)
+
+      val topologyChanged = result.viewsToAttach.isNotEmpty() || result.viewsToRemove.isNotEmpty()
+
+      if (width > 0) {
+        val heightBefore = computeSegmentsTotalHeight()
+        layoutSegments()
+        val heightAfter = computeSegmentsTotalHeight()
+
+        if (forceHeight || topologyChanged || heightBefore != heightAfter) {
+          MeasurementStore.invalidate(id)
+          requestLayout()
+        }
       }
-      layoutSegments()
+    }
+
+    private fun viewMatchesSegmentKind(
+      view: View,
+      segment: RenderedSegment,
+    ): Boolean =
+      when (segment) {
+        is RenderedSegment.Text -> view is EnrichedMarkdownInternalText
+        is RenderedSegment.Table -> view is TableContainerView
+        is RenderedSegment.Math -> isMathContainerView(view)
+      }
+
+    private fun isMathContainerView(view: View): Boolean = mathContainerClass?.isInstance(view) == true
+
+    private fun createSegmentView(
+      segment: RenderedSegment,
+      style: StyleConfig,
+    ): View =
+      when (segment) {
+        is RenderedSegment.Text -> createTextView(segment)
+        is RenderedSegment.Table -> createTableView(segment, style)
+        is RenderedSegment.Math -> createMathView(segment, style)
+      }
+
+    private fun updateSegmentView(
+      view: View,
+      segment: RenderedSegment,
+    ) {
+      when (segment) {
+        is RenderedSegment.Text -> {
+          val textView = view as EnrichedMarkdownInternalText
+          val tailStart = textView.text?.length ?: 0
+          textView.lastElementMarginBottom = segment.lastElementMarginBottom
+          textView.applyStyledText(segment.styledText)
+          segment.imageSpans.forEach { it.registerTextView(textView) }
+          animateTextViewTail(textView, tailStart)
+        }
+
+        is RenderedSegment.Table -> {
+          (view as TableContainerView).applyTableNode(segment.node)
+        }
+
+        is RenderedSegment.Math -> {
+          mathContainerClass
+            ?.getMethod("applyLatex", String::class.java)
+            ?.invoke(view, segment.latex)
+        }
+      }
+    }
+
+    private fun animateNewView(
+      view: View,
+      segment: RenderedSegment,
+    ) {
+      if (!streamingAnimation) return
+      when (segment) {
+        is RenderedSegment.Text -> animateTextViewTail(view as EnrichedMarkdownInternalText, 0)
+        is RenderedSegment.Table, is RenderedSegment.Math -> animateBlockViewFadeIn(view)
+      }
+    }
+
+    private fun animateTextViewTail(
+      view: EnrichedMarkdownInternalText,
+      tailStart: Int,
+    ) {
+      if (!streamingAnimation) return
+      val textLength = view.text?.length ?: 0
+      if (textLength <= tailStart) return
+      val animator = TailFadeInAnimator(view)
+      animator.animate(tailStart, textLength)
+    }
+
+    private fun animateBlockViewFadeIn(view: View) {
+      if (!streamingAnimation) return
+      view.alpha = 0f
+      view
+        .animate()
+        .alpha(1f)
+        .setDuration(BLOCK_FADE_DURATION_MS)
+        .start()
     }
 
     private fun createTextView(segment: RenderedSegment.Text) =
@@ -273,18 +420,18 @@ class EnrichedMarkdown
     private fun createMathView(
       segment: RenderedSegment.Math,
       style: StyleConfig,
-    ): android.view.View {
-      if (!FeatureFlags.IS_MATH_ENABLED) return android.view.View(context)
+    ): View {
+      val resolvedClass = mathContainerClass
+      if (!FeatureFlags.IS_MATH_ENABLED || resolvedClass == null) return View(context)
       return try {
-        val mathContainerClass = Class.forName("com.swmansion.enriched.markdown.views.MathContainerView")
         val view =
-          mathContainerClass
-            .getConstructor(android.content.Context::class.java, StyleConfig::class.java)
-            .newInstance(context, style) as android.view.View
-        mathContainerClass.getMethod("applyLatex", String::class.java).invoke(view, segment.latex)
+          resolvedClass
+            .getConstructor(Context::class.java, StyleConfig::class.java)
+            .newInstance(context, style) as View
+        resolvedClass.getMethod("applyLatex", String::class.java).invoke(view, segment.latex)
         view
       } catch (_: Exception) {
-        android.view.View(context)
+        View(context)
       }
     }
 
@@ -295,11 +442,6 @@ class EnrichedMarkdown
       mainHandler.post {
         if (renderId == currentRenderId) action()
       }
-    }
-
-    private fun clearSegments() {
-      segmentViews.forEach { removeView(it) }
-      segmentViews.clear()
     }
 
     override fun onLayout(
@@ -337,7 +479,22 @@ class EnrichedMarkdown
       }
     }
 
+    private fun computeSegmentsTotalHeight(): Int {
+      var totalHeight = 0
+      val lastIndex = segmentViews.lastIndex
+      segmentViews.forEachIndexed { index, view ->
+        val segment = view as? BlockSegmentView
+        totalHeight += segment?.segmentMarginTop ?: 0
+        totalHeight += view.measuredHeight
+        if (index != lastIndex || allowTrailingMargin) {
+          totalHeight += segment?.segmentMarginBottom ?: 0
+        }
+      }
+      return totalHeight
+    }
+
     companion object {
       private const val TAG = "EnrichedMarkdown"
+      private const val BLOCK_FADE_DURATION_MS = 200L
     }
   }

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -12,6 +12,7 @@ import com.facebook.react.viewmanagers.EnrichedMarkdownManagerDelegate
 import com.facebook.react.viewmanagers.EnrichedMarkdownManagerInterface
 import com.facebook.yoga.YogaMeasureMode
 import com.swmansion.enriched.markdown.spoiler.SpoilerOverlay
+import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
 import com.swmansion.enriched.markdown.utils.common.emitContextMenuItemPress
 import com.swmansion.enriched.markdown.utils.common.emitLinkLongPress
 import com.swmansion.enriched.markdown.utils.common.emitLinkPress
@@ -37,6 +38,18 @@ class EnrichedMarkdownManager :
       emitContextMenuItemPress(view, itemText, selectedText, selectionStart, selectionEnd)
     }
     return view
+  }
+
+  override fun onAfterUpdateTransaction(view: EnrichedMarkdown) {
+    super.onAfterUpdateTransaction(view)
+    view.commitProps()
+  }
+
+  override fun onDropViewInstance(view: EnrichedMarkdown) {
+    super.onDropViewInstance(view)
+    view.cleanup()
+    MeasurementStore.release(view.id)
+    MeasurementStore.clearStreamingTableMode(view.id)
   }
 
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> = markdownEventTypeConstants()
@@ -140,6 +153,20 @@ class EnrichedMarkdownManager :
     streamingAnimation: Boolean,
   ) {
     view?.streamingAnimation = streamingAnimation
+  }
+
+  @ReactProp(name = "streamingConfig")
+  override fun setStreamingConfig(
+    view: EnrichedMarkdown?,
+    config: ReadableMap?,
+  ) {
+    if (view == null) return
+    val tableMode =
+      when (config?.getString("tableMode")) {
+        "progressive" -> TableStreamingMode.PROGRESSIVE
+        else -> TableStreamingMode.HIDDEN
+      }
+    view.tableStreamingMode = tableMode
   }
 
   @ReactProp(name = "spoilerOverlay")

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -139,8 +139,7 @@ class EnrichedMarkdownManager :
     view: EnrichedMarkdown?,
     streamingAnimation: Boolean,
   ) {
-    // TODO: Add streaming animation support for github flavor.
-    // Currently only supported with flavor="commonmark" (single TextView).
+    view?.streamingAnimation = streamingAnimation
   }
 
   @ReactProp(name = "spoilerOverlay")

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -162,6 +162,14 @@ class EnrichedMarkdownTextManager :
     view?.setStreamingAnimation(streamingAnimation)
   }
 
+  @ReactProp(name = "streamingConfig")
+  override fun setStreamingConfig(
+    view: EnrichedMarkdownText?,
+    config: ReadableMap?,
+  ) {
+    // No-op — CommonMark mode uses a single text view; table streaming is GFM-only.
+  }
+
   @ReactProp(name = "spoilerOverlay")
   override fun setSpoilerOverlay(
     view: EnrichedMarkdownText?,

--- a/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -23,6 +23,7 @@ import com.swmansion.enriched.markdown.utils.common.FeatureFlags
 import com.swmansion.enriched.markdown.utils.common.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.utils.common.RenderedSegment
 import com.swmansion.enriched.markdown.utils.common.StreamingMarkdownFilter
+import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
 import com.swmansion.enriched.markdown.utils.common.getBooleanOrDefault
 import com.swmansion.enriched.markdown.utils.common.getMapOrNull
 import com.swmansion.enriched.markdown.utils.common.getStringOrDefault
@@ -61,6 +62,8 @@ object MeasurementStore {
   )
 
   private val fontScalingSettings = ConcurrentHashMap<Int, FontScalingSettings>()
+
+  private val streamingTableModes = ConcurrentHashMap<Int, TableStreamingMode>()
 
   private fun resolveFontScalingSettings(
     viewId: Int?,
@@ -151,6 +154,17 @@ object MeasurementStore {
 
   fun clearFontScalingSettings(viewId: Int) {
     fontScalingSettings.remove(viewId)
+  }
+
+  fun updateStreamingTableMode(
+    viewId: Int,
+    mode: TableStreamingMode,
+  ) {
+    streamingTableModes[viewId] = mode
+  }
+
+  fun clearStreamingTableMode(viewId: Int) {
+    streamingTableModes.remove(viewId)
   }
 
   private fun getMeasureByIdInternal(
@@ -304,9 +318,10 @@ object MeasurementStore {
     val isStreaming = props.getBooleanOrDefault("streamingAnimation", false)
 
     val rawMarkdown = props.getStringOrDefault("markdown", "")
+    val tableMode = if (isStreaming) id?.let { streamingTableModes[it] } ?: TableStreamingMode.HIDDEN else TableStreamingMode.HIDDEN
     val markdown =
       if (isStreaming) {
-        StreamingMarkdownFilter.renderableMarkdownForStreaming(rawMarkdown)
+        StreamingMarkdownFilter.renderableMarkdownForStreaming(rawMarkdown, tableMode)
       } else {
         rawMarkdown
       }

--- a/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -22,6 +22,7 @@ import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.FeatureFlags
 import com.swmansion.enriched.markdown.utils.common.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.utils.common.RenderedSegment
+import com.swmansion.enriched.markdown.utils.common.StreamingMarkdownFilter
 import com.swmansion.enriched.markdown.utils.common.getBooleanOrDefault
 import com.swmansion.enriched.markdown.utils.common.getMapOrNull
 import com.swmansion.enriched.markdown.utils.common.getStringOrDefault
@@ -102,6 +103,10 @@ object MeasurementStore {
   }
 
   fun release(id: Int) {
+    data.remove(id)
+  }
+
+  fun invalidate(id: Int) {
     data.remove(id)
   }
 
@@ -190,6 +195,16 @@ object MeasurementStore {
     maxFontSizeMultiplier: Float,
   ): Int {
     val markdown = props.getStringOrDefault("markdown", "")
+    return computePropsHashForMarkdown(markdown, props, allowFontScaling, fontScale, maxFontSizeMultiplier)
+  }
+
+  private fun computePropsHashForMarkdown(
+    markdown: String,
+    props: ReadableMap?,
+    allowFontScaling: Boolean,
+    fontScale: Float,
+    maxFontSizeMultiplier: Float,
+  ): Int {
     val styleMap = props.getMapOrNull("markdownStyle")
     val md4cFlagsMap = props.getMapOrNull("md4cFlags")
     val allowTrailingMargin = props.getBooleanOrDefault("allowTrailingMargin", false)
@@ -286,7 +301,26 @@ object MeasurementStore {
     fontScale: Float,
     maxFontSizeMultiplier: Float,
   ): Long {
-    val markdown = props.getStringOrDefault("markdown", "")
+    val isStreaming = props.getBooleanOrDefault("streamingAnimation", false)
+
+    val rawMarkdown = props.getStringOrDefault("markdown", "")
+    val markdown =
+      if (isStreaming) {
+        StreamingMarkdownFilter.renderableMarkdownForStreaming(rawMarkdown)
+      } else {
+        rawMarkdown
+      }
+    val propsHash = computePropsHashForMarkdown(markdown, props, allowFontScaling, fontScale, maxFontSizeMultiplier)
+
+    // Streaming shortcut: reuse cached size when the filtered content and
+    // width are unchanged. When the filter output changes (e.g. a table
+    // becomes complete), the hash differs and we fall through to full measure.
+    if (isStreaming && id != null) {
+      val cached = data[id]
+      if (cached != null && cached.cachedWidth == width && cached.markdownHash == propsHash) {
+        return cached.cachedSize
+      }
+    }
     val styleMap =
       props.getMapOrNull("markdownStyle")
         ?: return YogaMeasureOutput.make(PixelUtil.toDIPFromPixel(width), 0f)
@@ -297,7 +331,6 @@ object MeasurementStore {
         latexMath = FeatureFlags.IS_MATH_ENABLED && props.getMapOrNull("md4cFlags").getBooleanOrDefault("latexMath", true),
       )
     val allowTrailingMargin = props.getBooleanOrDefault("allowTrailingMargin", false)
-    val propsHash = computePropsHash(props, allowFontScaling, fontScale, maxFontSizeMultiplier)
     val fontSize = getInitialFontSize(styleMap, context, allowFontScaling, fontScale, maxFontSizeMultiplier)
 
     return try {

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/RenderedSegment.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/RenderedSegment.kt
@@ -8,19 +8,24 @@ import com.swmansion.enriched.markdown.spans.ImageSpan
 import com.swmansion.enriched.markdown.styles.StyleConfig
 
 sealed interface RenderedSegment {
+  val signature: Long
+
   data class Text(
     val styledText: SpannableString,
     val imageSpans: List<ImageSpan>,
     val needsJustify: Boolean,
     val lastElementMarginBottom: Float,
+    override val signature: Long,
   ) : RenderedSegment
 
   data class Table(
     val node: MarkdownASTNode,
+    override val signature: Long,
   ) : RenderedSegment
 
   data class Math(
     val latex: String,
+    override val signature: Long,
   ) : RenderedSegment
 }
 
@@ -34,9 +39,20 @@ object MarkdownSegmentRenderer {
   ): List<RenderedSegment> =
     segments.map { segment ->
       when (segment) {
-        is MarkdownSegment.Text -> renderTextSegment(segment.nodes, style, context, onLinkPress, onLinkLongPress)
-        is MarkdownSegment.Table -> RenderedSegment.Table(segment.node)
-        is MarkdownSegment.Math -> RenderedSegment.Math(segment.latex)
+        is MarkdownSegment.Text -> {
+          renderTextSegment(segment.nodes, style, context, onLinkPress, onLinkLongPress)
+        }
+
+        is MarkdownSegment.Table -> {
+          val signature = SegmentSignature.signatureForNode(segment.node) xor SegmentSignature.TABLE_KIND_SALT
+          RenderedSegment.Table(segment.node, signature)
+        }
+
+        is MarkdownSegment.Math -> {
+          var signature = SegmentSignature.signatureForNode(null) xor SegmentSignature.MATH_KIND_SALT
+          signature = SegmentSignature.fnvMixString(signature, segment.latex)
+          RenderedSegment.Math(segment.latex, signature)
+        }
       }
     }
 
@@ -49,12 +65,14 @@ object MarkdownSegmentRenderer {
   ): RenderedSegment.Text {
     val documentWrapper = MarkdownASTNode(type = MarkdownASTNode.NodeType.Document, children = nodes)
     val renderer = Renderer().apply { configure(style, context) }
+    val signature = SegmentSignature.signatureForNodes(nodes) xor SegmentSignature.TEXT_KIND_SALT
 
     return RenderedSegment.Text(
       styledText = renderer.renderDocument(documentWrapper, onLinkPress, onLinkLongPress),
       imageSpans = renderer.getCollectedImageSpans().toList(),
       needsJustify = style.needsJustify,
       lastElementMarginBottom = renderer.getLastElementMarginBottom(),
+      signature = signature,
     )
   }
 }

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/SegmentReconciler.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/SegmentReconciler.kt
@@ -1,0 +1,118 @@
+package com.swmansion.enriched.markdown.utils.common
+
+import android.view.View
+
+data class ReconciliationResult(
+  val views: List<View>,
+  val signatures: List<Long>,
+  val viewsToRemove: List<View>,
+  val viewsToAttach: List<View>,
+)
+
+object SegmentReconciler {
+  fun reconcile(
+    currentViews: List<View>,
+    currentSignatures: List<Long>,
+    renderedSegments: List<RenderedSegment>,
+    reset: Boolean,
+    matchesKind: (View, RenderedSegment) -> Boolean,
+    createView: (RenderedSegment) -> View,
+    updateView: (View, RenderedSegment) -> Unit,
+  ): ReconciliationResult {
+    val resetRemovals = if (reset) currentViews else emptyList()
+    val sourceViews = if (reset) emptyList() else currentViews
+    val sourceSignatures = if (reset) emptyList() else currentSignatures
+
+    val signatureToIndices = HashMap<Long, ArrayDeque<Int>>(sourceSignatures.size)
+    for ((index, signature) in sourceSignatures.withIndex()) {
+      signatureToIndices.getOrPut(signature) { ArrayDeque() }.addLast(index)
+    }
+
+    val remainingNextSignatureCounts = HashMap<Long, Int>(renderedSegments.size)
+    for (segment in renderedSegments) {
+      val signature = segment.signature
+      remainingNextSignatureCounts[signature] = (remainingNextSignatureCounts[signature] ?: 0) + 1
+    }
+
+    val nextViews = ArrayList<View>(renderedSegments.size)
+    val nextSignatures = ArrayList<Long>(renderedSegments.size)
+    val reusedViews = HashSet<View>(sourceViews.size)
+    val viewsToAttach = mutableListOf<View>()
+
+    for ((index, segment) in renderedSegments.withIndex()) {
+      val existingView = sourceViews.getOrNull(index)
+      val existingSignature = sourceSignatures.getOrNull(index)
+      val nextSignature = segment.signature
+
+      val remaining = remainingNextSignatureCounts.getOrDefault(nextSignature, 0)
+      if (remaining > 1) {
+        remainingNextSignatureCounts[nextSignature] = remaining - 1
+      } else {
+        remainingNextSignatureCounts.remove(nextSignature)
+      }
+
+      var view: View? = null
+
+      // 1. Exact positional match: same index, same kind, same signature.
+      if (existingView != null &&
+        existingView !in reusedViews &&
+        matchesKind(existingView, segment) &&
+        existingSignature == nextSignature
+      ) {
+        view = existingView
+      }
+
+      // 2. Signature-based fallback: find an unused view with exact same signature.
+      if (view == null) {
+        val candidateIndices = signatureToIndices[nextSignature]
+        if (candidateIndices != null) {
+          while (candidateIndices.isNotEmpty()) {
+            val candidateIdx = candidateIndices.removeFirst()
+            val candidate = sourceViews[candidateIdx]
+            if (candidate !in reusedViews && matchesKind(candidate, segment)) {
+              view = candidate
+              break
+            }
+          }
+        }
+      }
+
+      // 3. Same-kind positional update. If the old signature appears later in
+      // the new list, leave the view available for that exact reuse instead.
+      if (view == null &&
+        existingView != null &&
+        existingView !in reusedViews &&
+        matchesKind(existingView, segment) &&
+        (existingSignature == null || (remainingNextSignatureCounts[existingSignature] ?: 0) == 0)
+      ) {
+        updateView(existingView, segment)
+        view = existingView
+      }
+
+      // 4. No reusable view found — create a new one.
+      if (view == null) {
+        view = createView(segment)
+        viewsToAttach.add(view)
+      }
+
+      nextViews.add(view)
+      nextSignatures.add(nextSignature)
+      reusedViews.add(view)
+    }
+
+    val viewsToRemove = ArrayList<View>(resetRemovals.size + sourceViews.size)
+    viewsToRemove.addAll(resetRemovals)
+    for (view in sourceViews) {
+      if (view !in reusedViews) {
+        viewsToRemove.add(view)
+      }
+    }
+
+    return ReconciliationResult(
+      views = nextViews,
+      signatures = nextSignatures,
+      viewsToRemove = viewsToRemove,
+      viewsToAttach = viewsToAttach,
+    )
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/SegmentSignature.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/SegmentSignature.kt
@@ -1,0 +1,78 @@
+package com.swmansion.enriched.markdown.utils.common
+
+import com.swmansion.enriched.markdown.parser.MarkdownASTNode
+
+/** FNV-1a 64-bit hashing. Constants match the iOS implementation for cross-platform parity. */
+object SegmentSignature {
+  // FNV-1a 64-bit constants (same as iOS)
+  private const val FNV_OFFSET_BASIS = -3750763034362895579L // 14695981039346656037 as signed Long
+  private const val FNV_PRIME = 1099511628211L
+
+  internal const val TEXT_KIND_SALT = 0x7465787400000000L // "text"
+  internal const val TABLE_KIND_SALT = 0x7461626C00000000L // "tabl"
+  internal const val MATH_KIND_SALT = 0x6D61746800000000L // "math"
+
+  private fun fnvMixByte(
+    hash: Long,
+    byte: Byte,
+  ): Long {
+    var result = hash xor (byte.toLong() and 0xFF)
+    result *= FNV_PRIME
+    return result
+  }
+
+  private fun fnvMixLong(
+    hash: Long,
+    value: Long,
+  ): Long {
+    var result = hash
+    var remaining = value
+    for (i in 0 until 8) {
+      result = fnvMixByte(result, (remaining and 0xFF).toByte())
+      remaining = remaining ushr 8
+    }
+    return result
+  }
+
+  internal fun fnvMixString(
+    hash: Long,
+    string: String?,
+  ): Long {
+    if (string == null) return hash
+    var result = hash
+    val bytes = string.toByteArray(Charsets.UTF_8)
+    for (byte in bytes) {
+      result = fnvMixByte(result, byte)
+    }
+    return result
+  }
+
+  fun signatureForNode(node: MarkdownASTNode?): Long {
+    if (node == null) return FNV_OFFSET_BASIS
+
+    var hash = FNV_OFFSET_BASIS
+    hash = fnvMixLong(hash, node.type.ordinal.toLong())
+    hash = fnvMixString(hash, node.content)
+
+    if (node.attributes.isNotEmpty()) {
+      for (key in node.attributes.keys.sorted()) {
+        hash = fnvMixString(hash, key)
+        hash = fnvMixString(hash, node.attributes[key])
+      }
+    }
+
+    for (child in node.children) {
+      hash = fnvMixLong(hash, signatureForNode(child))
+    }
+
+    return hash
+  }
+
+  fun signatureForNodes(nodes: List<MarkdownASTNode>): Long {
+    var hash = FNV_OFFSET_BASIS
+    for (node in nodes) {
+      hash = fnvMixLong(hash, signatureForNode(node))
+    }
+    return hash
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
@@ -1,5 +1,10 @@
 package com.swmansion.enriched.markdown.utils.common
 
+enum class TableStreamingMode {
+  HIDDEN,
+  PROGRESSIVE,
+}
+
 /**
  * Pre-parse filter that hides incomplete trailing tables and block math
  * during streaming. A table is considered complete only after a blank
@@ -7,11 +12,14 @@ package com.swmansion.enriched.markdown.utils.common
  * a closing `$$` exists.
  */
 object StreamingMarkdownFilter {
-  fun renderableMarkdownForStreaming(markdown: String): String {
+  fun renderableMarkdownForStreaming(
+    markdown: String,
+    tableMode: TableStreamingMode = TableStreamingMode.HIDDEN,
+  ): String {
     val lines = markdown.split("\n")
     val afterMath = removePendingStreamingMathBlock(markdown, lines)
     val linesForTable = if (afterMath.length == markdown.length) lines else afterMath.split("\n")
-    return removePendingStreamingTableBlock(afterMath, linesForTable)
+    return removePendingStreamingTableBlock(afterMath, linesForTable, tableMode)
   }
 
   private fun removePendingStreamingMathBlock(
@@ -28,13 +36,14 @@ object StreamingMarkdownFilter {
 
     if (lastUnclosedDelimiterIndex == -1) return markdown
 
-    val offset = lineStartOffset(lines, lastUnclosedDelimiterIndex)
-    return markdown.substring(0, offset)
+    val offsets = buildLineOffsets(lines)
+    return markdown.substring(0, offsets[lastUnclosedDelimiterIndex])
   }
 
   private fun removePendingStreamingTableBlock(
     markdown: String,
     lines: List<String>,
+    tableMode: TableStreamingMode,
   ): String {
     var lastNonBlankLineIndex = -1
 
@@ -62,8 +71,28 @@ object StreamingMarkdownFilter {
 
     if (!blockLooksLikeTable) return markdown
 
-    val offset = lineStartOffset(lines, blockStartIndex)
-    return markdown.substring(0, offset)
+    val offsets = buildLineOffsets(lines)
+
+    if (tableMode == TableStreamingMode.PROGRESSIVE) {
+      val tableLineCount = lastNonBlankLineIndex - blockStartIndex + 1
+
+      if (tableLineCount < 2 || !lineLooksLikeTableSeparator(lines[blockStartIndex + 1])) {
+        return markdown.substring(0, offsets[blockStartIndex])
+      }
+
+      if (tableLineCount > 2) {
+        val lastRow = lines[lastNonBlankLineIndex]
+        val lastRowTrimmed = lastRow.trim()
+        val headerRow = lines[blockStartIndex]
+        if (!lastRowTrimmed.endsWith("|") || pipeCount(lastRow) < pipeCount(headerRow)) {
+          return markdown.substring(0, offsets[lastNonBlankLineIndex])
+        }
+      }
+
+      return markdown
+    }
+
+    return markdown.substring(0, offsets[blockStartIndex])
   }
 
   private fun lineIsBlank(line: String): Boolean = line.isBlank()
@@ -72,17 +101,42 @@ object StreamingMarkdownFilter {
 
   private fun lineLooksLikeTableRow(line: String): Boolean {
     val trimmed = line.trim()
-    return trimmed.startsWith("|") && trimmed.contains("|")
+    return trimmed.startsWith("|")
   }
 
-  private fun lineStartOffset(
-    lines: List<String>,
-    lineIndex: Int,
-  ): Int {
-    var offset = 0
-    for (i in 0 until lineIndex) {
-      offset += lines[i].length + 1
+  private fun lineLooksLikeTableSeparator(line: String): Boolean {
+    val trimmed = line.trim()
+    if (trimmed.isEmpty()) return false
+    if (trimmed[0] != '|') return false
+    var hasTripleDash = false
+    var dashRun = 0
+    for (ch in trimmed) {
+      if (ch == '-') {
+        dashRun++
+        if (dashRun >= 3) hasTripleDash = true
+      } else {
+        dashRun = 0
+        if (ch != '|' && ch != ':' && ch != ' ') return false
+      }
     }
-    return offset
+    return hasTripleDash
+  }
+
+  private fun pipeCount(line: String): Int {
+    var count = 0
+    for (ch in line) {
+      if (ch == '|') count++
+    }
+    return count
+  }
+
+  private fun buildLineOffsets(lines: List<String>): IntArray {
+    val offsets = IntArray(lines.size)
+    var pos = 0
+    for (i in lines.indices) {
+      offsets[i] = pos
+      pos += lines[i].length + 1
+    }
+    return offsets
   }
 }

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
@@ -132,10 +132,10 @@ object StreamingMarkdownFilter {
 
   private fun buildLineOffsets(lines: List<String>): IntArray {
     val offsets = IntArray(lines.size)
-    var pos = 0
+    var currentOffset = 0
     for (i in lines.indices) {
-      offsets[i] = pos
-      pos += lines[i].length + 1
+      offsets[i] = currentOffset
+      currentOffset += lines[i].length + 1
     }
     return offsets
   }

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
@@ -1,0 +1,88 @@
+package com.swmansion.enriched.markdown.utils.common
+
+/**
+ * Pre-parse filter that hides incomplete trailing tables and block math
+ * during streaming. A table is considered complete only after a blank
+ * separator line follows it; a block math (`$$`) is complete only when
+ * a closing `$$` exists.
+ */
+object StreamingMarkdownFilter {
+  fun renderableMarkdownForStreaming(markdown: String): String {
+    val lines = markdown.split("\n")
+    val afterMath = removePendingStreamingMathBlock(markdown, lines)
+    val linesForTable = if (afterMath.length == markdown.length) lines else afterMath.split("\n")
+    return removePendingStreamingTableBlock(afterMath, linesForTable)
+  }
+
+  private fun removePendingStreamingMathBlock(
+    markdown: String,
+    lines: List<String>,
+  ): String {
+    var lastUnclosedDelimiterIndex = -1
+
+    for (i in lines.indices) {
+      if (lineIsBlockMathDelimiter(lines[i])) {
+        lastUnclosedDelimiterIndex = if (lastUnclosedDelimiterIndex == -1) i else -1
+      }
+    }
+
+    if (lastUnclosedDelimiterIndex == -1) return markdown
+
+    val offset = lineStartOffset(lines, lastUnclosedDelimiterIndex)
+    return markdown.substring(0, offset)
+  }
+
+  private fun removePendingStreamingTableBlock(
+    markdown: String,
+    lines: List<String>,
+  ): String {
+    var lastNonBlankLineIndex = -1
+
+    for (i in lines.indices.reversed()) {
+      if (!lineIsBlank(lines[i])) {
+        lastNonBlankLineIndex = i
+        break
+      }
+    }
+
+    if (lastNonBlankLineIndex == -1) return markdown
+
+    if (lastNonBlankLineIndex + 1 < lines.size - 1) return markdown
+
+    var blockStartIndex = lastNonBlankLineIndex
+    while (blockStartIndex > 0 && !lineIsBlank(lines[blockStartIndex - 1])) {
+      blockStartIndex--
+    }
+
+    var blockLooksLikeTable = false
+    for (i in blockStartIndex..lastNonBlankLineIndex) {
+      if (!lineLooksLikeTableRow(lines[i])) return markdown
+      blockLooksLikeTable = true
+    }
+
+    if (!blockLooksLikeTable) return markdown
+
+    val offset = lineStartOffset(lines, blockStartIndex)
+    return markdown.substring(0, offset)
+  }
+
+  private fun lineIsBlank(line: String): Boolean = line.isBlank()
+
+  private fun lineIsBlockMathDelimiter(line: String): Boolean = line.trim() == "$$"
+
+  private fun lineLooksLikeTableRow(line: String): Boolean {
+    val trimmed = line.trim()
+    return trimmed.startsWith("|") && trimmed.contains("|")
+  }
+
+  private fun lineStartOffset(
+    lines: List<String>,
+    lineIndex: Int,
+  ): Int {
+    var offset = 0
+    for (i in 0 until lineIndex) {
+      offset += lines[i].length + 1
+    }
+    return offset
+  }
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
@@ -58,6 +58,32 @@ class TableContainerView(
     }
   private val gridContainer get() = scrollView.getChildAt(0) as GridContainerView
 
+  val rowCount: Int get() = rows.size
+
+  fun animateNewRows(
+    previousRowCount: Int,
+    durationMs: Long,
+  ) {
+    if (rowCount <= previousRowCount) return
+    val grid = gridContainer
+    val childCount = grid.childCount
+    if (childCount == 0 || rowCount == 0) return
+
+    val colCount = childCount / rowCount
+    if (colCount == 0) return
+
+    val firstNewCellIndex = previousRowCount * colCount
+    for (i in firstNewCellIndex until childCount) {
+      val cell = grid.getChildAt(i) ?: continue
+      cell.alpha = 0f
+      cell
+        .animate()
+        .alpha(1f)
+        .setDuration(durationMs)
+        .start()
+    }
+  }
+
   private var rows: List<List<TableCellData>> = emptyList()
   private var columnCount = 0
   private var columnWidths = emptyList<Float>()

--- a/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
+++ b/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
@@ -13,6 +13,7 @@ inline folly::dynamic toDynamic(const EnrichedMarkdownTextProps &props) {
   serializedProps["markdownStyle"] = toDynamic(props.markdownStyle);
   serializedProps["md4cFlags"] = toDynamic(props.md4cFlags);
   serializedProps["allowTrailingMargin"] = props.allowTrailingMargin;
+  serializedProps["streamingAnimation"] = props.streamingAnimation;
 
   return serializedProps;
 }
@@ -23,6 +24,7 @@ inline folly::dynamic toDynamic(const EnrichedMarkdownProps &props) {
   serializedProps["markdownStyle"] = toDynamic(props.markdownStyle);
   serializedProps["md4cFlags"] = toDynamic(props.md4cFlags);
   serializedProps["allowTrailingMargin"] = props.allowTrailingMargin;
+  serializedProps["streamingAnimation"] = props.streamingAnimation;
 
   return serializedProps;
 }

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -566,32 +566,9 @@ static char kENRMSegmentFadeAnimatorKey;
   NSUInteger previousRowCount = view.rowCount;
   [view applyTableNode:tableSegment.tableNode];
 
-#if !TARGET_OS_OSX
-  if (!_streamingAnimation || view.rowCount <= previousRowCount) {
-    return;
+  if (_streamingAnimation) {
+    [view animateNewRowsFromPreviousCount:previousRowCount duration:0.20];
   }
-
-  // The grid container is inside the scroll view: TableContainerView > UIScrollView > gridContainer.
-  // After applyTableNode:, cells are laid out sequentially — each row has colCount cell-background subviews.
-  RCTUIView *scrollView = view.subviews.firstObject;
-  RCTUIView *gridContainer = scrollView.subviews.firstObject;
-  if (!gridContainer || gridContainer.subviews.count == 0 || view.rowCount == 0) {
-    return;
-  }
-
-  NSUInteger colCount = gridContainer.subviews.count / view.rowCount;
-  if (colCount == 0) {
-    return;
-  }
-
-  NSUInteger firstNewCellIndex = previousRowCount * colCount;
-  NSArray<RCTUIView *> *subviews = gridContainer.subviews;
-  for (NSUInteger i = firstNewCellIndex; i < subviews.count; i++) {
-    RCTUIView *cellView = subviews[i];
-    cellView.alpha = 0.0;
-    [UIView animateWithDuration:0.20 animations:^{ cellView.alpha = 1.0; }];
-  }
-#endif
 }
 
 #if ENRICHED_MARKDOWN_MATH

--- a/ios/utils/StreamingMarkdownFilter.m
+++ b/ios/utils/StreamingMarkdownFilter.m
@@ -13,7 +13,7 @@ static BOOL ENRMLineIsBlockMathDelimiter(NSString *line)
 static BOOL ENRMLineLooksLikeTableRow(NSString *line)
 {
   NSString *trimmed = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-  return [trimmed hasPrefix:@"|"] && [trimmed containsString:@"|"];
+  return [trimmed hasPrefix:@"|"];
 }
 
 static NSUInteger ENRMPipeCount(NSString *line)
@@ -55,19 +55,19 @@ static BOOL ENRMLineLooksLikeTableSeparator(NSString *line)
   return hasTripleDash;
 }
 
-static NSUInteger ENRMLineStartOffset(NSArray<NSString *> *lines, NSUInteger lineIndex)
+static NSUInteger *ENRMBuildLineOffsets(NSArray<NSString *> *lines, NSUInteger count)
 {
-  NSUInteger offset = 0;
-  for (NSUInteger i = 0; i < lineIndex; i++) {
-    offset += lines[i].length;
-    offset += 1;
+  NSUInteger *offsets = (NSUInteger *)calloc(count, sizeof(NSUInteger));
+  NSUInteger currentOffset = 0;
+  for (NSUInteger i = 0; i < count; i++) {
+    offsets[i] = currentOffset;
+    currentOffset += lines[i].length + 1;
   }
-  return offset;
+  return offsets;
 }
 
-static NSString *ENRMRemovePendingStreamingMathBlock(NSString *markdown)
+static NSString *ENRMRemovePendingStreamingMathBlock(NSString *markdown, NSArray<NSString *> *lines)
 {
-  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
   NSInteger lastUnclosedDelimiterIndex = -1;
 
   for (NSUInteger i = 0; i < lines.count; i++) {
@@ -80,13 +80,15 @@ static NSString *ENRMRemovePendingStreamingMathBlock(NSString *markdown)
     return markdown;
   }
 
-  NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)lastUnclosedDelimiterIndex);
-  return [markdown substringToIndex:offset];
+  NSUInteger *offsets = ENRMBuildLineOffsets(lines, lines.count);
+  NSString *result = [markdown substringToIndex:offsets[(NSUInteger)lastUnclosedDelimiterIndex]];
+  free(offsets);
+  return result;
 }
 
-static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown, ENRMTableStreamingMode tableMode)
+static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown, NSArray<NSString *> *lines,
+                                                      ENRMTableStreamingMode tableMode)
 {
-  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
   NSInteger lastNonBlankLineIndex = -1;
 
   for (NSInteger i = (NSInteger)lines.count - 1; i >= 0; i--) {
@@ -100,8 +102,6 @@ static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown, ENRMTa
     return markdown;
   }
 
-  // During streaming, treat a trailing table as complete only after a blank
-  // separator line. A single trailing newline can still be followed by more rows.
   if ((NSUInteger)lastNonBlankLineIndex + 1 < lines.count - 1) {
     return markdown;
   }
@@ -124,36 +124,42 @@ static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown, ENRMTa
     return markdown;
   }
 
+  NSUInteger *offsets = ENRMBuildLineOffsets(lines, lines.count);
+
   if (tableMode == ENRMTableStreamingModeProgressive) {
     NSInteger tableLineCount = lastNonBlankLineIndex - blockStartIndex + 1;
 
-    // Need at least header + separator to show anything.
     if (tableLineCount < 2 || !ENRMLineLooksLikeTableSeparator(lines[(NSUInteger)blockStartIndex + 1])) {
-      NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)blockStartIndex);
-      return [markdown substringToIndex:offset];
+      NSString *result = [markdown substringToIndex:offsets[(NSUInteger)blockStartIndex]];
+      free(offsets);
+      return result;
     }
 
-    // Trim the last data row if it's incomplete: either doesn't end with '|'
-    // or has fewer pipe characters than the header (mid-cell streaming).
     if (tableLineCount > 2) {
       NSString *lastRow = lines[(NSUInteger)lastNonBlankLineIndex];
       NSString *lastRowTrimmed = [lastRow stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
       NSString *headerRow = lines[(NSUInteger)blockStartIndex];
       if (![lastRowTrimmed hasSuffix:@"|"] || ENRMPipeCount(lastRow) < ENRMPipeCount(headerRow)) {
-        NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)lastNonBlankLineIndex);
-        return [markdown substringToIndex:offset];
+        NSString *result = [markdown substringToIndex:offsets[(NSUInteger)lastNonBlankLineIndex]];
+        free(offsets);
+        return result;
       }
     }
 
+    free(offsets);
     return markdown;
   }
 
-  NSUInteger offset = ENRMLineStartOffset(lines, (NSUInteger)blockStartIndex);
-  return [markdown substringToIndex:offset];
+  NSString *result = [markdown substringToIndex:offsets[(NSUInteger)blockStartIndex]];
+  free(offsets);
+  return result;
 }
 
 NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStreamingMode tableMode)
 {
-  NSString *withoutPendingMath = ENRMRemovePendingStreamingMathBlock(markdown);
-  return ENRMRemovePendingStreamingTableBlock(withoutPendingMath, tableMode);
+  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
+  NSString *afterMath = ENRMRemovePendingStreamingMathBlock(markdown, lines);
+  NSArray<NSString *> *linesForTable =
+      (afterMath.length == markdown.length) ? lines : [afterMath componentsSeparatedByString:@"\n"];
+  return ENRMRemovePendingStreamingTableBlock(afterMath, linesForTable, tableMode);
 }

--- a/ios/views/TableContainerView.h
+++ b/ios/views/TableContainerView.h
@@ -28,6 +28,8 @@ typedef void (^TableLinkPressBlock)(NSString *url);
 
 @property (nonatomic, readonly) NSUInteger rowCount;
 
+- (void)animateNewRowsFromPreviousCount:(NSUInteger)previousRowCount duration:(NSTimeInterval)duration;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/views/TableContainerView.m
+++ b/ios/views/TableContainerView.m
@@ -172,6 +172,38 @@
   return _rows.count;
 }
 
+#if !TARGET_OS_OSX
+- (void)animateNewRowsFromPreviousCount:(NSUInteger)previousRowCount duration:(NSTimeInterval)duration
+{
+  if (self.rowCount <= previousRowCount) {
+    return;
+  }
+
+  NSArray<RCTUIView *> *subviews = _gridContainer.subviews;
+  NSUInteger childCount = subviews.count;
+  if (childCount == 0 || self.rowCount == 0) {
+    return;
+  }
+
+  NSUInteger colCount = childCount / self.rowCount;
+  if (colCount == 0) {
+    return;
+  }
+
+  NSUInteger firstNewCellIndex = previousRowCount * colCount;
+  for (NSUInteger i = firstNewCellIndex; i < childCount; i++) {
+    RCTUIView *cellView = subviews[i];
+    cellView.alpha = 0.0;
+    [UIView animateWithDuration:duration animations:^{ cellView.alpha = 1.0; }];
+  }
+}
+#else
+- (void)animateNewRowsFromPreviousCount:(NSUInteger)previousRowCount duration:(NSTimeInterval)duration
+{
+  // No-op on macOS
+}
+#endif
+
 - (void)applyTableNode:(MarkdownASTNode *)tableNode
 {
   [[_gridContainer subviews] makeObjectsPerformSelector:@selector(removeFromSuperview)];


### PR DESCRIPTION
### What/Why?
Ports the iOS GFM streaming approach (#270) to Android.

Introduces the same segment-based architecture: streaming filter, FNV-1a signatures, and 4-step view reconciliation. Aligns Android measurement with the streaming filter so Yoga layout height tracks rendered content reliably, and serializes the streamingAnimation prop through the C++ bridge to ensure the measurement path applies the same filtering as the view layer.

Static GFM behavior remains unchanged.



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

