### PR TITLE
fix(ios): break retain cycle between renderers and RendererFactory

### DIFF
--- a/ios/renderer/BlockquoteRenderer.m
+++ b/ios/renderer/BlockquoteRenderer.m
@@ -10,7 +10,7 @@ static NSString *const kNestedInfoDepthKey = @"depth";
 static NSString *const kNestedInfoRangeKey = @"range";
 
 @implementation BlockquoteRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/CodeBlockRenderer.m
+++ b/ios/renderer/CodeBlockRenderer.m
@@ -8,7 +8,7 @@
 #import "StyleConfig.h"
 
 @implementation CodeBlockRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/CodeRenderer.m
+++ b/ios/renderer/CodeRenderer.m
@@ -9,7 +9,7 @@
 #import <React/RCTFont.h>
 
 @implementation CodeRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/ENRMImageRenderer.m
+++ b/ios/renderer/ENRMImageRenderer.m
@@ -9,7 +9,7 @@ static const unichar kLineBreak = '\n';
 static const unichar kZeroWidthSpace = 0x200B;
 
 @implementation ENRMImageRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/ENRMMathInlineRenderer.m
+++ b/ios/renderer/ENRMMathInlineRenderer.m
@@ -10,7 +10,7 @@
 #if ENRICHED_MARKDOWN_MATH
 
 @implementation ENRMMathInlineRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/ENRMSpoilerRenderer.m
+++ b/ios/renderer/ENRMSpoilerRenderer.m
@@ -5,7 +5,7 @@
 #import "RendererFactory.h"
 
 @implementation ENRMSpoilerRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
 }
 
 - (instancetype)initWithRendererFactory:(id)rendererFactory config:(__unused id)config

--- a/ios/renderer/EmphasisRenderer.m
+++ b/ios/renderer/EmphasisRenderer.m
@@ -7,7 +7,7 @@
 #import <React/RCTFont.h>
 
 @implementation EmphasisRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/HeadingRenderer.m
+++ b/ios/renderer/HeadingRenderer.m
@@ -20,7 +20,7 @@ static NSString *const kHeadingTypes[] = {nil,          @"heading-1", @"heading-
                                           @"heading-4", @"heading-5", @"heading-6"};
 
 @implementation HeadingRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/LinkRenderer.m
+++ b/ios/renderer/LinkRenderer.m
@@ -6,7 +6,7 @@
 #import <React/RCTFont.h>
 
 @implementation LinkRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/ListItemRenderer.m
+++ b/ios/renderer/ListItemRenderer.m
@@ -21,7 +21,7 @@ NSString *const TaskIndexAttribute = @"TaskIndex";
 @end
 
 @implementation ListItemRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/ListRenderer.m
+++ b/ios/renderer/ListRenderer.m
@@ -7,7 +7,7 @@
 #import "StyleConfig.h"
 
 @implementation ListRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
   BOOL _isOrdered;
 }

--- a/ios/renderer/ParagraphRenderer.m
+++ b/ios/renderer/ParagraphRenderer.m
@@ -6,7 +6,7 @@
 #import "StyleConfig.h"
 
 @implementation ParagraphRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/StrikethroughRenderer.m
+++ b/ios/renderer/StrikethroughRenderer.m
@@ -5,7 +5,7 @@
 #import "StyleConfig.h"
 
 @implementation StrikethroughRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/StrongRenderer.m
+++ b/ios/renderer/StrongRenderer.m
@@ -7,7 +7,7 @@
 #import <React/RCTFont.h>
 
 @implementation StrongRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 

--- a/ios/renderer/UnderlineRenderer.m
+++ b/ios/renderer/UnderlineRenderer.m
@@ -5,7 +5,7 @@
 #import "StyleConfig.h"
 
 @implementation UnderlineRenderer {
-  RendererFactory *_rendererFactory;
+  __weak RendererFactory *_rendererFactory;
   StyleConfig *_config;
 }
 


### PR DESCRIPTION
  ### What/Why?

  Closes #283

  Each renderer subclass held a strong reference to `RendererFactory`,
  which itself caches renderers in a strong-keyed dictionary. This
  created a retain cycle that ARC could not break, causing the factory
  and all renderers (plus their `StyleConfig` instances, ~9 KiB each)
  to leak on every props update — significant for `EnrichedMarkdownText`
  with frequently changing `markdown` props (e.g. LLM streaming).

  Fix: change `_rendererFactory` from strong to `__weak` in all 15
  renderer subclasses. `AttributedRenderer.m` remains strong since it
  is the actual owner of the factory. Matches the pattern already used
  in `ThematicBreakRenderer.m`.

  ### Testing

  Profiled with Instruments → Leaks template, Release build on iPhone 15 Pro
  (iOS 26), new architecture enabled. Same reproduction flow before and after.

  **Before:** ~150 leaks per 30s scan, dominated by `RendererFactory`,
  all renderer subclasses, and `StyleConfig`.

  **After:** 0 library leaks. Only 1–2 unrelated `TextInputProps`
  leaks from React Native core remain.

  Reproduced and verified via `patch-package` on a production app
  using `EnrichedMarkdownText` for LLM streaming.

  ### PR Checklist

  - [x] Code compiles and runs on iOS
  - [x] Code compiles and runs on Android (no Android changes — fix is iOS-only)
  - [x] Updated documentation/README if applicable (N/A — internal change)
  - [ ] Ran example app to verify changes
