### PR TITLE
fix(android): update tail fade in animation to not reset

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -399,8 +399,7 @@ class EnrichedMarkdown
       if (!streamingAnimation) return
       val textLength = view.text?.length ?: 0
       if (textLength <= tailStart) return
-      val animator = TailFadeInAnimator(view)
-      animator.animate(tailStart, textLength)
+      TailFadeInAnimator(view).animate(tailStart, textLength)
     }
 
     private fun animateBlockViewFadeIn(view: View) {

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/TailFadeInAnimator.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/TailFadeInAnimator.kt
@@ -40,7 +40,7 @@ class TailFadeInAnimator(
           fadeSpan.alpha = anim.animatedValue as Float
           val tv = viewRef.get() ?: return@addUpdateListener
           val currentSpannable = tv.text as? Spannable ?: return@addUpdateListener
-          // Re-attach the span to the current text in case text was replaced mid-animation.
+
           val end = minOf(tailEnd, currentSpannable.length)
           if (end > tailStart) {
             currentSpannable.setSpan(fadeSpan, tailStart, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)

--- a/android/src/main/java/com/swmansion/enriched/markdown/utils/text/TailFadeInAnimator.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/utils/text/TailFadeInAnimator.kt
@@ -38,7 +38,14 @@ class TailFadeInAnimator(
 
         addUpdateListener { anim ->
           fadeSpan.alpha = anim.animatedValue as Float
-          viewRef.get()?.invalidate()
+          val tv = viewRef.get() ?: return@addUpdateListener
+          val currentSpannable = tv.text as? Spannable ?: return@addUpdateListener
+          // Re-attach the span to the current text in case text was replaced mid-animation.
+          val end = minOf(tailEnd, currentSpannable.length)
+          if (end > tailStart) {
+            currentSpannable.setSpan(fadeSpan, tailStart, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+          }
+          tv.invalidate()
         }
 
         addListener(


### PR DESCRIPTION
### What/Why?                                                                                           
                                                                                                    
Fixes the tail fade-in animation for plain text in the Android GFM (`flavor="github"`) streaming path.
 Previously, streaming text in the GFM flavor showed no animation at all - characters appeared
instantly at full opacity instead of fading in.                                                     
                                                                                                    
#### Root cause                                                                                          
   
The bug is in `TailFadeInAnimator`. When `animate(tailStart, tailEnd)` was called, it captured `spannable
 = textView.text` once at the start, attached a `FadeInSpan` to it, and then in the `ValueAnimator`   
update listener only updated `fadeSpan.alpha` and called `invalidate()`.                                
                                                                                                    
The problem: Android's `MarkdownSegmentRenderer` produces a fresh **SpannableString** on every render     
tick. When the next tick fires, `applyStyledText` sets a new SpannableString as `textView.text`. The
FadeInSpan was attached to the now-discarded old SpannableString. The `invalidate()` call triggered a 
redraw, but the current text had no FadeInSpan on it - so every frame was rendered at full opacity.     
                                                                                                    
#### Fix - TailFadeInAnimator.kt

The ValueAnimator update listener now fetches `textView.text` on every frame and re-attaches the      
FadeInSpan to whatever SpannableString is current:
                                                                                            
```kt
addUpdateListener { anim ->                                                                       
      fadeSpan.alpha = anim.animatedValue as Float
      val tv = viewRef.get() ?: return@addUpdateListener
      val currentSpannable = tv.text as? Spannable ?: return@addUpdateListener
      // Re-attach the span to the current text in case text was replaced mid-animation.              
      val end = minOf(tailEnd, currentSpannable.length)
      if (end > tailStart) {                                                                          
          currentSpannable.setSpan(fadeSpan, tailStart, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)      
      }
      tv.invalidate()                                                                                 
  }                                                                                                 
```

This mirrors exactly how the iOS implementation (ENRMTailFadeInAnimator.m) works: it accesses_textView.textStorage on every display link frame, not once at start. On iOS this is trivial because NSTextStorage is a persistent mutable object - always the same reference regardless of content changes. On Android there is no equivalent; the SpannableString is replaced each tick, so re-attaching on each frame is the Android-equivalent solution.                                                                                                                 
                                                                                                      
This matches the CommonMark path (`EnrichedMarkdownText.kt`), which has never called `cancelAll()`
between ticks.                                                                                      
                                                                                                    
### Testing

Open the Streaming markdown simulator screen in the example app (flavor="github",                   
streamingAnimation=true) on Android. Verify that plain text tokens fade in smoothly. Test at both
`TICK_MS=150` and `TICK_MS=80` to confirm no cut/flash at faster rates.  

#### Screenshots
(tick speed updated to 10 to show bigger difference)

###### Before

https://github.com/user-attachments/assets/4bc692be-6602-4aa8-a2b9-1eb4471e8e3e

##### After

https://github.com/user-attachments/assets/0bcf8a83-b50a-46d6-a043-d97259bf97bd

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [ ] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

