### PR TITLE
Remove maximum line height setting in ParagraphStyle

### DIFF
--- a/ios/utils/ParagraphStyleUtils.m
+++ b/ios/utils/ParagraphStyleUtils.m
@@ -118,7 +118,6 @@ void applyLineHeight(NSMutableAttributedString *output, NSRange range, CGFloat l
   NSMutableParagraphStyle *style = getOrCreateParagraphStyle(output, range.location);
 
   style.minimumLineHeight = lineHeight;
-  style.maximumLineHeight = lineHeight;
 
   [output addAttribute:NSParagraphStyleAttributeName value:style range:range];
 }


### PR DESCRIPTION
### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->
respects the user line height, but avoids cutting content and making each line dynamic.


### Testing
<!-- How to test changed code? What testing has been done? -->

`\\displaystyle\\frac{4/2}`

