### PR TITLE
refactor: extract emit helpers for link, task list, and context menu events

### DIFF
--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -4,6 +4,7 @@
 #import "ENRMImageAttachment.h"
 #import "ENRMMarkdownParser.h"
 #import "ENRMTailFadeInAnimator.h"
+#import "ENRMTextInteractionUtils.h"
 #import "ENRMTextRenderer.h"
 #import "ENRMTextViewSetup.h"
 #import "ENRMUIKit.h"
@@ -61,6 +62,13 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
 static char kENRMSegmentFadeAnimatorKey;
 
 @interface EnrichedMarkdown () <RCTEnrichedMarkdownViewProtocol, UITextViewDelegate>
+- (void)emitLinkPress:(NSString *)url;
+- (void)emitLinkLongPress:(NSString *)url;
+- (void)emitTaskListItemPress:(NSInteger)index checked:(BOOL)checked text:(NSString *)text;
+- (void)emitContextMenuItemPress:(NSString *)itemText
+                    selectedText:(NSString *)selectedText
+                  selectionStart:(NSUInteger)selectionStart
+                    selectionEnd:(NSUInteger)selectionEnd;
 @end
 
 @implementation EnrichedMarkdown {
@@ -492,15 +500,10 @@ static char kENRMSegmentFadeAnimatorKey;
     NSArray<NSMenuItem *> *customItems = ENRMBuildContextMenuItems(
         strongSelf->_contextMenuItemTexts, strongSelf->_contextMenuItemIcons, textView,
         ^(NSString *itemText, NSString *selectedText, NSUInteger selectionStart, NSUInteger selectionEnd) {
-          auto eventEmitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(strongSelf->_eventEmitter);
-          if (eventEmitter) {
-            eventEmitter->onContextMenuItemPress({
-                .itemText = std::string(itemText.UTF8String),
-                .selectedText = std::string(selectedText.UTF8String),
-                .selectionStart = (int)selectionStart,
-                .selectionEnd = (int)selectionEnd,
-            });
-          }
+          [strongSelf emitContextMenuItemPress:itemText
+                                  selectedText:selectedText
+                                selectionStart:selectionStart
+                                  selectionEnd:selectionEnd];
         });
     return buildEditMenuForSelection(textView.textStorage, textView.selectedRange, segmentMarkdown, strongSelf->_config,
                                      @[ baseMenu ], customItems, strongSelf -> _selectionMenuConfig);
@@ -522,24 +525,14 @@ static char kENRMSegmentFadeAnimatorKey;
 
   tableView.onLinkPress = ^(NSString *url) {
     EnrichedMarkdown *strongSelf = weakSelf;
-    if (!strongSelf || !url)
-      return;
-
-    auto eventEmitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(strongSelf->_eventEmitter);
-    if (eventEmitter) {
-      eventEmitter->onLinkPress({.url = std::string([url UTF8String])});
-    }
+    if (strongSelf && url)
+      [strongSelf emitLinkPress:url];
   };
 
   tableView.onLinkLongPress = ^(NSString *url) {
     EnrichedMarkdown *strongSelf = weakSelf;
-    if (!strongSelf || !url)
-      return;
-
-    auto eventEmitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(strongSelf->_eventEmitter);
-    if (eventEmitter) {
-      eventEmitter->onLinkLongPress({.url = std::string([url UTF8String])});
-    }
+    if (strongSelf && url)
+      [strongSelf emitLinkLongPress:url];
   };
 
   [tableView applyTableNode:tableSegment.tableNode];
@@ -844,6 +837,42 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
 }
 #endif
 
