### PR TITLE
fix(ios): prevent crash when deleting mixed selection or using IME input

### DIFF
--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -1091,8 +1091,10 @@ using namespace facebook::react;
 
   [self applyFormatting];
 
+  NSUInteger clampedEditLocation = MIN(editLocation, newLength);
+  NSUInteger clampedInsertedLength = MIN(insertedLength, newLength - clampedEditLocation);
   [_detectorPipeline processTextChange:ENRMGetPlainText(_textView)
-                     modificationRange:NSMakeRange(editLocation, insertedLength)];
+                     modificationRange:NSMakeRange(clampedEditLocation, clampedInsertedLength)];
 
   [self updatePlaceholderVisibility];
   [self emitOnChangeText];
@@ -1184,14 +1186,16 @@ using namespace facebook::react;
 
 - (void)textViewDidChangeSelection:(UITextView *)textView
 {
+  NSRange newSelection = textView.selectedRange;
+  NSRange previousSelection = _lastSelectedRange;
+  _lastSelectedRange = newSelection;
+
   if (_isApplyingFormatting || _isTextChanging) {
     return;
   }
 
-  NSRange newSelection = textView.selectedRange;
   BOOL selectionMoved =
-      newSelection.location != _lastSelectedRange.location || newSelection.length != _lastSelectedRange.length;
-  _lastSelectedRange = newSelection;
+      newSelection.location != previousSelection.location || newSelection.length != previousSelection.length;
 
   if (selectionMoved) {
     [_pendingStyles removeAllObjects];
@@ -1263,10 +1267,11 @@ using namespace facebook::react;
 
 - (void)textInputDidChangeSelection
 {
+  _lastSelectedRange = _textView.selectedRange;
+
   if (_isApplyingFormatting || _isTextChanging) {
     return;
   }
-  _lastSelectedRange = _textView.selectedRange;
 
   [_pendingStyles removeAllObjects];
   [_pendingStyleRemovals removeAllObjects];


### PR DESCRIPTION
### What/Why?
Fixes: #276 

Always update _lastSelectedRange in textViewDidChangeSelection and textInputDidChangeSelection before the isApplyingFormatting guard, ensuring _preEditSelectedRange is never stale when handleTextChanged computes edit parameters. Also clamp modificationRange passed to the detector pipeline so out-of-bounds values cannot reach ENRMWordsUtils.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

