### PR TITLE
fix(ci): include library native sources in turbo cache inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock', 'android/**', 'src/**', 'cpp/**', 'apps/example/android/**') }}
           restore-keys: |
             ${{ runner.os }}-turborepo-android-
 
@@ -142,7 +142,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock', 'ios/**', 'src/**', 'cpp/**', 'apps/example/ios/**') }}
           restore-keys: |
             ${{ runner.os }}-turborepo-ios-
 

--- a/turbo.json
+++ b/turbo.json
@@ -7,15 +7,16 @@
       "env": ["ANDROID_HOME", "ORG_GRADLE_PROJECT_newArchEnabled"],
       "inputs": [
         "package.json",
-        "android",
-        "!android/build",
-        "src/*.ts",
-        "src/*.tsx",
-        "apps/example/package.json",
-        "apps/example/android",
-        "!apps/example/android/.gradle",
-        "!apps/example/android/build",
-        "!apps/example/android/app/build"
+        "android/**",
+        "!android/build/**",
+        "!android/.gradle/**",
+        "src/**",
+        "$TURBO_ROOT$/android/**",
+        "!$TURBO_ROOT$/android/build/**",
+        "!$TURBO_ROOT$/android/generated/**",
+        "$TURBO_ROOT$/src/**",
+        "$TURBO_ROOT$/cpp/**",
+        "$TURBO_ROOT$/package.json"
       ],
       "outputs": []
     },
@@ -28,14 +29,16 @@
       ],
       "inputs": [
         "package.json",
-        "*.podspec",
-        "ios",
-        "src/*.ts",
-        "src/*.tsx",
-        "apps/example/package.json",
-        "apps/example/ios",
-        "!apps/example/ios/build",
-        "!apps/example/ios/Pods"
+        "ios/**",
+        "!ios/build/**",
+        "!ios/Pods/**",
+        "src/**",
+        "$TURBO_ROOT$/ios/**",
+        "!$TURBO_ROOT$/ios/build/**",
+        "$TURBO_ROOT$/src/**",
+        "$TURBO_ROOT$/cpp/**",
+        "$TURBO_ROOT$/*.podspec",
+        "$TURBO_ROOT$/package.json"
       ],
       "outputs": []
     }


### PR DESCRIPTION
### What/Why?
Turbo was serving stale cache hits for build:android and build:ios because inputs only tracked files relative to apps/example, missing the library's android/, ios/, cpp/, and src/ directories at the workspace root. Use `$TURBO_ROOT$` to reference library sources and update the GitHub Actions cache key to hash native source files.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