+- (void)emitLinkPress:(NSString *)url
+{
+  auto emitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(_eventEmitter);
+  if (emitter)
+    emitter->onLinkPress({.url = std::string(url.UTF8String)});
+}
+
+- (void)emitLinkLongPress:(NSString *)url
+{
+  auto emitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(_eventEmitter);
+  if (emitter)
+    emitter->onLinkLongPress({.url = std::string(url.UTF8String)});
+}
+
+- (void)emitTaskListItemPress:(NSInteger)index checked:(BOOL)checked text:(NSString *)text
+{
+  auto emitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(_eventEmitter);
+  if (emitter)
+    emitter->onTaskListItemPress({.index = (int)index, .checked = checked, .text = std::string(text.UTF8String ?: "")});
+}
+
+- (void)emitContextMenuItemPress:(NSString *)itemText
+                    selectedText:(NSString *)selectedText
+                  selectionStart:(NSUInteger)selectionStart
+                    selectionEnd:(NSUInteger)selectionEnd
+{
+  auto emitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(_eventEmitter);
+  if (emitter)
+    emitter->onContextMenuItemPress({
+        .itemText = std::string(itemText.UTF8String),
+        .selectedText = std::string(selectedText.UTF8String),
+        .selectionStart = (int)selectionStart,
+        .selectionEnd = (int)selectionEnd,
+    });
+}
+
 - (void)textTapped:(ENRMTapRecognizer *)recognizer
 {
   ENRMPlatformTextView *textView = (ENRMPlatformTextView *)recognizer.view;
@@ -851,14 +880,7 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
   if (handleTaskListTapWithSharedLogic(
           textView, recognizer, &self->_cachedMarkdown, self->_config,
           ^(NSInteger index, BOOL checked, NSString *itemText) {
-            auto eventEmitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(self->_eventEmitter);
-            if (eventEmitter) {
-              eventEmitter->onTaskListItemPress({
-                  .index = (int)index,
-                  .checked = checked,
-                  .text = std::string([itemText UTF8String] ?: ""),
-              });
-            }
+            [self emitTaskListItemPress:index checked:checked text:itemText];
           },
           ^(NSString *updatedMarkdown) { [self renderMarkdownContent:updatedMarkdown]; })) {
     return;
@@ -875,16 +897,7 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
     }
   }
 
-  NSString *url = linkURLAtTapLocation(textView, recognizer);
-  if (url) {
-    auto eventEmitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(_eventEmitter);
-    if (eventEmitter) {
-      eventEmitter->onLinkPress({.url = std::string([url UTF8String])});
-    }
-    return;
-  }
-
-  ENRMClearSelection(textView);
+  ENRMHandleTapOnTextView(textView, recognizer, ^(NSString *url) { [self emitLinkPress:url]; });
 }
 
 // TODO: Remove API_AVAILABLE(ios(16.0)) guard when the minimum iOS deployment target in RN is bumped to 16.
@@ -897,17 +910,11 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
   ENRMContextMenuPressHandler handler =
       ^(NSString *itemText, NSString *selectedText, NSUInteger selectionStart, NSUInteger selectionEnd) {
         EnrichedMarkdown *strongSelf = weakSelf;
-        if (!strongSelf)
-          return;
-        auto eventEmitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(strongSelf->_eventEmitter);
-        if (eventEmitter) {
-          eventEmitter->onContextMenuItemPress({
-              .itemText = std::string(itemText.UTF8String),
-              .selectedText = std::string(selectedText.UTF8String),
-              .selectionStart = (int)selectionStart,
-              .selectionEnd = (int)selectionEnd,
-          });
-        }
+        if (strongSelf)
+          [strongSelf emitContextMenuItemPress:itemText
+                                  selectedText:selectedText
+                                selectionStart:selectionStart
+                                  selectionEnd:selectionEnd];
       };
   NSMutableArray<UIAction *> *customActions =
       ENRMBuildContextMenuActions(_contextMenuItemTexts, _contextMenuItemIcons, textView, range, handler);
@@ -932,10 +939,7 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
     return YES;
   }
 
-  auto eventEmitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(_eventEmitter);
-  if (eventEmitter) {
-    eventEmitter->onLinkLongPress({.url = std::string([urlString UTF8String])});
-  }
+  [self emitLinkLongPress:urlString];
   return NO;
 }
 #endif

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -8,6 +8,7 @@
 #import "ENRMSpoilerOverlayManager.h"
 #import "ENRMSpoilerTapUtils.h"
 #import "ENRMTailFadeInAnimator.h"
+#import "ENRMTextInteractionUtils.h"
 #import "ENRMTextRenderer.h"
 #import "ENRMTextViewSetup.h"
 #import "ENRMUIKit.h"
@@ -42,6 +43,13 @@ using namespace facebook::react;
 - (void)applyRenderedText:(NSMutableAttributedString *)attributedText;
 - (void)textTapped:(ENRMTapRecognizer *)recognizer;
 - (void)setupLayoutManager;
