### PR TITLE
fix(android): use value animators are animators enabled for reduced motion

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MotionPreferences.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MotionPreferences.kt
@@ -1,21 +1,18 @@
 package com.swmansion.enriched.markdown.utils.common
 
+import android.animation.ValueAnimator
 import android.content.Context
 import android.os.Build
-import android.view.accessibility.AccessibilityManager
 
 /**
  * Returns true when the user has asked the system to minimise motion.
  *
- * On API 26+ this maps to [AccessibilityManager.isAnimatorEnabled], which is the
- * platform signal for "Remove animations" (Settings > Accessibility) and the
- * "Animator duration scale" developer toggle. Older API levels do not expose an
+ * On API 26+ delegates to [ValueAnimator.areAnimatorsEnabled], which covers
+ * the "Remove animations" accessibility setting, the "Animator duration scale"
+ * developer toggle, and Battery Saver mode. Older API levels do not expose an
  * equivalent flag, so we fall back to allowing animations.
  */
 fun isReducedMotionEnabled(context: Context): Boolean {
   if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false
-  val am =
-    context.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
-      ?: return false
-  return !am.isAnimatorEnabled
+  return !ValueAnimator.areAnimatorsEnabled()
 }

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MotionPreferences.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MotionPreferences.kt
@@ -10,7 +10,7 @@ import android.os.Build
  * On API 26+ delegates to [ValueAnimator.areAnimatorsEnabled], which covers
  * the "Remove animations" accessibility setting, the "Animator duration scale"
  * developer toggle, and Battery Saver mode. Older API levels do not expose an
- * equivalent flag, so we fall back to allowing animations.
+ * equivalent flag, hence the fall back to allowing animations.
  */
 fun isReducedMotionEnabled(context: Context): Boolean {
   if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false


### PR DESCRIPTION
### What/Why?
`MotionPreferences.kt` referenced `AccessibilityManager.isAnimatorEnabled` which does not exist in the Android SDK, causing a compilation failure on Android.
                                                                             
Replaced with ValueAnimator.areAnimatorsEnabled() (API 26+), the correct   
platform API for detecting whether system animations are enabled. As a
bonus, this also covers Battery Saver mode, which disables animations      
system-wide and wasn't previously accounted for.

### Testing
Due to some other bug, android does not display animation character by character, it does work (and uses the same code) for table row animation.

In developer mode:
Set Animator duration scale in Developer Options to:                       
- 1x → table fade-in animations play during streaming
- Animation off (0x) → table fade-in animations are skipped, content       
appears instantly

#### Screenshots

##### Animations on 
https://github.com/user-attachments/assets/f28153dd-abf7-4ecc-afe4-11ca88517499

##### Animations off 

https://github.com/user-attachments/assets/939efb84-0c00-4bd0-85ee-7abcbec91361


### PR Checklist

- [x] ~Code compiles and runs on iOS~
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] ~E2E tests are passing~
- [x] ~Required E2E tests have been added (if applicable)~

