### PR TITLE
fix(ios): use controlled path for Cut to prevent formatting corruption

### DIFF
--- a/ios/input/ENRMInputTextView.mm
+++ b/ios/input/ENRMInputTextView.mm
@@ -34,7 +34,7 @@ static NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-ma
 - (void)cut:(id)sender
 {
   [self copy:sender];
-  [self replaceRange:self.selectedTextRange withText:@""];
+  [self.markdownTextInput replaceSelectedTextWith:@"" formattingRanges:@[]];
 }
 
 - (void)paste:(id)sender
@@ -111,9 +111,7 @@ static NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-ma
 - (void)cut:(id)sender
 {
   [self copy:sender];
-  if (self.selectedRange.length > 0) {
-    [self insertText:@"" replacementRange:self.selectedRange];
-  }
+  [self.markdownTextInput replaceSelectedTextWith:@"" formattingRanges:@[]];
 }
 
 - (void)paste:(id)sender

--- a/ios/input/EnrichedMarkdownTextInput.h
+++ b/ios/input/EnrichedMarkdownTextInput.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (CGSize)measureSize:(CGFloat)maxWidth;
 - (nullable NSString *)markdownForSelectedRange;
 - (void)pasteMarkdown:(NSString *)markdown;
+- (void)replaceSelectedTextWith:(NSString *)text formattingRanges:(NSArray *)ranges;
 - (void)scheduleRelayoutIfNeeded;
 @end
 

--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -41,7 +41,6 @@ using namespace facebook::react;
 - (void)applyFormatting;
 - (void)toggleInlineStyle:(ENRMInputStyleType)styleType;
 - (void)resetBaseTypingAttributes;
-- (void)replaceSelectedTextWith:(NSString *)text formattingRanges:(NSArray<ENRMFormattingRange *> *)ranges;
 @end
 
 @implementation EnrichedMarkdownTextInput {

--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -1091,8 +1091,10 @@ using namespace facebook::react;
 
   [self applyFormatting];
 
+  NSUInteger clampedEditLocation = MIN(editLocation, newLength);
+  NSUInteger clampedInsertedLength = MIN(insertedLength, newLength - clampedEditLocation);
   [_detectorPipeline processTextChange:ENRMGetPlainText(_textView)
-                     modificationRange:NSMakeRange(editLocation, insertedLength)];
+                     modificationRange:NSMakeRange(clampedEditLocation, clampedInsertedLength)];
 
   [self updatePlaceholderVisibility];
   [self emitOnChangeText];
@@ -1184,14 +1186,16 @@ using namespace facebook::react;
 
 - (void)textViewDidChangeSelection:(UITextView *)textView
 {
+  NSRange newSelection = textView.selectedRange;
+  NSRange previousSelection = _lastSelectedRange;
+  _lastSelectedRange = newSelection;
+
   if (_isApplyingFormatting || _isTextChanging) {
     return;
   }
 
-  NSRange newSelection = textView.selectedRange;
   BOOL selectionMoved =
-      newSelection.location != _lastSelectedRange.location || newSelection.length != _lastSelectedRange.length;
-  _lastSelectedRange = newSelection;
+      newSelection.location != previousSelection.location || newSelection.length != previousSelection.length;
 
   if (selectionMoved) {
     [_pendingStyles removeAllObjects];
@@ -1263,10 +1267,11 @@ using namespace facebook::react;
 
 - (void)textInputDidChangeSelection
 {
+  _lastSelectedRange = _textView.selectedRange;
+
   if (_isApplyingFormatting || _isTextChanging) {
     return;
   }
-  _lastSelectedRange = _textView.selectedRange;
 
   [_pendingStyles removeAllObjects];
   [_pendingStyleRemovals removeAllObjects];


### PR DESCRIPTION
### What/Why?
Fixes: #273 

Using "Cut" on a mixed selection produces deformed markdown. Cut was routing through UIKit's standard delegate chain (replaceRange:withText:), which is subject to the same timing races. On slower devices or in low power mode, the formatting store gets misaligned because the delegate-based edit parameter inference uses stale values.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