+- (void)emitLinkPress:(NSString *)url;
+- (void)emitLinkLongPress:(NSString *)url;
+- (void)emitTaskListItemPress:(NSInteger)index checked:(BOOL)checked text:(NSString *)text;
+- (void)emitContextMenuItemPress:(NSString *)itemText
+                    selectedText:(NSString *)selectedText
+                  selectionStart:(NSUInteger)selectionStart
+                    selectionEnd:(NSUInteger)selectionEnd;
 @end
 
 @implementation EnrichedMarkdownText {
@@ -186,16 +194,10 @@ using namespace facebook::react;
     NSArray<NSMenuItem *> *customItems = ENRMBuildContextMenuItems(
         strongSelf->_contextMenuItemTexts, strongSelf->_contextMenuItemIcons, textView,
         ^(NSString *itemText, NSString *selectedText, NSUInteger selectionStart, NSUInteger selectionEnd) {
-          auto eventEmitter =
-              std::static_pointer_cast<EnrichedMarkdownTextEventEmitter const>(strongSelf->_eventEmitter);
-          if (eventEmitter) {
-            eventEmitter->onContextMenuItemPress({
-                .itemText = std::string(itemText.UTF8String),
-                .selectedText = std::string(selectedText.UTF8String),
-                .selectionStart = (int)selectionStart,
-                .selectionEnd = (int)selectionEnd,
-            });
-          }
+          [strongSelf emitContextMenuItemPress:itemText
+                                  selectedText:selectedText
+                                selectionStart:selectionStart
+                                  selectionEnd:selectionEnd];
         });
     return buildEditMenuForSelection(textView.textStorage, textView.selectedRange, strongSelf->_cachedMarkdown,
                                      strongSelf->_config, @[ baseMenu ], customItems,
@@ -537,6 +539,42 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownTextCls(void)
   return [super touchEventEmitterAtPoint:point];
 }
 
+- (void)emitLinkPress:(NSString *)url
+{
+  auto emitter = std::static_pointer_cast<EnrichedMarkdownTextEventEmitter const>(_eventEmitter);
+  if (emitter)
+    emitter->onLinkPress({.url = std::string(url.UTF8String)});
+}
+
+- (void)emitLinkLongPress:(NSString *)url
+{
+  auto emitter = std::static_pointer_cast<EnrichedMarkdownTextEventEmitter const>(_eventEmitter);
+  if (emitter)
+    emitter->onLinkLongPress({.url = std::string(url.UTF8String)});
+}
+
+- (void)emitTaskListItemPress:(NSInteger)index checked:(BOOL)checked text:(NSString *)text
+{
+  auto emitter = std::static_pointer_cast<EnrichedMarkdownTextEventEmitter const>(_eventEmitter);
+  if (emitter)
+    emitter->onTaskListItemPress({.index = (int)index, .checked = checked, .text = std::string(text.UTF8String ?: "")});
+}
+
+- (void)emitContextMenuItemPress:(NSString *)itemText
+                    selectedText:(NSString *)selectedText
+                  selectionStart:(NSUInteger)selectionStart
+                    selectionEnd:(NSUInteger)selectionEnd
+{
+  auto emitter = std::static_pointer_cast<EnrichedMarkdownTextEventEmitter const>(_eventEmitter);
+  if (emitter)
+    emitter->onContextMenuItemPress({
+        .itemText = std::string(itemText.UTF8String),
+        .selectedText = std::string(selectedText.UTF8String),
+        .selectionStart = (int)selectionStart,
+        .selectionEnd = (int)selectionEnd,
+    });
+}
+
 - (void)textTapped:(ENRMTapRecognizer *)recognizer
 {
   ENRMPlatformTextView *textView = (ENRMPlatformTextView *)recognizer.view;
@@ -544,14 +582,7 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownTextCls(void)
   if (handleTaskListTapWithSharedLogic(
           textView, recognizer, &self->_cachedMarkdown, self->_config,
           ^(NSInteger index, BOOL checked, NSString *itemText) {
-            auto eventEmitter = std::static_pointer_cast<EnrichedMarkdownTextEventEmitter const>(self->_eventEmitter);
-            if (eventEmitter) {
-              eventEmitter->onTaskListItemPress({
-                  .index = (int)index,
-                  .checked = checked,
-                  .text = std::string([itemText UTF8String] ?: ""),
-              });
-            }
+            [self emitTaskListItemPress:index checked:checked text:itemText];
           },
           ^(NSString *updatedMarkdown) { [self renderMarkdownContent:updatedMarkdown]; })) {
     return;
@@ -561,16 +592,7 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownTextCls(void)
     return;
   }
 
-  NSString *url = linkURLAtTapLocation(textView, recognizer);
-  if (url) {
-    auto eventEmitter = std::static_pointer_cast<EnrichedMarkdownTextEventEmitter const>(_eventEmitter);
-    if (eventEmitter) {
-      eventEmitter->onLinkPress({.url = std::string([url UTF8String])});
-    }
-    return;
-  }
-
-  ENRMClearSelection(textView);
+  ENRMHandleTapOnTextView(textView, recognizer, ^(NSString *url) { [self emitLinkPress:url]; });
 }
 
 #pragma mark - UITextViewDelegate (Link Interaction)
@@ -591,10 +613,7 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownTextCls(void)
     return YES;
   }
 
