### PR TITLE
fix(ios): assert on regex compilation failure in ENRMAutoLinkDetector

### DIFF
--- a/ios/input/ENRMAutoLinkDetector.mm
+++ b/ios/input/ENRMAutoLinkDetector.mm
@@ -195,13 +195,15 @@ static NSAttributedStringKey const ENRMAutomaticLinkAttributeName = @"ENRMAutoma
   static NSRegularExpression *regex;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
+    NSError *error = nil;
     regex = [NSRegularExpression
         regularExpressionWithPattern:
             @"(?:https?://[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,6}\\b[-a-zA-Z0-9@:%_\\+.~#?&//=]*"
             @"|www\\.[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,6}\\b[-a-zA-Z0-9@:%_\\+.~#?&//=]*"
             @"|[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,6}\\b[-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
                              options:NSRegularExpressionCaseInsensitive
-                               error:nil];
+                               error:&error];
+    NSCAssert(regex != nil, @"ENRMAutoLinkDetector: failed to compile default regex: %@", error);
   });
   return regex;
 }


### PR DESCRIPTION
### What/Why?
defaultRegex was passing nil for the error parameter, so a broken regex pattern would silently produce nil 
  — disabling auto-linking entirely with no diagnostic. Added NSCAssert so any compilation failure surfaces  
  immediately in debug builds.   

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

