### PR TITLE
feat: add selectionMenuConfig prop to control built-in selection menu items

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -22,6 +22,7 @@ import com.swmansion.enriched.markdown.utils.common.StreamingMarkdownFilter
 import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
 import com.swmansion.enriched.markdown.utils.common.splitASTIntoSegments
 import com.swmansion.enriched.markdown.utils.text.TailFadeInAnimator
+import com.swmansion.enriched.markdown.utils.text.view.SelectionMenuConfig
 import com.swmansion.enriched.markdown.utils.text.view.applySelectionColors
 import com.swmansion.enriched.markdown.views.BlockSegmentView
 import com.swmansion.enriched.markdown.views.TableContainerView
@@ -78,6 +79,7 @@ class EnrichedMarkdown
     private var selectable: Boolean = true
     private var selectionColor: Int? = null
     private var selectionHandleColor: Int? = null
+    private var selectionMenuConfig = SelectionMenuConfig()
 
     private var onLinkPressCallback: ((String) -> Unit)? = null
     private var onLinkLongPressCallback: ((String) -> Unit)? = null
@@ -204,6 +206,14 @@ class EnrichedMarkdown
       contextMenuItemTexts = items
       segmentViews.filterIsInstance<EnrichedMarkdownInternalText>().forEach {
         it.setContextMenuItems(items, ::forwardContextMenuItemPress)
+      }
+    }
+
+    fun setSelectionMenuConfig(config: SelectionMenuConfig) {
+      if (selectionMenuConfig == config) return
+      selectionMenuConfig = config
+      segmentViews.filterIsInstance<EnrichedMarkdownInternalText>().forEach {
+        it.selectionMenuConfig = config
       }
     }
 