-  auto eventEmitter = std::static_pointer_cast<EnrichedMarkdownTextEventEmitter const>(_eventEmitter);
-  if (eventEmitter) {
-    eventEmitter->onLinkLongPress({.url = std::string([urlString UTF8String])});
-  }
+  [self emitLinkLongPress:urlString];
   return NO;
 }
 
@@ -609,17 +628,11 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownTextCls(void)
   ENRMContextMenuPressHandler handler =
       ^(NSString *itemText, NSString *selectedText, NSUInteger selectionStart, NSUInteger selectionEnd) {
         EnrichedMarkdownText *strongSelf = weakSelf;
-        if (!strongSelf)
-          return;
-        auto eventEmitter = std::static_pointer_cast<EnrichedMarkdownTextEventEmitter const>(strongSelf->_eventEmitter);
-        if (eventEmitter) {
-          eventEmitter->onContextMenuItemPress({
-              .itemText = std::string(itemText.UTF8String),
-              .selectedText = std::string(selectedText.UTF8String),
-              .selectionStart = (int)selectionStart,
-              .selectionEnd = (int)selectionEnd,
-          });
-        }
+        if (strongSelf)
+          [strongSelf emitContextMenuItemPress:itemText
+                                  selectedText:selectedText
+                                selectionStart:selectionStart
+                                  selectionEnd:selectionEnd];
       };
   NSMutableArray<UIAction *> *customActions =
       ENRMBuildContextMenuActions(_contextMenuItemTexts, _contextMenuItemIcons, textView, range, handler);

--- a/ios/utils/ENRMTextInteractionUtils.h
+++ b/ios/utils/ENRMTextInteractionUtils.h
@@ -1,0 +1,20 @@
+#pragma once
+#import "ENRMUIKit.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Resolves the link URL at the tap location.
+/// If a link is found, calls onLinkPress and returns YES.
+/// If no link is found, calls ENRMClearSelection and returns NO.
+BOOL ENRMHandleTapOnTextView(ENRMPlatformTextView *textView, ENRMTapRecognizer *recognizer,
+                             void (^onLinkPress)(NSString *url));
+
+#ifdef __cplusplus
+}
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/ios/utils/ENRMTextInteractionUtils.m
+++ b/ios/utils/ENRMTextInteractionUtils.m
@@ -1,0 +1,15 @@
+#import "ENRMTextInteractionUtils.h"
+#import "LinkTapUtils.h"
+
+BOOL ENRMHandleTapOnTextView(ENRMPlatformTextView *textView, ENRMTapRecognizer *recognizer,
+                             void (^onLinkPress)(NSString *url))
+{
+  NSString *url = linkURLAtTapLocation(textView, recognizer);
+  if (!url) {
+    ENRMClearSelection(textView);
+    return NO;
+  }
+  if (onLinkPress)
+    onLinkPress(url);
+  return YES;
+}


### PR DESCRIPTION
### What/Why?
Replaces inline std::static_pointer_cast + event emitter calls with dedicated emit* helper methods (emitLinkPress:, emitLinkLongPress:, emitTaskListItemPress:checked:text:, emitContextMenuItemPress:selectedText:selectionStart:selectionEnd:) in both EnrichedMarkdown and EnrichedMarkdownText. Also extracts the shared link-tap-or-clear-selection pattern into ENRMHandleTapOnTextView. This removes ~100 lines of duplicated C++ boilerplate and makes the tap/interaction handlers significantly easier to read.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

