### PR TITLE
fix(android): use ceil for split-segment width to match commonmark path and rendered TextView

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -381,7 +381,7 @@ object MeasurementStore {
         }
       }
 
-      val widthPx = width.toInt().coerceAtLeast(1)
+      val widthPx = ceil(width).toInt().coerceAtLeast(1)
       val lastIndex = renderedSegments.lastIndex
       var totalHeightPx = 0f
       var maxContentWidthPx = 0f


### PR DESCRIPTION
Fixes #281

`measureAndCacheSplit` truncated the Yoga width with `width.toInt()`,
while the commonmark paths

https://github.com/software-mansion-labs/react-native-enriched-markdown/blob/main/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt#L523

https://github.com/FylerSearch/react-native-enriched-markdown/blob/cd484331e51a1e937fada0431e80ab29943dc68f/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt#L559-L561

already use `ceil(maxWidth).toInt()`. 

Yoga rounds the rendered TextView frame UP to the next pixel.


Locally I tested with the following code, and wasn't able to reproduce, (BTW it's rare bug on random ;-))

```typescript
import { ScrollView, View } from "react-native";
import { EnrichedMarkdownText } from "react-native-enriched-markdown";

const WORDS = [
  "fields",
  ",",
  "it",
  "consistently",
  "emphasizes",
  "that",
  "reaching",
  "higher",
  "goals",
  "requires",
  "a",
  "fundamental",
  "change",
  "in",
  "thinking",
  "and",
  "effort",
  "rather",
  "than",
  "simply",
  "working",
  "more",
  "hours",
  ".",
];

function mulberry32(seed: number) {
  let state = seed;
  return () => {
    state = (state + 0x6d2b79f5) | 0;
    let t = state;
    t = Math.imul(t ^ (t >>> 15), t | 1);
    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
  };
}

function randomBlock(seed: number): string {
  const rand = mulberry32(seed * Math.random());
  const count = 20 + Math.floor(rand() * 20);
  const words: string[] = [];
  for (let i = 0; i < count; i++) {
    words.push(WORDS[Math.floor(rand() * WORDS.length)]);
  }
  return `${words.join(" ")}.`;
}

const BLOCKS = Array.from({ length: 300 }, (_, i) => randomBlock(i * 112 + 1));

export default function PartsPlayground() {
  return (
    <ScrollView className="flex-1 bg-background p-4 pt-safe">
      {BLOCKS.map((markdown, i) => (
        <View key={i}>
          <EnrichedMarkdownText
            containerStyle={{
              backgroundColor: "red",
            }}
            flavor="github"
            markdown={markdown}
          />
          <View className="h-4" />
        </View>
      ))}
    </ScrollView>
  );
}
```

