### PR TITLE
fix(android): prevent duplicate-URL images from sharing a single ImageSpan

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -304,10 +304,6 @@ class EnrichedMarkdownText
       checkboxTouchHelper.onCheckboxTap = callback
     }
 
-    fun clearActiveImageSpans() {
-      renderer.clearActiveImageSpans()
-    }
-
     override fun onDetachedFromWindow() {
       stopSpoilerAnimations()
       super.onDetachedFromWindow()

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -45,7 +45,6 @@ class EnrichedMarkdownTextManager :
     super.onDropViewInstance(view)
     MeasurementStore.clearFontScalingSettings(view.id)
     view.layoutManager.releaseMeasurementStore()
-    view.clearActiveImageSpans()
   }
 
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> = markdownEventTypeConstants()

--- a/android/src/main/java/com/swmansion/enriched/markdown/renderer/ImageRenderer.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/renderer/ImageRenderer.kt
@@ -25,7 +25,7 @@ class ImageRenderer : NodeRenderer {
     val altText = extractTextFromNode(node)
 
     val span =
-      factory.getOrCreateImageSpan(
+      factory.createImageSpan(
         imageUrl = imageUrl,
         isInline = isInline,
         altText = altText,

--- a/android/src/main/java/com/swmansion/enriched/markdown/renderer/NodeRenderer.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/renderer/NodeRenderer.kt
@@ -6,7 +6,6 @@ import com.swmansion.enriched.markdown.parser.MarkdownASTNode
 import com.swmansion.enriched.markdown.spans.ImageSpan
 import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.FeatureFlags
-import java.lang.ref.WeakReference
 
 interface NodeRenderer {
   fun render(
@@ -31,37 +30,22 @@ class RendererFactory(
 
   val styleCache = SpanStyleCache(config.style)
 
-  private val activeImageSpans = HashMap<String, WeakReference<ImageSpan>>()
-
   fun resetForNewRender() {
     blockStyleContext.resetForNewRender()
   }
 
-  fun getOrCreateImageSpan(
+  fun createImageSpan(
     imageUrl: String,
     isInline: Boolean,
     altText: String,
-  ): ImageSpan {
-    val key = "${imageUrl}_$isInline"
-    val existing = activeImageSpans[key]?.get()
-    if (existing != null && existing.imageUrl == imageUrl) {
-      return existing
-    }
-    val span =
-      ImageSpan(
-        context = context,
-        imageUrl = imageUrl,
-        styleConfig = config.style,
-        isInline = isInline,
-        altText = altText,
-      )
-    activeImageSpans[key] = WeakReference(span)
-    return span
-  }
-
-  fun clearActiveImageSpans() {
-    activeImageSpans.clear()
-  }
+  ): ImageSpan =
+    ImageSpan(
+      context = context,
+      imageUrl = imageUrl,
+      styleConfig = config.style,
+      isInline = isInline,
+      altText = altText,
+    )
 
   private val textRenderer = TextRenderer()
   private val lineBreakRenderer = LineBreakRenderer()

--- a/android/src/main/java/com/swmansion/enriched/markdown/renderer/Renderer.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/renderer/Renderer.kt
@@ -106,8 +106,4 @@ class Renderer {
    * Provides the EnrichedMarkdownText with the exact list of spans that need registration.
    */
   fun getCollectedImageSpans(): List<ImageSpan> = collectedImageSpans
-
-  fun clearActiveImageSpans() {
-    cachedFactory?.clearActiveImageSpans()
-  }
 }


### PR DESCRIPTION
### What/Why?
Fixes: #294 

When two or more markdown images share the same URL, only the last one renders — earlier images show a raw ￼ (U+FFFC) replacement character. This happens because RendererFactory.getOrCreateImageSpan cached ImageSpan objects by URL, so duplicate URLs returned the same span instance. Android's SpannableStringBuilder.setSpan moves an already-attached span instead of duplicating it, leaving previous anchor characters without a span.

The fix removes the activeImageSpans cache entirely and always creates a fresh ImageSpan per image node. Bitmap performance is unaffected — ImageCache already handles download/decode caching at the URL level. Also adds an example screen to verify the fix with duplicate, triple, and mixed-URL image layouts.

### Testing
<!-- How to test changed code? What testing has been done? -->

#### Screenshots

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/57037796-b11b-4bcd-bb65-6f511fda0a64" width=300 /> | <video src="https://github.com/user-attachments/assets/de5a1c97-f4b4-4362-a871-1352cf68c22b" width=300 /> |

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

