### PR TITLE
fix: skip streaming animations when Reduce Motion is enabled

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -20,6 +20,7 @@ import com.swmansion.enriched.markdown.utils.common.RenderedSegment
 import com.swmansion.enriched.markdown.utils.common.SegmentReconciler
 import com.swmansion.enriched.markdown.utils.common.StreamingMarkdownFilter
 import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
+import com.swmansion.enriched.markdown.utils.common.isReducedMotionEnabled
 import com.swmansion.enriched.markdown.utils.common.splitASTIntoSegments
 import com.swmansion.enriched.markdown.utils.text.TailFadeInAnimator
 import com.swmansion.enriched.markdown.utils.text.view.SelectionMenuConfig
@@ -367,7 +368,7 @@ class EnrichedMarkdown
           val tableView = view as TableContainerView
           val previousRowCount = tableView.rowCount
           tableView.applyTableNode(segment.node)
-          if (streamingAnimation) {
+          if (streamingAnimation && !isReducedMotionEnabled(context)) {
             tableView.animateNewRows(previousRowCount, BLOCK_FADE_DURATION_MS)
           }
         }
@@ -404,6 +405,7 @@ class EnrichedMarkdown
 
     private fun animateBlockViewFadeIn(view: View) {
       if (!streamingAnimation) return
+      if (isReducedMotionEnabled(context)) return
       view.alpha = 0f
       view
         .animate()

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MotionPreferences.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MotionPreferences.kt
@@ -1,0 +1,21 @@
+package com.swmansion.enriched.markdown.utils.common
+
+import android.content.Context
+import android.os.Build
+import android.view.accessibility.AccessibilityManager
+
+/**
+ * Returns true when the user has asked the system to minimise motion.
+ *
+ * On API 26+ this maps to [AccessibilityManager.isAnimatorEnabled], which is the
+ * platform signal for "Remove animations" (Settings > Accessibility) and the
+ * "Animator duration scale" developer toggle. Older API levels do not expose an
+ * equivalent flag, so we fall back to allowing animations.
+ */
+fun isReducedMotionEnabled(context: Context): Boolean {
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false
+  val am =
+    context.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+      ?: return false
+  return !am.isAnimatorEnabled
+}

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/TailFadeInAnimator.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/TailFadeInAnimator.kt
@@ -7,6 +7,7 @@ import android.text.Spannable
 import android.view.animation.LinearInterpolator
 import android.widget.TextView
 import com.swmansion.enriched.markdown.spans.FadeInSpan
+import com.swmansion.enriched.markdown.utils.common.isReducedMotionEnabled
 import java.lang.ref.WeakReference
 
 class TailFadeInAnimator(
@@ -24,6 +25,9 @@ class TailFadeInAnimator(
 
     val textView = viewRef.get() ?: return
     val spannable = textView.text as? Spannable ?: return
+
+    // Honor the system accessibility preference and leave the new tail visible.
+    if (isReducedMotionEnabled(textView.context)) return
 
     val fadeSpan = FadeInSpan().apply { alpha = 0f }
     spannable.setSpan(fadeSpan, tailStart, tailEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/TailFadeInAnimator.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/TailFadeInAnimator.kt
@@ -26,7 +26,6 @@ class TailFadeInAnimator(
     val textView = viewRef.get() ?: return
     val spannable = textView.text as? Spannable ?: return
 
-    // Honor the system accessibility preference and leave the new tail visible.
     if (isReducedMotionEnabled(textView.context)) return
 
     val fadeSpan = FadeInSpan().apply { alpha = 0f }

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -545,7 +545,7 @@ static char kENRMSegmentFadeAnimatorKey;
   NSUInteger previousRowCount = view.rowCount;
   [view applyTableNode:tableSegment.tableNode];
 
-  if (_streamingAnimation) {
+  if (_streamingAnimation && !ENRMShouldReduceMotion()) {
     [view animateNewRowsFromPreviousCount:previousRowCount duration:0.20];
   }
 }
@@ -565,6 +565,9 @@ static char kENRMSegmentFadeAnimatorKey;
     return;
 
 #if !TARGET_OS_OSX
+  if (ENRMShouldReduceMotion()) {
+    return;
+  }
   view.alpha = 0.0;
   [UIView animateWithDuration:0.20 animations:^{ view.alpha = 1.0; }];
 #endif

--- a/ios/utils/ENRMTailFadeInAnimator.m
+++ b/ios/utils/ENRMTailFadeInAnimator.m
@@ -49,8 +49,6 @@ typedef struct {
     return;
 
 #if !TARGET_OS_OSX
-  // Honor the system-wide accessibility preference: when Reduce Motion is on
-  // we leave the new tail at full alpha instead of running the fade.
   if (UIAccessibilityIsReduceMotionEnabled()) {
     return;
   }
@@ -72,6 +70,9 @@ typedef struct {
   // CADisplayLink doesn't exist on macOS; the equivalent is CVDisplayLink (Core Video)
   // or an NSTimer driven at the display refresh rate. The iOS step:/eased-progress
   // logic below can be reused directly once a display-sync callback is wired up.
+  // TODO: When this is implemented, gate it on
+  // NSWorkspace.sharedWorkspace.accessibilityDisplayShouldReduceMotion so macOS
+  // users with Reduce Motion enabled also skip the fade.
   [self updateAlpha:1.0];
   [self cleanupEntries];
 #endif

--- a/ios/utils/ENRMTailFadeInAnimator.m
+++ b/ios/utils/ENRMTailFadeInAnimator.m
@@ -48,6 +48,14 @@ typedef struct {
   if (!storage || tailEnd <= tailStart || tailEnd > storage.length)
     return;
 
+#if !TARGET_OS_OSX
+  // Honor the system-wide accessibility preference: when Reduce Motion is on
+  // we leave the new tail at full alpha instead of running the fade.
+  if (UIAccessibilityIsReduceMotionEnabled()) {
+    return;
+  }
+#endif
+
   NSRange range = NSMakeRange(tailStart, tailEnd - tailStart);
 
   [self snapshotColorsInRange:range storage:storage];

--- a/ios/utils/ENRMUIKit.h
+++ b/ios/utils/ENRMUIKit.h
@@ -162,6 +162,22 @@ static inline void ENRMSetContentSize(ENRMPlatformTextView *textView, CGSize siz
 #endif
 }
 
+/// Returns YES when the user has asked the system to minimise motion.
+/// iOS: UIAccessibilityIsReduceMotionEnabled.
+/// macOS: NSWorkspace.shared.accessibilityDisplayShouldReduceMotion.
+/// Always NO on platforms where the API is unavailable.
+static inline BOOL ENRMShouldReduceMotion(void)
+{
+#if !TARGET_OS_OSX
+  return UIAccessibilityIsReduceMotionEnabled();
+#else
+  if (@available(macOS 10.12, *)) {
+    return NSWorkspace.sharedWorkspace.accessibilityDisplayShouldReduceMotion;
+  }
+  return NO;
+#endif
+}
+
 /// Sets default typing attributes on the text view.
 /// On macOS, RCTUITextView overrides setTypingAttributes: to use defaultTextAttributes,
 /// so we must set that property as well.


### PR DESCRIPTION
### What/Why?

The streaming-animation paths in the GFM container run regardless of the system-wide accessibility preference for reduced motion:

- `ENRMTailFadeInAnimator.animateFrom:to:` always snapshots colors, sets the new tail to alpha 0 and runs a `CADisplayLink` fade up to alpha 1.
- `EnrichedMarkdown.animateBlockViewIfNeeded:` always sets `view.alpha = 0` and runs a 200ms opacity animation on new table / math segments.
- `EnrichedMarkdown.updateTableView:withSegment:` always calls `animateNewRowsFromPreviousCount:` on growing tables.
- The Android equivalents in `TailFadeInAnimator.animate` and `EnrichedMarkdown.animateBlockViewFadeIn` / `animateNewRows` have the same shape.

Users who have enabled \"Reduce Motion\" on iOS or \"Remove animations\" on Android explicitly opt out of non-essential animations. The current implementation produces visible fades for them, which is both an accessibility regression (against `UIAccessibilityIsReduceMotionEnabled` / `AccessibilityManager.isAnimatorEnabled`) and a perceptual mismatch with how UIKit and AppKit's own widgets behave under the same preference.

Gate the three iOS sites and three Android sites on the platform flag. When it's set, the new content is shown at its final opacity with no transition.

To keep call sites short, a small helper is added on each platform:

- iOS: `ENRMShouldReduceMotion()` in `ENRMUIKit.h`, which folds `UIAccessibilityIsReduceMotionEnabled` and the macOS `NSWorkspace.accessibilityDisplayShouldReduceMotion` equivalent behind one call.
- Android: `isReducedMotionEnabled(context)` in `utils/common/MotionPreferences.kt`, using `AccessibilityManager.isAnimatorEnabled` on API 26+ and falling back to allowing animations on older API levels.

The flag is read on each animation entry rather than cached on the host. macOS observers (`NSWorkspace.accessibilityDisplayOptionsDidChangeNotification`) could update a cached value reactively, but the current call sites only fire on render boundaries, so the polled read is cheap and avoids extra notification plumbing.

### Testing

- Verified the iOS host pod compiles cleanly on an iOS simulator build (Xcode 26.2 SDK, Debug) with the helper and gates applied.
- `yarn typecheck`, `yarn lint`, `yarn test` green.
- Manual: with Reduce Motion enabled in the iOS Simulator's Accessibility settings, no fades are triggered when streaming markdown that contains a paragraph, a table that grows row-by-row, and a block math segment; with the setting off, animations behave as before.

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android (no JVM-level changes besides the new helper and three callers)
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)