### PR TITLE
refactor: extract async render queue and stale-result cancellation into ENRMAsyncRenderCoordinator

### DIFF
--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -1,5 +1,6 @@
 #import "EnrichedMarkdown.h"
 #import "ContextMenuUtils.h"
+#import "ENRMAsyncRenderCoordinator.h"
 #import "ENRMImageAttachment.h"
 #import "ENRMMarkdownParser.h"
 #import "ENRMTailFadeInAnimator.h"
@@ -73,9 +74,7 @@ static char kENRMSegmentFadeAnimatorKey;
   ENRMSegmentViewRegistry *_segmentViewRegistry;
   ENRMDirtyFlags _dirtyFlags;
 
-  dispatch_queue_t _renderQueue;
-  NSUInteger _currentRenderId;
-  BOOL _blockAsyncRender;
+  ENRMAsyncRenderCoordinator *_renderCoordinator;
 
   EnrichedMarkdownShadowNode::ConcreteState::Shared _state;
   int _heightUpdateCounter;
@@ -115,8 +114,8 @@ static char kENRMSegmentFadeAnimatorKey;
     _dirtyFlags = ENRMDirtyNone;
     [self configureSegmentViewRegistry];
 
-    _renderQueue = dispatch_queue_create("com.swmansion.enriched.markdown.container.render", DISPATCH_QUEUE_SERIAL);
-    _currentRenderId = 0;
+    _renderCoordinator =
+        [[ENRMAsyncRenderCoordinator alloc] initWithQueueLabel:"com.swmansion.enriched.markdown.container.render"];
 
     _maxFontSizeMultiplier = 0;
     _allowTrailingMargin = NO;
@@ -331,12 +330,10 @@ static char kENRMSegmentFadeAnimatorKey;
 
 - (void)renderMarkdownContent:(NSString *)markdownString
 {
-  if (_blockAsyncRender) {
+  if (_renderCoordinator.blockAsyncRender)
     return;
-  }
 
   _cachedMarkdown = [markdownString copy];
-  NSUInteger renderId = ++_currentRenderId;
 
   StyleConfig *config = [_config copy];
   ENRMMarkdownParser *parser = _parser;
@@ -348,34 +345,28 @@ static char kENRMSegmentFadeAnimatorKey;
   BOOL streamingAnimation = _streamingAnimation;
   ENRMTableStreamingMode tableStreamingMode = _tableStreamingMode;
 
-  dispatch_async(_renderQueue, ^{
-    NSString *renderableMarkdown =
-        streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString, tableStreamingMode) : markdownString;
-    if (renderableMarkdown.length == 0) {
-      dispatch_async(dispatch_get_main_queue(), ^{
-        if (renderId == self->_currentRenderId) {
-          [self applyRenderedSegments:@[] renderedMarkdown:renderableMarkdown];
+  __block NSArray<ENRMRenderedSegment *> *renderedSegments = nil;
+  __block NSString *renderableMarkdown = nil;
+
+  [_renderCoordinator
+      scheduleRender:^BOOL {
+        renderableMarkdown = streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString, tableStreamingMode)
+                                                : markdownString;
+
+        if (renderableMarkdown.length == 0) {
+          renderedSegments = @[];
+          return YES;
         }
-      });
-      return;
-    }
 
-    MarkdownASTNode *ast = [parser parseMarkdown:renderableMarkdown flags:md4cFlags];
-    if (!ast) {
-      return;
-    }
+        MarkdownASTNode *ast = [parser parseMarkdown:renderableMarkdown flags:md4cFlags];
+        if (!ast)
+          return NO;
 
-    NSArray<ENRMRenderedSegment *> *renderedSegments =
-        ENRMRenderSegmentsFromAST(ast, config, allowTrailingMargin, allowFontScaling, maxFontSizeMultiplier);
-
-    dispatch_async(dispatch_get_main_queue(), ^{
-      if (renderId != self->_currentRenderId) {
-        return;
+        renderedSegments =
+            ENRMRenderSegmentsFromAST(ast, config, allowTrailingMargin, allowFontScaling, maxFontSizeMultiplier);
+        return YES;
       }
-
-      [self applyRenderedSegments:renderedSegments renderedMarkdown:renderableMarkdown];
-    });
-  });
+      apply:^{ [self applyRenderedSegments:renderedSegments renderedMarkdown:renderableMarkdown]; }];
 }
 
 - (NSArray *)parseAndRenderSegments:(NSString *)markdownString
@@ -402,7 +393,7 @@ static char kENRMSegmentFadeAnimatorKey;
   [_segmentViews removeAllObjects];
   [_segmentSignatures removeAllObjects];
 
-  _blockAsyncRender = YES;
+  _renderCoordinator.blockAsyncRender = YES;
   _cachedMarkdown = [markdownString copy];
   NSString *renderableMarkdown =
       _streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString, _tableStreamingMode) : markdownString;

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -1,6 +1,7 @@
 #import "EnrichedMarkdownText.h"
 #import "CodeBlockBackground.h"
 #import "ContextMenuUtils.h"
+#import "ENRMAsyncRenderCoordinator.h"
 #import "ENRMContextMenuTextView+macOS.h"
 #import "ENRMImageAttachment.h"
 #import "ENRMMarkdownParser.h"
@@ -51,9 +52,7 @@ using namespace facebook::react;
   StyleConfig *_config;
   ENRMMd4cFlags *_md4cFlags;
 
-  dispatch_queue_t _renderQueue;
-  NSUInteger _currentRenderId;
-  BOOL _blockAsyncRender;
+  ENRMAsyncRenderCoordinator *_renderCoordinator;
 
   EnrichedMarkdownTextShadowNode::ConcreteState::Shared _state;
   int _heightUpdateCounter;
