### PR TITLE
fix(ios): reverse dealloc order in ENRMTailFadeInAnimator to prevent use-after-free

### DIFF
--- a/ios/utils/ENRMTailFadeInAnimator.m
+++ b/ios/utils/ENRMTailFadeInAnimator.m
@@ -33,10 +33,11 @@ typedef struct {
 
 - (void)dealloc
 {
-  [self cleanupEntries];
 #if !TARGET_OS_OSX
   [_displayLink invalidate];
+  _displayLink = nil;
 #endif
+  [self cleanupEntries];
 }
 
 - (void)animateFrom:(NSUInteger)tailStart to:(NSUInteger)tailEnd


### PR DESCRIPTION
### What/Why?
dealloc was calling cleanupEntries before invalidating the CADisplayLink. If the display link fired between
those two calls — possible when something triggers a runloop iteration on the main thread — step: would   
access the already-freed _colorEntries C array, causing a use-after-free crash.                          
                                                                                                             
Fixed by reversing the order: the display link is invalidated and nilled first, guaranteeing no further    
step: callbacks can fire before the entries array is freed.  

### Testing
<!-- How to test changed code? What testing has been done? -->


<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