@@ -405,6 +415,7 @@ class EnrichedMarkdown
     private fun createTextView(segment: RenderedSegment.Text) =
       EnrichedMarkdownInternalText(context).apply {
         spoilerOverlay = this@EnrichedMarkdown.spoilerOverlay
+        selectionMenuConfig = this@EnrichedMarkdown.selectionMenuConfig
         setIsSelectable(selectable)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && segment.needsJustify) {
           justificationMode = android.text.Layout.JUSTIFICATION_MODE_INTER_WORD

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownInternalText.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownInternalText.kt
@@ -12,6 +12,7 @@ import com.swmansion.enriched.markdown.spoiler.SpoilerOverlay
 import com.swmansion.enriched.markdown.spoiler.SpoilerOverlayDrawer
 import com.swmansion.enriched.markdown.utils.text.interaction.CheckboxTouchHelper
 import com.swmansion.enriched.markdown.utils.text.view.LinkLongPressMovementMethod
+import com.swmansion.enriched.markdown.utils.text.view.SelectionMenuConfig
 import com.swmansion.enriched.markdown.utils.text.view.applySelectableState
 import com.swmansion.enriched.markdown.utils.text.view.cancelJSTouchForCheckboxTap
 import com.swmansion.enriched.markdown.utils.text.view.cancelJSTouchForLinkTap
@@ -45,6 +46,7 @@ class EnrichedMarkdownInternalText
     var spoilerOverlay: SpoilerOverlay = SpoilerOverlay.PARTICLES
     private var contextMenuItemTexts: List<String> = emptyList()
     private var onContextMenuItemPress: ((itemText: String, selectedText: String, selectionStart: Int, selectionEnd: Int) -> Unit)? = null
+    var selectionMenuConfig: SelectionMenuConfig = SelectionMenuConfig()
 
     init {
       setupAsMarkdownTextView()
@@ -52,6 +54,7 @@ class EnrichedMarkdownInternalText
         createSelectionActionModeCallback(
           this,
           getCustomItemTexts = { contextMenuItemTexts },
+          getSelectionMenuConfig = { selectionMenuConfig },
           onCustomItemPress = { itemText, selectedText, start, end ->
             onContextMenuItemPress?.invoke(itemText, selectedText, start, end)
           },

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -20,6 +20,7 @@ import com.swmansion.enriched.markdown.utils.common.emitTaskListItemPress
 import com.swmansion.enriched.markdown.utils.common.markdownEventTypeConstants
 import com.swmansion.enriched.markdown.utils.common.parseContextMenuItems
 import com.swmansion.enriched.markdown.utils.common.parseMd4cFlags
+import com.swmansion.enriched.markdown.utils.common.parseSelectionMenuConfig
 import com.swmansion.enriched.markdown.utils.text.interaction.TaskListToggleUtils
 
 @ReactModule(name = EnrichedMarkdownManager.NAME)
@@ -184,6 +185,15 @@ class EnrichedMarkdownManager :
   ) {
     if (view == null) return
     view.setContextMenuItems(parseContextMenuItems(value))
+  }
+
+  @ReactProp(name = "selectionMenuConfig")
+  override fun setSelectionMenuConfig(
+    view: EnrichedMarkdown?,
+    value: ReadableMap?,
+  ) {
+    if (view == null) return
+    view.setSelectionMenuConfig(parseSelectionMenuConfig(value))
   }
 
   override fun setPadding(

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -22,6 +22,7 @@ import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.text.TailFadeInAnimator
 import com.swmansion.enriched.markdown.utils.text.interaction.CheckboxTouchHelper
 import com.swmansion.enriched.markdown.utils.text.view.LinkLongPressMovementMethod
+import com.swmansion.enriched.markdown.utils.text.view.SelectionMenuConfig
 import com.swmansion.enriched.markdown.utils.text.view.applySelectableState
 import com.swmansion.enriched.markdown.utils.text.view.applySelectionColors
 import com.swmansion.enriched.markdown.utils.text.view.cancelJSTouchForCheckboxTap
@@ -84,6 +85,7 @@ class EnrichedMarkdownText
 
     private var selectionColor: Int? = null
     private var selectionHandleColor: Int? = null
+    private var selectionMenuConfig = SelectionMenuConfig()
 
     init {
       setupAsMarkdownTextView()
@@ -91,6 +93,7 @@ class EnrichedMarkdownText
         createSelectionActionModeCallback(
           this,
           getCustomItemTexts = { contextMenuItemTexts },
+          getSelectionMenuConfig = { selectionMenuConfig },
           onCustomItemPress = { itemText, selectedText, start, end ->
             onContextMenuItemPressCallback?.invoke(itemText, selectedText, start, end)
           },
@@ -258,6 +261,11 @@ class EnrichedMarkdownText
 
     fun setContextMenuItems(items: List<String>) {
       contextMenuItemTexts = items
+    }
+
+    fun setSelectionMenuConfig(config: SelectionMenuConfig) {
+      if (selectionMenuConfig == config) return
+      selectionMenuConfig = config
     }
 
     fun setIsSelectable(selectable: Boolean) {

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -19,6 +19,7 @@ import com.swmansion.enriched.markdown.utils.common.emitTaskListItemPress
 import com.swmansion.enriched.markdown.utils.common.markdownEventTypeConstants
 import com.swmansion.enriched.markdown.utils.common.parseContextMenuItems
 import com.swmansion.enriched.markdown.utils.common.parseMd4cFlags
+import com.swmansion.enriched.markdown.utils.common.parseSelectionMenuConfig
 import com.swmansion.enriched.markdown.utils.text.interaction.TaskListTapUtils
 import com.swmansion.enriched.markdown.utils.text.interaction.TaskListToggleUtils
 
@@ -185,6 +186,15 @@ class EnrichedMarkdownTextManager :
   ) {
     if (view == null) return
     view.setContextMenuItems(parseContextMenuItems(value))
+  }
+
+  @ReactProp(name = "selectionMenuConfig")
+  override fun setSelectionMenuConfig(
+    view: EnrichedMarkdownText?,
+    value: ReadableMap?,
+  ) {
+    if (view == null) return
+    view.setSelectionMenuConfig(parseSelectionMenuConfig(value))
   }
 
   override fun setPadding(

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MarkdownViewManagerUtils.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MarkdownViewManagerUtils.kt
@@ -9,6 +9,7 @@ import com.swmansion.enriched.markdown.events.LinkLongPressEvent
 import com.swmansion.enriched.markdown.events.LinkPressEvent
 import com.swmansion.enriched.markdown.events.TaskListItemPressEvent
 import com.swmansion.enriched.markdown.parser.Md4cFlags
+import com.swmansion.enriched.markdown.utils.text.view.SelectionMenuConfig
 
 fun markdownEventTypeConstants(): MutableMap<String, Any> {
   val map = mutableMapOf<String, Any>()
@@ -86,3 +87,11 @@ fun parseMd4cFlags(flags: ReadableMap?): Md4cFlags =
 
 fun parseContextMenuItems(value: ReadableArray?): List<String> =
   (0 until (value?.size() ?: 0)).mapNotNull { value?.getMap(it)?.getString("text") }
+
+fun parseSelectionMenuConfig(value: ReadableMap?): SelectionMenuConfig {
+  if (value == null) return SelectionMenuConfig()
+  return SelectionMenuConfig(
+    copyAsMarkdown = value.getBoolean("copyAsMarkdown"),
+    copyImageUrl = value.getBoolean("copyImageUrl"),
+  )
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionMode.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionMode.kt
@@ -22,6 +22,11 @@ private const val MENU_ITEM_COPY_IMAGE_URL = 1001
 private const val MENU_ITEM_CUSTOM_BASE = 2000
 private const val MENU_ITEM_CUSTOM_GROUP = 2001
 
+data class SelectionMenuConfig(
+  val copyAsMarkdown: Boolean = true,
+  val copyImageUrl: Boolean = true,
+)
+
 /**
  * Creates an ActionMode.Callback that adds custom copy options and
  * overrides the default "Copy" action to include HTML for rich text support.
@@ -29,7 +34,9 @@ private const val MENU_ITEM_CUSTOM_GROUP = 2001
 fun createSelectionActionModeCallback(
   textView: TextView,
   getCustomItemTexts: () -> List<String> = { emptyList() },
-  onCustomItemPress: (itemText: String, selectedText: String, selectionStart: Int, selectionEnd: Int) -> Unit = { _, _, _, _ -> },
+  getSelectionMenuConfig: () -> SelectionMenuConfig = { SelectionMenuConfig() },
+  onCustomItemPress: (itemText: String, selectedText: String, selectionStart: Int, selectionEnd: Int) -> Unit =
+    { _, _, _, _ -> },
 ): ActionMode.Callback =
   object : ActionMode.Callback {
     override fun onCreateActionMode(
@@ -47,9 +54,17 @@ fun createSelectionActionModeCallback(
       menu.removeItem(MENU_ITEM_COPY_IMAGE_URL)
       menu.removeGroup(MENU_ITEM_CUSTOM_GROUP)
 
-      if (textView.selectionStart >= 0 && textView.selectionEnd > textView.selectionStart) {
-        menu.add(Menu.NONE, MENU_ITEM_COPY_MARKDOWN, Menu.NONE, "Copy as Markdown")
+      val selectionMenuConfig = getSelectionMenuConfig()
 
+      if (
+        selectionMenuConfig.copyAsMarkdown &&
+        textView.selectionStart >= 0 &&
+        textView.selectionEnd > textView.selectionStart
+      ) {
+        menu.add(Menu.NONE, MENU_ITEM_COPY_MARKDOWN, Menu.NONE, "Copy as Markdown")
+      }
+
+      if (textView.selectionStart >= 0 && textView.selectionEnd > textView.selectionStart) {
         val customItems = getCustomItemTexts()
         customItems.forEachIndexed { index, text ->
           menu
@@ -58,7 +73,12 @@ fun createSelectionActionModeCallback(
         }
       }
 
-      val imageUrls = textView.getImageUrlsInSelection()
+      val imageUrls =
+        if (selectionMenuConfig.copyImageUrl) {
+          textView.getImageUrlsInSelection()
+        } else {
+          emptyList()
+        }
       if (imageUrls.isNotEmpty()) {
         val title =
           if (imageUrls.size == 1) {

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -2117,7 +2117,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
-  hermes-engine: b0f9c82a51be8e938eb979ada628323e1e093f1d
+  hermes-engine: 40811a005e96e04818cff405ec04a5b4c4411c1c
   iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
   RCTDeprecation: af44b104091a34482596cd9bd7e8d90c4e9b4bd7
   RCTRequired: bb77b070f75f53398ce43c0aaaa58337cebe2bf6
@@ -2127,7 +2127,7 @@ SPEC CHECKSUMS:
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
   React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
-  React-Core-prebuilt: 3dc04e91547fc0f260f4b84c12da0f672b813862
+  React-Core-prebuilt: 7965d06a81dcc544164f8e98b26d35ae2a4eb36e
   React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
   React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
   React-debug: 755200a6e7f5e6e0a40ff8d215493d43cce285fc
@@ -2189,7 +2189,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
   ReactCodegen: 797de5178718324c6eba3327b07f9a423fbd5787
   ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
-  ReactNativeDependencies: 44f7326a697de7f6c8629036b1a4689f0e64c684
+  ReactNativeDependencies: 0811b43c669e637a9f3c485fdb106f187fa88398
   ReactNativeEnrichedMarkdown: e6fea750b1ca4cbd853c1c78de9bd1ccb638ab77
   Yoga: c0b3f2c7e8d3e327e450223a2414ca3fa296b9a2
 

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -104,6 +104,10 @@ export default function App() {
             contextMenuItems={contextMenuItems}
             selectionColor={Platform.OS === 'ios' ? '#5A52FA' : '#DCDDFE'}
             selectionHandleColor="#5A52FA"
+            selectionMenuConfig={{
+              copyAsMarkdown: true,
+              copyImageUrl: true,
+            }}
           />
         </ScrollView>
       )}

--- a/apps/macos-example/src/App.tsx
+++ b/apps/macos-example/src/App.tsx
@@ -84,6 +84,10 @@ export default function App() {
               markdownStyle={markdownStyle}
               contextMenuItems={contextMenuItems}
               selectionColor="#DCDDFE"
+              selectionMenuConfig={{
+                copyAsMarkdown: true,
+                copyImageUrl: true,
+              }}
             />
           </ScrollView>
           {lastLink != null && (

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -285,6 +285,37 @@ interface ContextMenuItem {
 />
 ```
 
+### `selectionMenuConfig`
+
+Controls built-in actions added to the native text selection menu. Custom app-provided actions are controlled separately with `contextMenuItems`.
+
+| Type                 | Default Value                                  | Platform |
+| -------------------- | ---------------------------------------------- | -------- |
+| `SelectionMenuConfig` | `{ copyAsMarkdown: true, copyImageUrl: true }` | iOS, Android, macOS |
+
+**`SelectionMenuConfig` shape:**
+
+```ts
+interface SelectionMenuConfig {
+  /** Shows the built-in "Copy as Markdown" action for text selections. */
+  copyAsMarkdown?: boolean;
+  /** Shows the built-in "Copy Image URL" action when selected content contains images. */
+  copyImageUrl?: boolean;
+}
+```
+
+**Example:**
+
+```tsx
+<EnrichedMarkdownText
+  markdown={content}
+  selectionMenuConfig={{
+    copyAsMarkdown: false,
+    copyImageUrl: false,
+  }}
+/>
+```
+
 > **Note:** When using `flavor="github"`, `selection.start` and `selection.end` are relative to the text segment the selection is in, not the full markdown string. With `flavor="commonmark"` (default) they are always absolute within the full rendered text.
 
 ---

--- a/docs/COPY_OPTIONS.md
+++ b/docs/COPY_OPTIONS.md
@@ -29,3 +29,17 @@ A dedicated **Copy as Markdown** option is available in the context menu on both
 ## Copy Image URL
 
 When selecting text that contains images, a **Copy Image URL** option appears to copy the image's source URL. On Android, if multiple images are selected, all URLs are copied (one per line).
+
+## Controlling Built-in Menu Items
+
+Use `selectionMenuConfig` to hide built-in selection menu actions while keeping the native menu and any `contextMenuItems` intact:
+
+```tsx
+<EnrichedMarkdownText
+  markdown={content}
+  selectionMenuConfig={{
+    copyAsMarkdown: false,
+    copyImageUrl: false,
+  }}
+/>
+```

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -40,6 +40,7 @@ The web implementation also exports `WebMarkdownTextProps` which extends `Enrich
 | `streamingAnimation` | Native-only tail fade-in animation. Not yet implemented on web. |
 | `streamingConfig` | Native-only streaming table configuration. Not yet implemented on web. |
 | `contextMenuItems` | Not supported — browsers don't allow extending the native context menu. |
+| `selectionMenuConfig` | Not supported — native-only built-in selection menu actions. |
 | `selectionHandleColor` | Android-only — desktop browsers don't render selection handles. |
 
 ## Not supported on web

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -92,6 +92,7 @@ static char kENRMSegmentFadeAnimatorKey;
 
   NSArray<NSString *> *_contextMenuItemTexts;
   NSArray<NSString *> *_contextMenuItemIcons;
+  ENRMSelectionMenuConfig _selectionMenuConfig;
 
   ENRMSpoilerOverlay _spoilerOverlay;
 }
@@ -124,6 +125,7 @@ static char kENRMSegmentFadeAnimatorKey;
     _enableLinkPreview = YES;
     _streamingAnimation = NO;
     _tableStreamingMode = ENRMTableStreamingModeHidden;
+    _selectionMenuConfig = (ENRMSelectionMenuConfig){.copyAsMarkdown = YES, .copyImageURL = YES};
 
     _fontScaleObserver = [[FontScaleObserver alloc] init];
     __weak EnrichedMarkdown *weakSelf = self;
@@ -517,7 +519,7 @@ static char kENRMSegmentFadeAnimatorKey;
           }
         });
     return buildEditMenuForSelection(textView.textStorage, textView.selectedRange, segmentMarkdown, strongSelf->_config,
-                                     @[ baseMenu ], customItems);
+                                     @[ baseMenu ], customItems, strongSelf -> _selectionMenuConfig);
   }];
 #endif
 
