### PR TITLE
fix(web): use span instead of div for display math to prevent invalid p>div nesting

### DIFF
--- a/src/web/renderers/BlockRenderers.tsx
+++ b/src/web/renderers/BlockRenderers.tsx
@@ -75,7 +75,6 @@ function LatexMathDisplayRenderer({
       katex={capabilities.katex}
       displayMode
       style={styles.mathDisplay}
-      fallbackTag="pre"
     />
   );
 }

--- a/src/web/renderers/InlineRenderers.tsx
+++ b/src/web/renderers/InlineRenderers.tsx
@@ -88,7 +88,6 @@ function LatexMathInlineRenderer({
       katex={capabilities.katex}
       displayMode={false}
       style={styles.mathInline}
-      fallbackTag="code"
     />
   );
 }

--- a/src/web/renderers/KaTeXRenderer.tsx
+++ b/src/web/renderers/KaTeXRenderer.tsx
@@ -6,7 +6,6 @@ interface KaTeXRendererProps {
   katex: KaTeXInstance | null;
   displayMode: boolean;
   style: CSSProperties;
-  fallbackTag: 'code' | 'pre';
 }
 
 export function KaTeXRenderer({
@@ -14,7 +13,6 @@ export function KaTeXRenderer({
   katex,
   displayMode,
   style,
-  fallbackTag: FallbackTag,
 }: KaTeXRendererProps) {
   const delimiter = displayMode ? '$$' : '$';
 
@@ -28,21 +26,23 @@ export function KaTeXRenderer({
     });
   }, [katex, content, displayMode]);
 
+  const displayStyle = displayMode
+    ? { ...style, display: 'block' as const, whiteSpace: 'pre-wrap' as const }
+    : style;
+
   if (!html) {
     return (
-      <FallbackTag role="math" aria-label={content} style={style}>
+      <span role="math" aria-label={content} style={displayStyle}>
         {`${delimiter}${content}${delimiter}`}
-      </FallbackTag>
+      </span>
     );
   }
 
-  const WrapperTag = displayMode ? 'div' : 'span';
-
   return (
-    <WrapperTag
+    <span
       role="math"
       aria-label={content}
-      style={style}
+      style={displayStyle}
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );


### PR DESCRIPTION
### What/Why?
Fixes: #295 

On web, display math `($$...$$)` was rendered inside a `<div>`, which is invalid `HTML` when nested inside a `<p>` from `ParagraphRenderer`. This triggered a `<p>` cannot contain a nested `<div>` console error. The fix replaces the `<div>` (and the `<pre>` fallback) with a `<span style="display:block">`, which renders identically but is valid inside any `HTML` context. Also removes the now-unused fallbackTag prop from `KaTeXRenderer`.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

