### PR TITLE
refactor: change default streamingConfig.tableMode from 'hidden' to 'progressive'

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -60,7 +60,7 @@ class EnrichedMarkdown
     private val dirtyFlags = EnumSet.noneOf(DirtyFlag::class.java)
     var streamingAnimation: Boolean = false
 
-    var tableStreamingMode: TableStreamingMode = TableStreamingMode.HIDDEN
+    var tableStreamingMode: TableStreamingMode = TableStreamingMode.PROGRESSIVE
     private var renderPending: Boolean = false
 
     var currentMarkdown: String = ""

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -164,8 +164,8 @@ class EnrichedMarkdownManager :
     if (view == null) return
     val tableMode =
       when (config?.getString("tableMode")) {
-        "progressive" -> TableStreamingMode.PROGRESSIVE
-        else -> TableStreamingMode.HIDDEN
+        "hidden" -> TableStreamingMode.HIDDEN
+        else -> TableStreamingMode.PROGRESSIVE
       }
     view.tableStreamingMode = tableMode
   }

--- a/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -320,7 +320,14 @@ object MeasurementStore {
     val isStreaming = props.getBooleanOrDefault("streamingAnimation", false)
 
     val rawMarkdown = props.getStringOrDefault("markdown", "")
-    val tableMode = if (isStreaming) id?.let { streamingTableModes[it] } ?: TableStreamingMode.HIDDEN else TableStreamingMode.HIDDEN
+    val tableMode =
+      if (isStreaming) {
+        id?.let {
+          streamingTableModes[it]
+        } ?: TableStreamingMode.PROGRESSIVE
+      } else {
+        TableStreamingMode.PROGRESSIVE
+      }
     val markdown =
       if (isStreaming) {
         StreamingMarkdownFilter.renderableMarkdownForStreaming(rawMarkdown, tableMode)

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
@@ -14,7 +14,7 @@ enum class TableStreamingMode {
 object StreamingMarkdownFilter {
   fun renderableMarkdownForStreaming(
     markdown: String,
-    tableMode: TableStreamingMode = TableStreamingMode.HIDDEN,
+    tableMode: TableStreamingMode = TableStreamingMode.PROGRESSIVE,
   ): String {
     val lines = markdown.split("\n")
     val afterMath = removePendingStreamingMathBlock(markdown, lines)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -201,21 +201,21 @@ Configuration for streaming behavior. Currently controls how incomplete tables a
 
 | Type                    | Default Value            | Platform |
 | ----------------------- | ------------------------ | -------- |
-| `{ tableMode: string }` | `{ tableMode: 'hidden' }` | Both     |
+| `{ tableMode: string }` | `{ tableMode: 'progressive' }` | Both     |
 
 #### `tableMode`
 
 Controls how incomplete (still-streaming) tables are rendered:
 
-- **`'hidden'`** (default): The entire table is hidden until it is complete (followed by a blank line). This prevents visual jank from partially formed tables.
-- **`'progressive'`**: The table is rendered row-by-row as content arrives. Requires at least a header row and separator line before anything is shown. Incomplete trailing rows (missing closing `|` or fewer columns than the header) are trimmed. New rows fade in with animation when `streamingAnimation` is also enabled.
+- **`'progressive'`** (default): The table is rendered row-by-row as content arrives. Requires at least a header row and separator line before anything is shown. Incomplete trailing rows (missing closing `|` or fewer columns than the header) are trimmed. New rows fade in with animation when `streamingAnimation` is also enabled.
+- **`'hidden'`**: The entire table is hidden until it is complete (followed by a blank line). This prevents visual jank from partially formed tables.
 
 ```tsx
 <EnrichedMarkdownText
   markdown={streamingMarkdown}
   flavor="github"
   streamingAnimation
-  streamingConfig={{ tableMode: 'progressive' }}
+  streamingConfig={{ tableMode: 'hidden' }}
 />
 ```
 

--- a/docs/MARKDOWN_STREAMING.md
+++ b/docs/MARKDOWN_STREAMING.md
@@ -23,7 +23,7 @@ The `streamingConfig` prop controls this behavior:
   markdown={streamingMarkdown}
   flavor="github"
   streamingAnimation
-  streamingConfig={{ tableMode: 'progressive' }}
+  streamingConfig={{ tableMode: 'hidden' }}
 />
 ```
 
@@ -31,6 +31,6 @@ The `streamingConfig` prop controls this behavior:
 
 | Mode | Behavior |
 |---|---|
-| `'hidden'` (default) | The table is completely hidden until it is followed by a blank line, indicating the table is complete. Prevents visual jank from partially formed tables. |
-| `'progressive'` | Renders the table row-by-row as content arrives. New rows fade in when `streamingAnimation` is enabled. Incomplete trailing rows are automatically trimmed. |
+| `'progressive'` (default) | Renders the table row-by-row as content arrives. New rows fade in when `streamingAnimation` is enabled. Incomplete trailing rows are automatically trimmed. |
+| `'hidden'` | The table is completely hidden until it is followed by a blank line, indicating the table is complete. Prevents visual jank from partially formed tables. |
 

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -130,7 +130,7 @@ static char kENRMSegmentFadeAnimatorKey;
     _selectable = YES;
     _enableLinkPreview = YES;
     _streamingAnimation = NO;
-    _tableStreamingMode = ENRMTableStreamingModeHidden;
+    _tableStreamingMode = ENRMTableStreamingModeProgressive;
     _selectionMenuConfig = (ENRMSelectionMenuConfig){.copyAsMarkdown = YES, .copyImageURL = YES};
 
     _fontScaleObserver = [[FontScaleObserver alloc] init];
@@ -702,8 +702,8 @@ static char kENRMSegmentFadeAnimatorKey;
   BOOL streamingConfigChanged = NO;
   if (newViewProps.streamingConfig.tableMode != oldViewProps.streamingConfig.tableMode) {
     NSString *tableModeStr = [[NSString alloc] initWithUTF8String:newViewProps.streamingConfig.tableMode.c_str()];
-    _tableStreamingMode = [tableModeStr isEqualToString:@"progressive"] ? ENRMTableStreamingModeProgressive
-                                                                        : ENRMTableStreamingModeHidden;
+    _tableStreamingMode =
+        [tableModeStr isEqualToString:@"hidden"] ? ENRMTableStreamingModeHidden : ENRMTableStreamingModeProgressive;
     streamingConfigChanged = YES;
     _dirtyFlags |= ENRMDirtyForceHeight;
   }
@@ -785,7 +785,7 @@ static char kENRMSegmentFadeAnimatorKey;
   _cachedMarkdown = nil;
   _renderedMarkdown = nil;
   _streamingAnimation = NO;
-  _tableStreamingMode = ENRMTableStreamingModeHidden;
+  _tableStreamingMode = ENRMTableStreamingModeProgressive;
   _dirtyFlags = ENRMDirtyNone;
 
   [super prepareForRecycle];

--- a/src/native/EnrichedMarkdownText.tsx
+++ b/src/native/EnrichedMarkdownText.tsx
@@ -135,7 +135,7 @@ export const EnrichedMarkdownText = ({
     [onTaskListItemPress]
   );
 
-  const tableMode = streamingConfig?.tableMode ?? 'hidden';
+  const tableMode = streamingConfig?.tableMode ?? 'progressive';
   const normalizedStreamingConfig = useMemo(() => ({ tableMode }), [tableMode]);
   const normalizedSelectionMenuConfig = useMemo(
     () => ({

--- a/src/types/MarkdownTextProps.ts
+++ b/src/types/MarkdownTextProps.ts
@@ -36,10 +36,10 @@ export interface SelectionMenuConfig {
 export interface StreamingConfig {
   /**
    * Controls how incomplete tables are handled during streaming.
-   * - `'hidden'` (default): hide the entire table until it's complete.
-   * - `'progressive'`: show the table row-by-row as rows complete.
+   * - `'hidden'`: hide the entire table until it's complete.
+   * - `'progressive'` (default): show the table row-by-row as rows complete.
    * Only effective when `streamingAnimation` is `true`.
-   * @default 'hidden'
+   * @default 'progressive'
    * @platform ios, android
    */
   tableMode?: 'hidden' | 'progressive';


### PR DESCRIPTION
### What/Why?
Change the default streamingConfig.tableMode from 'hidden' to 'progressive' so streaming tables render row-by-row out of the box instead of being hidden until complete.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

