### PR TITLE
fix(ios): pin measured width to maxWidth for multiline content

### DIFF
--- a/ios/utils/ENRMTextViewSetup.h
+++ b/ios/utils/ENRMTextViewSetup.h
@@ -43,6 +43,22 @@ static inline CGSize ENRMMeasureMarkdownText(ENRMPlatformTextView *textView, CGF
   CGFloat measuredWidth = layout.usedRect.size.width;
   CGFloat measuredHeight = layout.usedRect.size.height;
 
+  // Detect multiline content by checking if the layout produced more than one
+  // line fragment. When text wraps, returning the tight usedRect width lets
+  // flexShrink narrow the view below maxWidth, causing re-wrap at the narrower
+  // width and a height mismatch. Pin to maxWidth for multiline content so Yoga
+  // assigns the width the text was actually measured at. Single-line content
+  // keeps its tight width for shrink-to-fit behavior.
+  NSLayoutManager *layoutManager = textView.layoutManager;
+  NSUInteger glyphCount = [layoutManager numberOfGlyphs];
+  if (glyphCount > 0) {
+    NSRange firstLineRange;
+    [layoutManager lineFragmentRectForGlyphAtIndex:0 effectiveRange:&firstLineRange];
+    if (NSMaxRange(firstLineRange) < glyphCount) {
+      measuredWidth = maxWidth;
+    }
+  }
+
   if (!CGRectIsEmpty(layout.extraLineFragmentRect)) {
     measuredHeight -= layout.extraLineFragmentRect.size.height;
   }


### PR DESCRIPTION
### What/Why?
Multiline EnrichedMarkdownText content gets clipped when placed in a flexShrink row layout (e.g. chat bubbles). The measurement function returns the tight content width (usedRect), which is narrower than the maxWidth used for layout. Yoga then shrinks the component to that width, causing the text to re-wrap into more lines than the measured height accounts for.

Fix: after the layout pass, check if NSLayoutManager produced multiple line fragments. If so, return maxWidth instead of the tight width, keeping height and width in sync. Single-line content still shrinks to fit. Zero performance cost — reads already-computed layout data.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

