### PR TITLE
fix(android): correct insertion boundary in FormattingStore and add serializer bounds check

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/FormattingStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/FormattingStore.kt
@@ -140,7 +140,7 @@ class FormattingStore {
         }
       } else {
         when {
-          range.start > editLocation -> {
+          range.start >= editLocation -> {
             range.start += insertedLength
             range.end += insertedLength
           }

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/MarkdownSerializer.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/MarkdownSerializer.kt
@@ -12,8 +12,10 @@ object MarkdownSerializer {
 
     val events = ArrayList<BoundaryEvent>(ranges.size * 2)
     for (range in ranges) {
-      var start = range.start
-      var end = range.end
+      var start = range.start.coerceIn(0, text.length)
+      var end = range.end.coerceIn(0, text.length)
+
+      if (start >= end) continue
 
       // Trim leading/trailing whitespace so delimiters hug non-whitespace content
       while (start < end && text[start].isWhitespace()) start++


### PR DESCRIPTION
### What/Why?
Change adjustForEdit to shift ranges when editLocation == range.start (using >= instead of >), matching iOS behavior. Without this, typing at the start of a formatted range fails to shift it, causing the inserted character to incorrectly inherit the style.

Add bounds clamping in MarkdownSerializer to prevent StringIndexOutOfBoundsException if the formatting store ever contains ranges that exceed the text length.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes

