### PR TITLE
fix(ios): spoiler not rendering after keystroke

### DIFF
--- a/ios/views/EnrichedMarkdownInternalText.m
+++ b/ios/views/EnrichedMarkdownInternalText.m
@@ -78,6 +78,7 @@
   [_textView.layoutManager invalidateLayoutForCharacterRange:NSMakeRange(0, text.length) actualCharacterRange:NULL];
 
   [_spoilerManager setNeedsUpdate];
+  [self setNeedsLayout];
 
 #if !TARGET_OS_OSX
   [_textView setNeedsLayout];


### PR DESCRIPTION
### What/Why?
While (check video section) working on playground I've found out that `||spoilers||` on IOS are not rendering properly when we try to render them after last `|` keystroke (so `||test|` -> `||test||`). This fixes the issue by setting `needsLayout` flag to trigger render of spoiler "frame" during re-render.  

### Testing
- open playground on IOS
- type `||test|` into input field -> add missing `|` to create spoiler 
    - expected: spoiler is being created
- turn on `||` (spoiler) mode 
    - expected: spoiler is being created in both input field and rendered field

### Video
##### Before

https://github.com/user-attachments/assets/78082dd7-6376-41b1-9703-ed8140101a2b

##### After

https://github.com/user-attachments/assets/63a1e15a-e470-45c6-b77f-da3807dd597c 


### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes

