### PR TITLE
refactor(ios): introduce BaseRenderer base class to eliminate duplicated ivar blocks and init

### DIFF
--- a/ios/renderer/BaseRenderer.h
+++ b/ios/renderer/BaseRenderer.h
@@ -1,0 +1,18 @@
+#pragma once
+#import "NodeRenderer.h"
+
+@class RendererFactory;
+@class StyleConfig;
+
+/// Shared base for all node renderers — provides `_rendererFactory` and `_config`
+/// as protected ivars and the common designated initializer.
+/// Concrete subclasses must implement `renderNode:into:context:`.
+@interface BaseRenderer : NSObject {
+@protected
+  __weak RendererFactory *_rendererFactory;
+  StyleConfig *_config;
+}
+
+- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+
+@end

--- a/ios/renderer/BaseRenderer.m
+++ b/ios/renderer/BaseRenderer.m
@@ -1,0 +1,16 @@
+#import "BaseRenderer.h"
+#import "RendererFactory.h"
+#import "StyleConfig.h"
+
+@implementation BaseRenderer
+
+- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
+{
+  if (self = [super init]) {
+    _rendererFactory = rendererFactory;
+    _config = (StyleConfig *)config;
+  }
+  return self;
+}
+
+@end

--- a/ios/renderer/BlockquoteRenderer.h
+++ b/ios/renderer/BlockquoteRenderer.h
@@ -1,7 +1,6 @@
+#import "BaseRenderer.h"
 #import "MarkdownASTNode.h"
-#import "NodeRenderer.h"
 #import "RenderContext.h"
 
-@interface BlockquoteRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface BlockquoteRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/BlockquoteRenderer.m
+++ b/ios/renderer/BlockquoteRenderer.m
@@ -9,19 +9,7 @@
 static NSString *const kNestedInfoDepthKey = @"depth";
 static NSString *const kNestedInfoRangeKey = @"range";
 
-@implementation BlockquoteRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  if (self = [super init]) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation BlockquoteRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {

--- a/ios/renderer/CodeBlockRenderer.h
+++ b/ios/renderer/CodeBlockRenderer.h
@@ -1,10 +1,9 @@
 #pragma once
-#import "NodeRenderer.h"
+#import "BaseRenderer.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CodeBlockRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface CodeBlockRenderer : BaseRenderer <NodeRenderer>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/renderer/CodeBlockRenderer.m
+++ b/ios/renderer/CodeBlockRenderer.m
@@ -7,19 +7,7 @@
 #import "RendererFactory.h"
 #import "StyleConfig.h"
 
-@implementation CodeBlockRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  if (self = [super init]) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation CodeBlockRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {

--- a/ios/renderer/CodeRenderer.h
+++ b/ios/renderer/CodeRenderer.h
@@ -1,10 +1,9 @@
 #pragma once
-#import "NodeRenderer.h"
+#import "BaseRenderer.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CodeRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface CodeRenderer : BaseRenderer <NodeRenderer>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/renderer/CodeRenderer.m
+++ b/ios/renderer/CodeRenderer.m
@@ -8,20 +8,7 @@
 #import "StyleConfig.h"
 #import <React/RCTFont.h>
 
-@implementation CodeRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  self = [super init];
-  if (self) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation CodeRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {

--- a/ios/renderer/ENRMImageRenderer.h
+++ b/ios/renderer/ENRMImageRenderer.h
@@ -1,12 +1,9 @@
 #pragma once
-#import "NodeRenderer.h"
+#import "BaseRenderer.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ENRMImageRenderer : NSObject <NodeRenderer>
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
-
+@interface ENRMImageRenderer : BaseRenderer <NodeRenderer>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/renderer/ENRMImageRenderer.m
+++ b/ios/renderer/ENRMImageRenderer.m
@@ -8,19 +8,7 @@
 static const unichar kLineBreak = '\n';
 static const unichar kZeroWidthSpace = 0x200B;
 
-@implementation ENRMImageRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  if (self = [super init]) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation ENRMImageRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {

--- a/ios/renderer/ENRMMathInlineRenderer.h
+++ b/ios/renderer/ENRMMathInlineRenderer.h
@@ -1,12 +1,9 @@
 #pragma once
-#import "NodeRenderer.h"
+#import "BaseRenderer.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ENRMMathInlineRenderer : NSObject <NodeRenderer>
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
-
+@interface ENRMMathInlineRenderer : BaseRenderer <NodeRenderer>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/renderer/ENRMMathInlineRenderer.m
+++ b/ios/renderer/ENRMMathInlineRenderer.m
@@ -9,19 +9,7 @@
 
 #if ENRICHED_MARKDOWN_MATH
 
-@implementation ENRMMathInlineRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  if (self = [super init]) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation ENRMMathInlineRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {

--- a/ios/renderer/ENRMSpoilerRenderer.h
+++ b/ios/renderer/ENRMSpoilerRenderer.h
@@ -1,6 +1,5 @@
 #pragma once
-#import "NodeRenderer.h"
+#import "BaseRenderer.h"
 
-@interface ENRMSpoilerRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface ENRMSpoilerRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/ENRMSpoilerRenderer.m
+++ b/ios/renderer/ENRMSpoilerRenderer.m
@@ -4,17 +4,7 @@
 #import "RenderContext.h"
 #import "RendererFactory.h"
 
-@implementation ENRMSpoilerRenderer {
-  __weak RendererFactory *_rendererFactory;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(__unused id)config
-{
-  if (self = [super init]) {
-    _rendererFactory = rendererFactory;
-  }
-  return self;
-}
+@implementation ENRMSpoilerRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {

--- a/ios/renderer/EmphasisRenderer.h
+++ b/ios/renderer/EmphasisRenderer.h
@@ -1,6 +1,5 @@
 #pragma once
-#import "NodeRenderer.h"
+#import "BaseRenderer.h"
 
-@interface EmphasisRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface EmphasisRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/EmphasisRenderer.m
+++ b/ios/renderer/EmphasisRenderer.m
@@ -6,20 +6,7 @@
 #import "StyleConfig.h"
 #import <React/RCTFont.h>
 
-@implementation EmphasisRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  self = [super init];
-  if (self) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation EmphasisRenderer
 
 #pragma mark - Rendering
 

--- a/ios/renderer/HeadingRenderer.h
+++ b/ios/renderer/HeadingRenderer.h
@@ -1,7 +1,6 @@
+#import "BaseRenderer.h"
 #import "MarkdownASTNode.h"
-#import "NodeRenderer.h"
 #import "RenderContext.h"
 
-@interface HeadingRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface HeadingRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/HeadingRenderer.m
+++ b/ios/renderer/HeadingRenderer.m
@@ -19,19 +19,7 @@ typedef struct {
 static NSString *const kHeadingTypes[] = {nil,          @"heading-1", @"heading-2", @"heading-3",
                                           @"heading-4", @"heading-5", @"heading-6"};
 
-@implementation HeadingRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  if (self = [super init]) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation HeadingRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {

--- a/ios/renderer/LinkRenderer.h
+++ b/ios/renderer/LinkRenderer.h
@@ -1,7 +1,6 @@
+#import "BaseRenderer.h"
 #import "MarkdownASTNode.h"
-#import "NodeRenderer.h"
 #import "RenderContext.h"
 
-@interface LinkRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface LinkRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/LinkRenderer.m
+++ b/ios/renderer/LinkRenderer.m
@@ -5,20 +5,7 @@
 #import "StyleConfig.h"
 #import <React/RCTFont.h>
 
-@implementation LinkRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  self = [super init];
-  if (self) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation LinkRenderer
 
 #pragma mark - Rendering
 

--- a/ios/renderer/ListItemRenderer.h
+++ b/ios/renderer/ListItemRenderer.h
@@ -1,8 +1,4 @@
-#import "NodeRenderer.h"
-
-@class RendererFactory;
-@class StyleConfig;
-@class RenderContext;
+#import "BaseRenderer.h"
 
 extern NSString *const ListDepthAttribute;
 extern NSString *const ListTypeAttribute;
@@ -12,8 +8,5 @@ extern NSString *const TaskItemAttribute;
 extern NSString *const TaskCheckedAttribute;
 extern NSString *const TaskIndexAttribute;
 
-@interface ListItemRenderer : NSObject <NodeRenderer>
-
-- (instancetype)initWithRendererFactory:(RendererFactory *)rendererFactory config:(StyleConfig *)config;
-
+@interface ListItemRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/ListItemRenderer.m
+++ b/ios/renderer/ListItemRenderer.m
@@ -20,19 +20,7 @@ NSString *const TaskIndexAttribute = @"TaskIndex";
                      nestingLevel:(NSInteger)nestingLevel;
 @end
 
-@implementation ListItemRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(RendererFactory *)factory config:(StyleConfig *)config
-{
-  if (self = [super init]) {
-    _rendererFactory = factory;
-    _config = config;
-  }
-  return self;
-}
+@implementation ListItemRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {

--- a/ios/renderer/ParagraphRenderer.h
+++ b/ios/renderer/ParagraphRenderer.h
@@ -1,7 +1,6 @@
+#import "BaseRenderer.h"
 #import "MarkdownASTNode.h"
-#import "NodeRenderer.h"
 #import "RenderContext.h"
 
-@interface ParagraphRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface ParagraphRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/ParagraphRenderer.m
+++ b/ios/renderer/ParagraphRenderer.m
@@ -5,20 +5,7 @@
 #import "RendererFactory.h"
 #import "StyleConfig.h"
 
-@implementation ParagraphRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  self = [super init];
-  if (self) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation ParagraphRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {

--- a/ios/renderer/StrikethroughRenderer.h
+++ b/ios/renderer/StrikethroughRenderer.h
@@ -1,6 +1,5 @@
 #pragma once
-#import "NodeRenderer.h"
+#import "BaseRenderer.h"
 
-@interface StrikethroughRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface StrikethroughRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/StrikethroughRenderer.m
+++ b/ios/renderer/StrikethroughRenderer.m
@@ -4,19 +4,7 @@
 #import "RendererFactory.h"
 #import "StyleConfig.h"
 
-@implementation StrikethroughRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  if (self = [super init]) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation StrikethroughRenderer
 
 #pragma mark - Rendering
 

--- a/ios/renderer/StrongRenderer.h
+++ b/ios/renderer/StrongRenderer.h
@@ -1,6 +1,5 @@
 #pragma once
-#import "NodeRenderer.h"
+#import "BaseRenderer.h"
 
-@interface StrongRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface StrongRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/StrongRenderer.m
+++ b/ios/renderer/StrongRenderer.m
@@ -6,19 +6,7 @@
 #import "StyleConfig.h"
 #import <React/RCTFont.h>
 
-@implementation StrongRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  if (self = [super init]) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation StrongRenderer
 
 #pragma mark - Rendering
 

--- a/ios/renderer/SubscriptRenderer.h
+++ b/ios/renderer/SubscriptRenderer.h
@@ -1,6 +1,5 @@
 #pragma once
-#import "NodeRenderer.h"
+#import "BaseRenderer.h"
 
-@interface SubscriptRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface SubscriptRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/SubscriptRenderer.m
+++ b/ios/renderer/SubscriptRenderer.m
@@ -5,22 +5,7 @@
 #import "RendererFactory.h"
 #import "StyleConfig.h"
 
-@implementation SubscriptRenderer {
-  __weak RendererFactory *_rendererFactory;
-  CGFloat _fontScale;
-  CGFloat _baselineOffsetScale;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  if (self = [super init]) {
-    _rendererFactory = rendererFactory;
-    StyleConfig *styleConfig = (StyleConfig *)config;
-    _fontScale = styleConfig.subscriptFontScale;
-    _baselineOffsetScale = -styleConfig.subscriptBaselineOffsetScale;
-  }
-  return self;
-}
+@implementation SubscriptRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {
@@ -31,7 +16,7 @@
   if (range.length == 0)
     return;
 
-  ENRMApplyBaselineShift(output, range, _fontScale, _baselineOffsetScale);
+  ENRMApplyBaselineShift(output, range, _config.subscriptFontScale, -_config.subscriptBaselineOffsetScale);
 }
 
 @end

--- a/ios/renderer/SuperscriptRenderer.h
+++ b/ios/renderer/SuperscriptRenderer.h
@@ -1,6 +1,5 @@
 #pragma once
-#import "NodeRenderer.h"
+#import "BaseRenderer.h"
 
-@interface SuperscriptRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface SuperscriptRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/SuperscriptRenderer.m
+++ b/ios/renderer/SuperscriptRenderer.m
@@ -5,22 +5,7 @@
 #import "RendererFactory.h"
 #import "StyleConfig.h"
 
-@implementation SuperscriptRenderer {
-  __weak RendererFactory *_rendererFactory;
-  CGFloat _fontScale;
-  CGFloat _baselineOffsetScale;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  if (self = [super init]) {
-    _rendererFactory = rendererFactory;
-    StyleConfig *styleConfig = (StyleConfig *)config;
-    _fontScale = styleConfig.superscriptFontScale;
-    _baselineOffsetScale = styleConfig.superscriptBaselineOffsetScale;
-  }
-  return self;
-}
+@implementation SuperscriptRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {
@@ -31,7 +16,7 @@
   if (range.length == 0)
     return;
 
-  ENRMApplyBaselineShift(output, range, _fontScale, _baselineOffsetScale);
+  ENRMApplyBaselineShift(output, range, _config.superscriptFontScale, _config.superscriptBaselineOffsetScale);
 }
 
 @end

--- a/ios/renderer/ThematicBreakRenderer.h
+++ b/ios/renderer/ThematicBreakRenderer.h
@@ -1,5 +1,4 @@
-#import "NodeRenderer.h"
+#import "BaseRenderer.h"
 
-@interface ThematicBreakRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface ThematicBreakRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/ThematicBreakRenderer.m
+++ b/ios/renderer/ThematicBreakRenderer.m
@@ -5,20 +5,7 @@
 
 #pragma mark - Renderer Implementation
 
-@implementation ThematicBreakRenderer {
-  __weak id _rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  self = [super init];
-  if (self) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation ThematicBreakRenderer
 
 - (void)renderNode:(MarkdownASTNode *)node into:(NSMutableAttributedString *)output context:(RenderContext *)context
 {

--- a/ios/renderer/UnderlineRenderer.h
+++ b/ios/renderer/UnderlineRenderer.h
@@ -1,6 +1,4 @@
-#import "NodeRenderer.h"
-#import <Foundation/Foundation.h>
+#import "BaseRenderer.h"
 
-@interface UnderlineRenderer : NSObject <NodeRenderer>
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config;
+@interface UnderlineRenderer : BaseRenderer <NodeRenderer>
 @end

--- a/ios/renderer/UnderlineRenderer.m
+++ b/ios/renderer/UnderlineRenderer.m
@@ -4,19 +4,7 @@
 #import "RendererFactory.h"
 #import "StyleConfig.h"
 
-@implementation UnderlineRenderer {
-  __weak RendererFactory *_rendererFactory;
-  StyleConfig *_config;
-}
-
-- (instancetype)initWithRendererFactory:(id)rendererFactory config:(id)config
-{
-  if (self = [super init]) {
-    _rendererFactory = rendererFactory;
-    _config = (StyleConfig *)config;
-  }
-  return self;
-}
+@implementation UnderlineRenderer
 
 #pragma mark - Rendering
 


### PR DESCRIPTION
### What/Why?
Introduces BaseRenderer — a thin base class with shared _rendererFactory and _config ivars and a single    
canonical initWithRendererFactory:config: implementation — and migrates all 17 standard renderers to      
inherit from it, eliminating the identical ivar block and init repeated across every file. Also removes the
pre-cached scalar ivars from SubscriptRenderer/SuperscriptRenderer in favour of reading directly from     
_config, consistent with every other renderer.  



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

