### PR TITLE
fix(android): skip LineHeightSpan on block image lines to prevent clipping and overlap

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/renderer/ListRenderer.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/renderer/ListRenderer.kt
@@ -4,8 +4,8 @@ import android.text.SpannableStringBuilder
 import com.swmansion.enriched.markdown.parser.MarkdownASTNode
 import com.swmansion.enriched.markdown.spans.MarginBottomSpan
 import com.swmansion.enriched.markdown.utils.text.span.SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE
+import com.swmansion.enriched.markdown.utils.text.span.applyLineHeightSkippingImages
 import com.swmansion.enriched.markdown.utils.text.span.applyMarginTop
-import com.swmansion.enriched.markdown.utils.text.span.createLineHeightSpan
 
 class ListRenderer(
   private val config: RendererConfig,
@@ -55,12 +55,7 @@ class ListRenderer(
     depth: Int,
     style: com.swmansion.enriched.markdown.styles.BaseBlockStyle,
   ) {
-    builder.setSpan(
-      createLineHeightSpan(style.lineHeight),
-      start,
-      builder.length,
-      SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
-    )
+    applyLineHeightSkippingImages(builder, start, builder.length, style.lineHeight)
 
     // External bottom margin is only handled by the root-level list
     if (depth == 0) {

--- a/android/src/main/java/com/swmansion/enriched/markdown/renderer/ParagraphRenderer.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/renderer/ParagraphRenderer.kt
@@ -6,9 +6,9 @@ import com.swmansion.enriched.markdown.parser.MarkdownASTNode
 import com.swmansion.enriched.markdown.styles.ParagraphStyle
 import com.swmansion.enriched.markdown.utils.text.extensions.containsBlockImage
 import com.swmansion.enriched.markdown.utils.text.span.SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE
+import com.swmansion.enriched.markdown.utils.text.span.applyLineHeightSkippingImages
 import com.swmansion.enriched.markdown.utils.text.span.applyMarginBottom
 import com.swmansion.enriched.markdown.utils.text.span.applyMarginTop
-import com.swmansion.enriched.markdown.utils.text.span.createLineHeightSpan
 
 class ParagraphRenderer(
   private val config: RendererConfig,
@@ -51,15 +51,7 @@ class ParagraphRenderer(
   ) {
     val end = length
 
-    // LineHeightSpan is avoided for block images to prevent clipping/overlapping
-    if (!node.containsBlockImage()) {
-      setSpan(
-        createLineHeightSpan(style.lineHeight),
-        start,
-        end,
-        SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
-      )
-    }
+    applyLineHeightSkippingImages(this, start, end, style.lineHeight)
 
     // Only apply AlignmentSpan for non-default alignments (Center/Right)
     if (style.textAlign.needsAlignmentSpan) {

--- a/android/src/main/java/com/swmansion/enriched/markdown/spans/ImageSpan.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/spans/ImageSpan.kt
@@ -9,6 +9,8 @@ import android.graphics.Path
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.text.Spannable
+import android.text.Spanned
+import android.text.style.LeadingMarginSpan
 import android.util.Log
 import android.widget.TextView
 import androidx.core.graphics.createBitmap
@@ -138,7 +140,20 @@ class ImageSpan(
     }
   }
 
-  private fun getAvailableWidth(view: TextView): Int = view.layout?.width ?: view.width
+  private fun getAvailableWidth(view: TextView): Int {
+    val baseWidth = (view.layout?.width ?: view.width).coerceAtLeast(0)
+    val text = view.text as? Spanned ?: return baseWidth
+    val start = text.getSpanStart(this).takeIf { it >= 0 } ?: return baseWidth
+    val end = text.getSpanEnd(this).coerceAtLeast(start)
+    // Subtract leading margins (list bullet/indent, blockquote bar) that consume
+    // horizontal space on the image's line. first=true is correct because a block
+    // image sits on its own line — the "first line" from the layout's perspective.
+    val totalMargin =
+      text
+        .getSpans(start, end, LeadingMarginSpan::class.java)
+        .sumOf { it.getLeadingMargin(true) }
+    return (baseWidth - totalMargin).coerceAtLeast(0)
+  }
 
   override fun getDrawable(): Drawable {
     val drawable = loadedDrawable ?: transparentDrawable

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/span/BlockSpacing.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/span/BlockSpacing.kt
@@ -1,12 +1,55 @@
 package com.swmansion.enriched.markdown.utils.text.span
 
 import android.text.SpannableStringBuilder
+import com.swmansion.enriched.markdown.spans.ImageSpan
 import com.swmansion.enriched.markdown.spans.LineHeightSpan
 import com.swmansion.enriched.markdown.spans.MarginBottomSpan
 import com.swmansion.enriched.markdown.utils.text.span.SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE
 import android.text.style.LineHeightSpan as AndroidLineHeightSpan
 
 fun createLineHeightSpan(lineHeight: Float): AndroidLineHeightSpan = LineHeightSpan(lineHeight)
+
+/**
+ * Applies [LineHeightSpan] to [start]..[end] but skips ranges occupied by
+ * block [ImageSpan]s (and their trailing '\n'). Without this, the fixed line
+ * height would re-clamp the metrics that [ImageSpan.chooseHeight] expanded,
+ * causing the image to overflow downward and overlap subsequent content.
+ */
+fun applyLineHeightSkippingImages(
+  builder: SpannableStringBuilder,
+  start: Int,
+  end: Int,
+  lineHeight: Float,
+) {
+  val blockImageRanges =
+    builder
+      .getSpans(start, end, ImageSpan::class.java)
+      .filter { !it.isInline }
+      .map { builder.getSpanStart(it) to builder.getSpanEnd(it) }
+      .sortedBy { it.first }
+
+  var pos = start
+  for ((imgStart, imgEnd) in blockImageRanges) {
+    if (pos < imgStart) {
+      builder.setSpan(
+        createLineHeightSpan(lineHeight),
+        pos,
+        imgStart,
+        SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
+      )
+    }
+    val skipEnd = if (imgEnd < end && builder[imgEnd] == '\n') imgEnd + 1 else imgEnd
+    pos = maxOf(pos, skipEnd)
+  }
+  if (pos < end) {
+    builder.setSpan(
+      createLineHeightSpan(lineHeight),
+      pos,
+      end,
+      SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
+    )
+  }
+}
 
 fun applyMarginTop(
   builder: SpannableStringBuilder,


### PR DESCRIPTION
### What/Why?
Fixes: #293 

Block images inside list items and mixed paragraphs on Android get clipped or overlap subsequent text. The root cause is LineHeightSpan re-clamping the line metrics that ImageSpan.chooseHeight() expanded for the image.

Fix: apply LineHeightSpan only to text ranges, skipping block image characters and their trailing newline. Also subtract LeadingMarginSpan indents in ImageSpan.getAvailableWidth() so images inside lists don't overflow the right edge.

### Testing
<!-- How to test changed code? What testing has been done? -->

#### Screenshots

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/6a2aaf68-e676-42e0-8fe0-44690fb078f8" width=300 /> | <video src="https://github.com/user-attachments/assets/b7d63046-cc4c-4990-9cb5-e22189419f93" width=300 /> |

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