@@ -721,6 +723,11 @@ static char kENRMSegmentFadeAnimatorKey;
     _contextMenuItemIcons = ENRMContextMenuIconsFromItems(newViewProps.contextMenuItems);
   }
 
+  _selectionMenuConfig = (ENRMSelectionMenuConfig){
+      .copyAsMarkdown = newViewProps.selectionMenuConfig.copyAsMarkdown,
+      .copyImageURL = newViewProps.selectionMenuConfig.copyImageUrl,
+  };
+
   if (newViewProps.spoilerOverlay != oldViewProps.spoilerOverlay) {
     NSString *modeStr = [[NSString alloc] initWithUTF8String:newViewProps.spoilerOverlay.c_str()];
     _spoilerOverlay = ENRMSpoilerOverlayFromString(modeStr);
@@ -913,7 +920,7 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
 
   NSString *segmentMarkdown = extractMarkdownFromAttributedString(textView.attributedText, range);
   return buildEditMenuForSelection(textView.attributedText, range, segmentMarkdown, _config, suggestedActions,
-                                   customActions);
+                                   customActions, _selectionMenuConfig);
 }
 
 - (BOOL)textView:(UITextView *)textView

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -81,6 +81,7 @@ using namespace facebook::react;
 
   NSArray<NSString *> *_contextMenuItemTexts;
   NSArray<NSString *> *_contextMenuItemIcons;
+  ENRMSelectionMenuConfig _selectionMenuConfig;
 
   ENRMSpoilerOverlayManager *_spoilerManager;
 }
@@ -145,6 +146,7 @@ using namespace facebook::react;
     _allowTrailingMargin = NO;
     _enableLinkPreview = YES;
     _forceHeightUpdateOnNextRender = NO;
+    _selectionMenuConfig = (ENRMSelectionMenuConfig){.copyAsMarkdown = YES, .copyImageURL = YES};
 
     _fontScaleObserver = [[FontScaleObserver alloc] init];
     __weak EnrichedMarkdownText *weakSelf = self;
@@ -204,7 +206,8 @@ using namespace facebook::react;
           }
         });
     return buildEditMenuForSelection(textView.textStorage, textView.selectedRange, strongSelf->_cachedMarkdown,
-                                     strongSelf->_config, @[ baseMenu ], customItems);
+                                     strongSelf->_config, @[ baseMenu ], customItems,
+                                     strongSelf -> _selectionMenuConfig);
   };
 #endif
 
@@ -474,6 +477,11 @@ using namespace facebook::react;
     _contextMenuItemIcons = ENRMContextMenuIconsFromItems(newViewProps.contextMenuItems);
   }
 
+  _selectionMenuConfig = (ENRMSelectionMenuConfig){
+      .copyAsMarkdown = newViewProps.selectionMenuConfig.copyAsMarkdown,
+      .copyImageURL = newViewProps.selectionMenuConfig.copyImageUrl,
+  };
+
   if (newViewProps.streamingAnimation != oldViewProps.streamingAnimation) {
     _streamingAnimation = newViewProps.streamingAnimation;
     if (_streamingAnimation) {
@@ -621,7 +629,7 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownTextCls(void)
       ENRMBuildContextMenuActions(_contextMenuItemTexts, _contextMenuItemIcons, textView, range, handler);
 
   return buildEditMenuForSelection(textView.attributedText, range, _cachedMarkdown, _config, suggestedActions,
-                                   customActions);
+                                   customActions, _selectionMenuConfig);
 }
 #endif
 

