### PR TITLE
fix(ios): reset _props in prepareForRecycle to fix streaming animation on remount

### DIFF
--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -767,6 +767,7 @@ static char kENRMSegmentFadeAnimatorKey;
 
 - (void)prepareForRecycle
 {
+  _props = std::make_shared<const EnrichedMarkdownProps>();
   [_renderCoordinator invalidate];
 
   for (RCTUIView *segment in _segmentViews) {

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -524,6 +524,7 @@ using namespace facebook::react;
 
 - (void)prepareForRecycle
 {
+  _props = std::make_shared<const EnrichedMarkdownTextProps>();
   [_renderCoordinator invalidate];
 
   [_fadeAnimator cancel];


### PR DESCRIPTION
### What/Why?
Streaming animations stopped working after clearing and restarting an LLM stream. On recycled views, prepareForRecycle resets ivars but _props retained stale values, causing updateProps to miss the change. 
Fix: reset _props to defaults in prepareForRecycle so the diff works correctly on remount.

### Testing
<!-- How to test changed code? What testing has been done? -->

#### Screenshots

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/16023048-cb81-40e6-87f6-146ca6d7dc8a" width=300 /> | <video src="https://github.com/user-attachments/assets/06915bc0-c20e-4721-8024-a02a536cea28" width=300 /> |

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