@@ -132,8 +131,8 @@ using namespace facebook::react;
     _parser = [[ENRMMarkdownParser alloc] init];
     _md4cFlags = [ENRMMd4cFlags defaultFlags];
 
-    _renderQueue = dispatch_queue_create("com.swmansion.enriched.markdown.render", DISPATCH_QUEUE_SERIAL);
-    _currentRenderId = 0;
+    _renderCoordinator =
+        [[ENRMAsyncRenderCoordinator alloc] initWithQueueLabel:"com.swmansion.enriched.markdown.render"];
 
     _maxFontSizeMultiplier = 0;
     _allowTrailingMargin = NO;
@@ -234,13 +233,10 @@ using namespace facebook::react;
 
 - (void)renderMarkdownContent:(NSString *)markdownString
 {
-  if (_blockAsyncRender) {
+  if (_renderCoordinator.blockAsyncRender)
     return;
-  }
 
   _cachedMarkdown = [markdownString copy];
-
-  NSUInteger renderId = ++_currentRenderId;
 
   StyleConfig *config = [_config copy];
   ENRMMarkdownParser *parser = _parser;
@@ -252,26 +248,23 @@ using namespace facebook::react;
 
   NSWritingDirection writingDirection = currentWritingDirection();
 
-  dispatch_async(_renderQueue, ^{
-    MarkdownASTNode *ast = [parser parseMarkdown:markdownString flags:md4cFlags];
-    if (!ast) {
-      return;
-    }
+  __block ENRMRenderResult *result = nil;
 
-    ENRMRenderResult *result = ENRMRenderASTNodes(ast.children, config, allowTrailingMargin, allowFontScaling,
-                                                  maxFontSizeMultiplier, writingDirection);
+  [_renderCoordinator
+      scheduleRender:^BOOL {
+        MarkdownASTNode *ast = [parser parseMarkdown:markdownString flags:md4cFlags];
+        if (!ast)
+          return NO;
 
-    dispatch_async(dispatch_get_main_queue(), ^{
-      if (renderId != self->_currentRenderId) {
-        return;
+        result = ENRMRenderASTNodes(ast.children, config, allowTrailingMargin, allowFontScaling, maxFontSizeMultiplier,
+                                    writingDirection);
+        return YES;
       }
-
-      self->_lastElementMarginBottom = result.lastElementMarginBottom;
-      self->_accessibilityInfo = result.accessibilityInfo;
-
-      [self applyRenderedText:result.attributedText];
-    });
-  });
+      apply:^{
+        self->_lastElementMarginBottom = result.lastElementMarginBottom;
+        self->_accessibilityInfo = result.accessibilityInfo;
+        [self applyRenderedText:result.attributedText];
+      }];
 }
 
 - (NSMutableAttributedString *)parseAndRenderMarkdown:(NSString *)markdownString
@@ -298,7 +291,7 @@ using namespace facebook::react;
     return;
   }
 
-  _blockAsyncRender = YES;
+  _renderCoordinator.blockAsyncRender = YES;
   _cachedMarkdown = [markdownString copy];
 
   NSMutableAttributedString *attributedText = [self parseAndRenderMarkdown:markdownString];

--- a/ios/utils/ENRMAsyncRenderCoordinator.h
+++ b/ios/utils/ENRMAsyncRenderCoordinator.h
@@ -1,0 +1,19 @@
+#pragma once
+#import <Foundation/Foundation.h>
+
+/// Owns the serial render queue and render-ID counter used by async render pipelines.
+/// Handles stale-result cancellation and main-thread dispatch automatically.
+/// Set blockAsyncRender = YES before synchronous rendering to suppress queued dispatches.
+@interface ENRMAsyncRenderCoordinator : NSObject
+
+@property (nonatomic) BOOL blockAsyncRender;
+
+- (instancetype)initWithQueueLabel:(const char *)label NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Dispatches renderBlock on the serial queue.
+/// If renderBlock returns YES, applyBlock is dispatched on the main queue,
+/// provided the render ID has not been superseded by a newer call.
+- (void)scheduleRender:(BOOL (^)(void))renderBlock apply:(dispatch_block_t)applyBlock;
+
+@end

--- a/ios/utils/ENRMAsyncRenderCoordinator.m
+++ b/ios/utils/ENRMAsyncRenderCoordinator.m
@@ -1,0 +1,32 @@
+#import "ENRMAsyncRenderCoordinator.h"
+
+@implementation ENRMAsyncRenderCoordinator {
+  dispatch_queue_t _queue;
+  NSUInteger _currentRenderId;
+}
+
+- (instancetype)initWithQueueLabel:(const char *)label
+{
+  if (self = [super init]) {
+    _queue = dispatch_queue_create(label, DISPATCH_QUEUE_SERIAL);
+  }
+  return self;
+}
+
+- (void)scheduleRender:(BOOL (^)(void))renderBlock apply:(dispatch_block_t)applyBlock
+{
+  if (_blockAsyncRender)
+    return;
+  NSUInteger renderId = ++_currentRenderId;
+  dispatch_async(_queue, ^{
+    if (!renderBlock())
+      return;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (renderId == self->_currentRenderId) {
+        applyBlock();
+      }
+    });
+  });
+}
+
+@end


### PR DESCRIPTION
### What/Why?
Extracts the duplicated async render pattern (serial queue, render-ID counter, stale-result cancellation, main-thread apply) from EnrichedMarkdown and EnrichedMarkdownText into a shared ENRMAsyncRenderCoordinator. This eliminates copy-pasted boilerplate and gives a single place to maintain the render lifecycle logic.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