--- a/ios/utils/EditMenuUtils+macOS.m
+++ b/ios/utils/EditMenuUtils+macOS.m
@@ -9,7 +9,8 @@
 
 NSMenu *_Nullable buildEditMenuForSelection(NSAttributedString *attributedText, NSRange range,
                                             NSString *_Nullable cachedMarkdown, StyleConfig *styleConfig,
-                                            NSArray *suggestedActions, NSArray<NSMenuItem *> *_Nullable customItems)
+                                            NSArray *suggestedActions, NSArray<NSMenuItem *> *_Nullable customItems,
+                                            ENRMSelectionMenuConfig selectionMenuConfig)
 {
   NSMenu *menu = ([suggestedActions.firstObject isKindOfClass:[NSMenu class]]) ? (NSMenu *)suggestedActions.firstObject
                                                                                : [[NSMenu alloc] initWithTitle:@""];
@@ -37,11 +38,11 @@ NSMenu *_Nullable buildEditMenuForSelection(NSAttributedString *attributedText, 
     [menu addItem:enhancedCopy];
   }
 
-  if (markdown.length > 0) {
+  if (selectionMenuConfig.copyAsMarkdown && markdown.length > 0) {
     [menu addItem:ENRMCreateMenuItem(@"Copy as Markdown", ^{ copyStringToPasteboard(markdown); })];
   }
 
-  if (imageURLs.count > 0) {
+  if (selectionMenuConfig.copyImageURL && imageURLs.count > 0) {
     NSString *title = (imageURLs.count == 1)
                           ? @"Copy Image URL"
                           : [NSString stringWithFormat:@"Copy %lu Image URLs", (unsigned long)imageURLs.count];

--- a/ios/utils/EditMenuUtils.h
+++ b/ios/utils/EditMenuUtils.h
@@ -6,6 +6,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef struct {
+  BOOL copyAsMarkdown;
+  BOOL copyImageURL;
+} ENRMSelectionMenuConfig;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -14,11 +19,13 @@ extern "C" {
 // TODO: Remove API_AVAILABLE(ios(16.0)) guard when the minimum iOS deployment target in RN is bumped to 16.
 UIMenu *buildEditMenuForSelection(NSAttributedString *attributedText, NSRange range, NSString *_Nullable cachedMarkdown,
                                   StyleConfig *styleConfig, NSArray<UIMenuElement *> *suggestedActions,
-                                  NSArray<UIAction *> *_Nullable customActions) API_AVAILABLE(ios(16.0));
+                                  NSArray<UIAction *> *_Nullable customActions,
+                                  ENRMSelectionMenuConfig selectionMenuConfig) API_AVAILABLE(ios(16.0));
 #else
 NSMenu *_Nullable buildEditMenuForSelection(NSAttributedString *attributedText, NSRange range,
                                             NSString *_Nullable cachedMarkdown, StyleConfig *styleConfig,
-                                            NSArray *suggestedActions, NSArray<NSMenuItem *> *_Nullable customItems);
+                                            NSArray *suggestedActions, NSArray<NSMenuItem *> *_Nullable customItems,
+                                            ENRMSelectionMenuConfig selectionMenuConfig);
 #endif
 
 #ifdef __cplusplus

--- a/ios/utils/EditMenuUtils.m
+++ b/ios/utils/EditMenuUtils.m
@@ -73,15 +73,16 @@ static void insertOptionalAction(NSMutableArray<UIMenuElement *> *array, UIActio
 // TODO: Remove API_AVAILABLE(ios(16.0)) guard when the minimum iOS deployment target in RN is bumped to 16.
 UIMenu *buildEditMenuForSelection(NSAttributedString *attributedText, NSRange range, NSString *_Nullable cachedMarkdown,
                                   StyleConfig *styleConfig, NSArray<UIMenuElement *> *suggestedActions,
-                                  NSArray<UIAction *> *_Nullable customActions) API_AVAILABLE(ios(16.0))
+                                  NSArray<UIAction *> *_Nullable customActions,
+                                  ENRMSelectionMenuConfig selectionMenuConfig) API_AVAILABLE(ios(16.0))
 {
   NSAttributedString *selectedText = [attributedText attributedSubstringFromRange:range];
   NSString *markdown = markdownForRange(attributedText, range, cachedMarkdown);
   NSArray<NSString *> *imageURLs = imageURLsInRange(attributedText, range);
 
   UIAction *copyAction = createCopyAction(selectedText, markdown, styleConfig);
-  UIAction *copyMarkdownAction = createCopyMarkdownAction(markdown);
-  UIAction *copyImageURLAction = createCopyImageURLAction(imageURLs);
+  UIAction *copyMarkdownAction = selectionMenuConfig.copyAsMarkdown ? createCopyMarkdownAction(markdown) : nil;
+  UIAction *copyImageURLAction = selectionMenuConfig.copyImageURL ? createCopyImageURLAction(imageURLs) : nil;
 
   NSMutableArray<UIMenuElement *> *result = [NSMutableArray array];
   BOOL foundStandardEditMenu = NO;

--- a/src/EnrichedMarkdownNativeComponent.ts
+++ b/src/EnrichedMarkdownNativeComponent.ts
@@ -199,6 +199,11 @@ export interface ContextMenuItemConfig {
   icon?: string;
 }
 
+export interface SelectionMenuConfig {
+  copyAsMarkdown: boolean;
+  copyImageUrl: boolean;
+}
+
 export interface OnContextMenuItemPressEvent {
   itemText: string;
   selectedText: string;
@@ -342,6 +347,10 @@ export interface NativeProps extends ViewProps {
    * Custom items to show in the text selection context menu.
    */
   contextMenuItems?: ReadonlyArray<Readonly<ContextMenuItemConfig>>;
+  /**
+   * Built-in items to show in the text selection context menu.
+   */
+  selectionMenuConfig: Readonly<SelectionMenuConfig>;
   /**
    * Fired when a custom context menu item is pressed.
    * Receives the item label, the currently selected text, and the selection range.

--- a/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/src/EnrichedMarkdownTextNativeComponent.ts
@@ -199,6 +199,11 @@ export interface ContextMenuItemConfig {
   icon?: string;
 }
 
+export interface SelectionMenuConfig {
+  copyAsMarkdown: boolean;
+  copyImageUrl: boolean;
+}
+
 export interface OnContextMenuItemPressEvent {
   itemText: string;
   selectedText: string;
@@ -341,6 +346,10 @@ export interface NativeProps extends ViewProps {
    * Custom items to show in the text selection context menu.
    */
   contextMenuItems?: ReadonlyArray<Readonly<ContextMenuItemConfig>>;
+  /**
+   * Built-in items to show in the text selection context menu.
+   */
+  selectionMenuConfig: Readonly<SelectionMenuConfig>;
   /**
    * Fired when a custom context menu item is pressed.
    * Receives the item label, the currently selected text, and the selection range.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ export type {
   MarkdownStyle,
   Md4cFlags,
   ContextMenuItem as TextContextMenuItem,
+  SelectionMenuConfig as TextSelectionMenuConfig,
 } from './native/EnrichedMarkdownText';
 export type {
   LinkPressEvent,

--- a/src/native/EnrichedMarkdownText.tsx
+++ b/src/native/EnrichedMarkdownText.tsx
@@ -9,6 +9,7 @@ import type {
   EnrichedMarkdownTextProps,
   StreamingConfig,
   ContextMenuItem,
+  SelectionMenuConfig,
 } from '../types/MarkdownTextProps';
 import type {
   LinkPressEvent,
@@ -18,7 +19,12 @@ import type {
 } from '../types/events';
 
 export type { MarkdownStyle, Md4cFlags };
-export type { EnrichedMarkdownTextProps, StreamingConfig, ContextMenuItem };
+export type {
+  EnrichedMarkdownTextProps,
+  StreamingConfig,
+  ContextMenuItem,
+  SelectionMenuConfig,
+};
 export type { LinkPressEvent, LinkLongPressEvent, TaskListItemPressEvent };
 
 const defaultMd4cFlags: Md4cFlags = {
@@ -44,6 +50,7 @@ export const EnrichedMarkdownText = ({
   streamingConfig,
   spoilerOverlay = 'particles',
   contextMenuItems,
+  selectionMenuConfig,
   selectionColor,
   selectionHandleColor,
   ...rest
@@ -126,6 +133,13 @@ export const EnrichedMarkdownText = ({
 
   const tableMode = streamingConfig?.tableMode ?? 'hidden';
   const normalizedStreamingConfig = useMemo(() => ({ tableMode }), [tableMode]);
+  const normalizedSelectionMenuConfig = useMemo(
+    () => ({
+      copyAsMarkdown: selectionMenuConfig?.copyAsMarkdown ?? true,
+      copyImageUrl: selectionMenuConfig?.copyImageUrl ?? true,
+    }),
+    [selectionMenuConfig]
+  );
 
   const sharedProps = {
     markdown,
@@ -144,6 +158,7 @@ export const EnrichedMarkdownText = ({
     spoilerOverlay,
     style: containerStyle,
     contextMenuItems: nativeContextMenuItems,
+    selectionMenuConfig: normalizedSelectionMenuConfig,
     onContextMenuItemPress: handleContextMenuItemPress,
     selectionColor,
     selectionHandleColor,

--- a/src/types/MarkdownTextProps.ts
+++ b/src/types/MarkdownTextProps.ts
@@ -20,6 +20,19 @@ export interface ContextMenuItem {
   visible?: boolean;
 }
 
+export interface SelectionMenuConfig {
+  /**
+   * Shows the built-in "Copy as Markdown" action for text selections.
+   * @default true
+   */
+  copyAsMarkdown?: boolean;
+  /**
+   * Shows the built-in "Copy Image URL" action when selected content contains images.
+   * @default true
+   */
+  copyImageUrl?: boolean;
+}
+
 export interface StreamingConfig {
   /**
    * Controls how incomplete tables are handled during streaming.
@@ -186,6 +199,13 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    * @platform ios, android
    */
   contextMenuItems?: ContextMenuItem[];
+  /**
+   * Controls built-in items added to the native text selection menu.
+   * Custom app-provided actions are controlled separately with `contextMenuItems`.
+   * @default { copyAsMarkdown: true, copyImageUrl: true }
+   * @platform ios, android, macos
+   */
+  selectionMenuConfig?: SelectionMenuConfig;
   /**
    * Sets the text direction on the root container.
    * Useful for RTL languages — CSS logical properties in the renderers


### PR DESCRIPTION
### What/Why?
Fixes: #272 

Adds a selectionMenuConfig prop to control the visibility of built-in text selection menu actions ("Copy as Markdown" and "Copy Image URL"). Previously these actions were always shown; now consumers can opt out of either or both while keeping the native selection menu and any custom contextMenuItems intact.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes

