### PR TITLE
refactor: extract requestHeightUpdate into a shared C++ template

### DIFF
--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -48,7 +48,6 @@
 #import "RCTFabricComponentsPlugins.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFont.h>
-#import <react/utils/ManagedObjectWrapper.h>
 
 using namespace facebook::react;
 
@@ -327,13 +326,7 @@ static char kENRMSegmentFadeAnimatorKey;
 
 - (void)requestHeightUpdate
 {
-  if (_state == nullptr) {
-    return;
-  }
-
-  _heightUpdateCounter++;
-  auto selfRef = wrapManagedObjectWeakly(self);
-  _state->updateState(EnrichedMarkdownState(_heightUpdateCounter, selfRef));
+  ENRMRequestHeightUpdate<EnrichedMarkdownState>(_state, _heightUpdateCounter, self);
 }
 
 - (void)renderMarkdownContent:(NSString *)markdownString

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -32,7 +32,6 @@
 #import "RCTFabricComponentsPlugins.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFont.h>
-#import <react/utils/ManagedObjectWrapper.h>
 
 using namespace facebook::react;
 
@@ -120,13 +119,7 @@ using namespace facebook::react;
 
 - (void)requestHeightUpdate
 {
-  if (_state == nullptr) {
-    return;
-  }
-
-  _heightUpdateCounter++;
-  auto selfRef = wrapManagedObjectWeakly(self);
-  _state->updateState(EnrichedMarkdownTextState(_heightUpdateCounter, selfRef));
+  ENRMRequestHeightUpdate<EnrichedMarkdownTextState>(_state, _heightUpdateCounter, self);
 }
 
 - (instancetype)initWithFrame:(CGRect)frame

--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -26,9 +26,9 @@
 #import <ReactNativeEnrichedMarkdown/RCTComponentViewHelpers.h>
 
 #import "EnrichedMarkdownTextInputShadowNode.h"
+#import "HeightUpdateUtils.h"
 #import "RCTFabricComponentsPlugins.h"
 #import <React/RCTConversions.h>
-#import <react/utils/ManagedObjectWrapper.h>
 
 using namespace facebook::react;
 
@@ -200,13 +200,7 @@ using namespace facebook::react;
 
 - (void)requestHeightUpdate
 {
-  if (_state == nullptr) {
-    return;
-  }
-
-  _heightUpdateCounter++;
-  auto selfRef = wrapManagedObjectWeakly(self);
-  _state->updateState(EnrichedMarkdownTextInputState(_heightUpdateCounter, selfRef));
+  ENRMRequestHeightUpdate<EnrichedMarkdownTextInputState>(_state, _heightUpdateCounter, self);
 }
 
 #pragma mark - Measurement

--- a/ios/utils/HeightUpdateUtils.h
+++ b/ios/utils/HeightUpdateUtils.h
@@ -1,6 +1,8 @@
 #pragma once
 #import "ENRMUIKit.h"
 #import <React/RCTUtils.h>
+#include <memory>
+#import <react/utils/ManagedObjectWrapper.h>
 
 /// Returns YES if the measured content height differs from the frame height
 /// Yoga assigned, comparing at physical-pixel granularity to avoid
@@ -11,4 +13,13 @@ static inline BOOL needsHeightUpdate(CGSize measuredSize, CGRect bounds)
   CGFloat assignedHeight = ceil(bounds.size.height * scale) / scale;
   CGFloat measuredHeight = ceil(measuredSize.height * scale) / scale;
   return assignedHeight != measuredHeight;
+}
+
+template <typename StateDataT, typename ConcreteStateT>
+inline void ENRMRequestHeightUpdate(std::shared_ptr<const ConcreteStateT> const &state, int &counter, id self)
+{
+  if (!state)
+    return;
+  counter++;
+  state->updateState(StateDataT(counter, facebook::react::wrapManagedObjectWeakly(self)));
 }


### PR DESCRIPTION
### What/Why?
The requestHeightUpdate method was copy-pasted identically across EnrichedMarkdown, EnrichedMarkdownText, and EnrichedMarkdownTextInput — same null-check, counter increment, and updateState call, differing only in the state data type. This PR extracts that pattern into a single C++ template function ENRMRequestHeightUpdate<StateDataT> in HeightUpdateUtils.h.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

