### PR TITLE
fix(ios): reset state in prepareForRecycle on both host components

### DIFF
--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -768,6 +768,8 @@ static char kENRMSegmentFadeAnimatorKey;
   // segment subviews, signatures, cached markdown and any running tail-fade
   // animators from the previous mount would leak into the next mount and the
   // reconciler would reuse stale views against unrelated content.
+  [_renderCoordinator invalidate];
+
   for (RCTUIView *segment in _segmentViews) {
     if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
       EnrichedMarkdownInternalText *textSegment = (EnrichedMarkdownInternalText *)segment;

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -762,6 +762,34 @@ static char kENRMSegmentFadeAnimatorKey;
   }
 }
 
+- (void)prepareForRecycle
+{
+  // Fabric pools `RCTViewComponentView` instances. Without resetting here, the
+  // segment subviews, signatures, cached markdown and any running tail-fade
+  // animators from the previous mount would leak into the next mount and the
+  // reconciler would reuse stale views against unrelated content.
+  for (RCTUIView *segment in _segmentViews) {
+    if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
+      ENRMTailFadeInAnimator *animator =
+          objc_getAssociatedObject(((EnrichedMarkdownInternalText *)segment).textView, &kENRMSegmentFadeAnimatorKey);
+      [animator cancel];
+      objc_setAssociatedObject(((EnrichedMarkdownInternalText *)segment).textView, &kENRMSegmentFadeAnimatorKey, nil,
+                               OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    [segment removeFromSuperview];
+  }
+  [_segmentViews removeAllObjects];
+  [_segmentSignatures removeAllObjects];
+
+  _cachedMarkdown = nil;
+  _renderedMarkdown = nil;
+  _streamingAnimation = NO;
+  _tableStreamingMode = ENRMTableStreamingModeHidden;
+  _dirtyFlags = ENRMDirtyNone;
+
+  [super prepareForRecycle];
+}
+
 Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
 {
   return EnrichedMarkdown.class;

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -770,10 +770,10 @@ static char kENRMSegmentFadeAnimatorKey;
   // reconciler would reuse stale views against unrelated content.
   for (RCTUIView *segment in _segmentViews) {
     if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
-      ENRMTailFadeInAnimator *animator =
-          objc_getAssociatedObject(((EnrichedMarkdownInternalText *)segment).textView, &kENRMSegmentFadeAnimatorKey);
+      EnrichedMarkdownInternalText *textSegment = (EnrichedMarkdownInternalText *)segment;
+      ENRMTailFadeInAnimator *animator = objc_getAssociatedObject(textSegment.textView, &kENRMSegmentFadeAnimatorKey);
       [animator cancel];
-      objc_setAssociatedObject(((EnrichedMarkdownInternalText *)segment).textView, &kENRMSegmentFadeAnimatorKey, nil,
+      objc_setAssociatedObject(textSegment.textView, &kENRMSegmentFadeAnimatorKey, nil,
                                OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     [segment removeFromSuperview];

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -764,10 +764,6 @@ static char kENRMSegmentFadeAnimatorKey;
 
 - (void)prepareForRecycle
 {
-  // Fabric pools `RCTViewComponentView` instances. Without resetting here, the
-  // segment subviews, signatures, cached markdown and any running tail-fade
-  // animators from the previous mount would leak into the next mount and the
-  // reconciler would reuse stale views against unrelated content.
   [_renderCoordinator invalidate];
 
   for (RCTUIView *segment in _segmentViews) {

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -522,6 +522,30 @@ using namespace facebook::react;
   }
 }
 
+- (void)prepareForRecycle
+{
+  // Fabric pools `RCTViewComponentView` instances. Without resetting here, the
+  // running tail-fade animator, previous text length and cached markdown from
+  // the previous mount would resume against the new content and the text view
+  // would briefly show the prior message.
+  [_fadeAnimator cancel];
+  _fadeAnimator = nil;
+  _previousTextLength = 0;
+  _streamingAnimation = NO;
+  _forceHeightUpdateOnNextRender = NO;
+  _cachedMarkdown = nil;
+  _renderedMarkdown = nil;
+  _accessibilityElements = nil;
+  _accessibilityInfo = nil;
+  _accessibilityNeedsRebuild = NO;
+  if (_textView != nil) {
+    ENRMSetAttributedText(_textView, [[NSAttributedString alloc] initWithString:@""]);
+    _textView.hidden = YES;
+  }
+
+  [super prepareForRecycle];
+}
+
 Class<RCTComponentViewProtocol> EnrichedMarkdownTextCls(void)
 {
   return EnrichedMarkdownText.class;

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -528,6 +528,8 @@ using namespace facebook::react;
   // running tail-fade animator, previous text length and cached markdown from
   // the previous mount would resume against the new content and the text view
   // would briefly show the prior message.
+  [_renderCoordinator invalidate];
+
   [_fadeAnimator cancel];
   _fadeAnimator = nil;
   _previousTextLength = 0;

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -540,6 +540,7 @@ using namespace facebook::react;
   _accessibilityElements = nil;
   _accessibilityInfo = nil;
   _accessibilityNeedsRebuild = NO;
+  [_spoilerManager removeAllOverlays];
   if (_textView != nil) {
     ENRMSetAttributedText(_textView, [[NSAttributedString alloc] initWithString:@""]);
     _textView.hidden = YES;

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -524,10 +524,6 @@ using namespace facebook::react;
 
 - (void)prepareForRecycle
 {
-  // Fabric pools `RCTViewComponentView` instances. Without resetting here, the
-  // running tail-fade animator, previous text length and cached markdown from
-  // the previous mount would resume against the new content and the text view
-  // would briefly show the prior message.
   [_renderCoordinator invalidate];
 
   [_fadeAnimator cancel];

--- a/ios/utils/ENRMAsyncRenderCoordinator.h
+++ b/ios/utils/ENRMAsyncRenderCoordinator.h
@@ -16,4 +16,9 @@
 /// provided the render ID has not been superseded by a newer call.
 - (void)scheduleRender:(BOOL (^)(void))renderBlock apply:(dispatch_block_t)applyBlock;
 
+/// Advances the render ID so any in-flight render's apply block is discarded
+/// by the renderId == currentRenderId check when it lands on the main queue.
+/// Use before recycling or otherwise resetting a host that owns this coordinator.
+- (void)invalidate;
+
 @end

--- a/ios/utils/ENRMAsyncRenderCoordinator.m
+++ b/ios/utils/ENRMAsyncRenderCoordinator.m
@@ -29,4 +29,9 @@
   });
 }
 
+- (void)invalidate
+{
+  ++_currentRenderId;
+}
+
 @end


### PR DESCRIPTION
### What/Why?

When a chat / feed UI virtualises its rows (FlatList, FlashList, etc.), Fabric pools the host `RCTViewComponentView` instances and reuses them for new mounts. Both `EnrichedMarkdown` (GFM container) and `EnrichedMarkdownText` (commonmark) keep mutable state across that boundary that the new mount has no way to clear before its own props arrive:

- `EnrichedMarkdown` holds `_segmentViews`, `_segmentSignatures`, the cached / rendered markdown strings, the `ENRMTailFadeInAnimator` instances attached to each segment text view via `objc_setAssociatedObject`, the streaming flags and the dirty bitset.
- `EnrichedMarkdownText` holds `_fadeAnimator`, `_previousTextLength`, the cached / rendered markdown, the streaming flag, the accessibility cache and the text view contents.

Concrete consequences I hit while wiring this up against a chat list:

- The reconciler reuses subviews from the previous message because their signatures happen to match the new content, and the new content's leading bytes briefly show the prior message's typography until the new render commits.
- The tail-fade animator that was mid-animation when the host was pooled resumes against the new attributed string and fades a slice that has no semantic relationship to the appended tail.
- `_renderedMarkdown` from the previous mount short-circuits `hasRenderedMarkdown:` for the new content if the strings happen to match, skipping a render.

Override `prepareForRecycle` on both host components to drop subviews, cancel any per-text-view tail-fade animators, clear the cached / rendered markdown, reset the streaming flags and invalidate the accessibility cache before calling `super`.

Android and macOS are unaffected. Android does not opt views into Fabric's recycle pool (no `setupViewRecycling`) and already releases per-instance state via `onDropViewInstance` on the view managers. macOS uses the same `RCTViewComponentView` shape; the reset is platform-neutral and the helpers used (`ENRMSetAttributedText`, the `objc_setAssociatedObject` clear) are available there too.

### Testing

- Verified the host pod compiles cleanly on an iOS simulator build (Xcode 26.2 SDK, Debug).
- `yarn typecheck`, `yarn lint`, `yarn test` green.
- Did not exercise the example app's E2E suite locally for this PR — the change is reset-only and has no rendering surface; happy to run it on request if you'd prefer.

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android (no change)
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)