### PR TITLE
fix(ios): use mock view for measurement when style changes are pending

### DIFF
--- a/ios/EnrichedMarkdown.h
+++ b/ios/EnrichedMarkdown.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (CGSize)measureSize:(CGFloat)maxWidth;
 - (void)renderMarkdownSynchronously:(NSString *)markdownString;
 - (BOOL)hasRenderedMarkdown:(NSString *)markdown;
+- (BOOL)hasRenderedWithStyleFingerprint:(size_t)fingerprint;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -27,6 +27,7 @@
 #import "MarkdownASTNode.h"
 #import "MarkdownAccessibilityElementBuilder.h"
 #import "MarkdownExtractor.h"
+#import "MeasurementCache.h"
 #import "RenderedMarkdownSegment.h"
 #import "RuntimeKeys.h"
 #import "SegmentReconciler.h"
@@ -95,6 +96,9 @@ static char kENRMSegmentFadeAnimatorKey;
   BOOL _enableLinkPreview;
   BOOL _streamingAnimation;
   ENRMTableStreamingMode _tableStreamingMode;
+
+  size_t _renderedStyleFingerprint;
+  size_t _pendingStyleFingerprint;
 
   NSArray<NSString *> *_contextMenuItemTexts;
   NSArray<NSString *> *_contextMenuItemIcons;
@@ -306,6 +310,11 @@ static char kENRMSegmentFadeAnimatorKey;
   return _renderedMarkdown != nil && [_renderedMarkdown isEqualToString:markdown];
 }
 
+- (BOOL)hasRenderedWithStyleFingerprint:(size_t)fingerprint
+{
+  return _renderedStyleFingerprint == fingerprint;
+}
+
 - (BOOL)renderedSegmentsChangeTopology:(NSArray<ENRMRenderedSegment *> *)renderedSegments
 {
   if (renderedSegments.count != _segmentViews.count) {
@@ -374,7 +383,10 @@ static char kENRMSegmentFadeAnimatorKey;
             ENRMRenderSegmentsFromAST(ast, config, allowTrailingMargin, allowFontScaling, maxFontSizeMultiplier);
         return YES;
       }
-      apply:^{ [self applyRenderedSegments:renderedSegments renderedMarkdown:renderableMarkdown]; }];
+      apply:^{
+        self->_renderedStyleFingerprint = self->_pendingStyleFingerprint;
+        [self applyRenderedSegments:renderedSegments renderedMarkdown:renderableMarkdown];
+      }];
 }
 
 - (NSArray *)parseAndRenderSegments:(NSString *)markdownString
@@ -406,6 +418,7 @@ static char kENRMSegmentFadeAnimatorKey;
   NSString *renderableMarkdown =
       _streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString, _tableStreamingMode) : markdownString;
   _renderedMarkdown = [renderableMarkdown copy];
+  _renderedStyleFingerprint = _pendingStyleFingerprint;
 
   if (renderableMarkdown.length == 0) {
     return;
@@ -739,6 +752,8 @@ static char kENRMSegmentFadeAnimatorKey;
 
   if (markdownChanged || stylePropChanged || md4cFlagsChanged || allowTrailingMarginChanged ||
       streamingAnimationChanged || streamingConfigChanged) {
+    _pendingStyleFingerprint =
+        computeStyleFingerprint(newViewProps.markdownStyle) ^ std::hash<bool>{}(newViewProps.allowTrailingMargin);
     NSString *markdownString = [[NSString alloc] initWithUTF8String:newViewProps.markdown.c_str()];
     [self renderMarkdownContent:markdownString];
   }

--- a/ios/EnrichedMarkdownText.h
+++ b/ios/EnrichedMarkdownText.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (CGSize)measureSize:(CGFloat)maxWidth;
 - (void)renderMarkdownSynchronously:(NSString *)markdownString;
 - (BOOL)hasRenderedMarkdown:(NSString *)markdown;
+- (BOOL)hasRenderedWithStyleFingerprint:(size_t)fingerprint;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -20,6 +20,7 @@
 #import "MarkdownASTNode.h"
 #import "MarkdownAccessibilityElementBuilder.h"
 #import "MarkdownExtractor.h"
+#import "MeasurementCache.h"
 #import "ParagraphStyleUtils.h"
 #import "RuntimeKeys.h"
 #import "SelectionColorUtils.h"
@@ -74,6 +75,9 @@ using namespace facebook::react;
   BOOL _streamingAnimation;
   BOOL _forceHeightUpdateOnNextRender;
 
+  size_t _renderedStyleFingerprint;
+  size_t _pendingStyleFingerprint;
+
   NSUInteger _previousTextLength;
   ENRMTailFadeInAnimator *_fadeAnimator;
 
@@ -112,6 +116,11 @@ using namespace facebook::react;
 - (BOOL)hasRenderedMarkdown:(NSString *)markdown
 {
   return _renderedMarkdown != nil && [_renderedMarkdown isEqualToString:markdown];
+}
+
+- (BOOL)hasRenderedWithStyleFingerprint:(size_t)fingerprint
+{
+  return _renderedStyleFingerprint == fingerprint;
 }
 
 - (void)updateState:(const facebook::react::State::Shared &)state
@@ -265,6 +274,7 @@ using namespace facebook::react;
       apply:^{
         self->_lastElementMarginBottom = result.lastElementMarginBottom;
         self->_accessibilityInfo = result.accessibilityInfo;
+        self->_renderedStyleFingerprint = self->_pendingStyleFingerprint;
         [self applyRenderedText:result.attributedText];
       }];
 }
@@ -303,6 +313,7 @@ using namespace facebook::react;
 
   _textView.attributedText = attributedText;
   _renderedMarkdown = [_cachedMarkdown copy];
+  _renderedStyleFingerprint = _pendingStyleFingerprint;
 }
 
 - (void)applyRenderedText:(NSMutableAttributedString *)attributedText
@@ -497,6 +508,8 @@ using namespace facebook::react;
   }
 
   if (markdownChanged || stylePropChanged || md4cFlagsChanged || allowTrailingMarginChanged) {
+    _pendingStyleFingerprint =
+        computeStyleFingerprint(newViewProps.markdownStyle) ^ std::hash<bool>{}(newViewProps.allowTrailingMargin);
     NSString *markdownString = [[NSString alloc] initWithUTF8String:newViewProps.markdown.c_str()];
     [self renderMarkdownContent:markdownString];
   }

--- a/ios/internals/ShadowMeasurementUtils.h
+++ b/ios/internals/ShadowMeasurementUtils.h
@@ -101,9 +101,12 @@ static inline Size ENRMMeasureMarkdownContent(const PropsT &typedProps, const st
 
   __block CGSize size;
   NSString *currentMarkdown = typedProps.markdown.empty() ? nil : @(typedProps.markdown.c_str());
+  size_t styleFingerprint =
+      computeStyleFingerprint(typedProps.markdownStyle) ^ std::hash<bool>{}(typedProps.allowTrailingMargin);
 
   void (^measureBlock)(void) = ^{
-    if (view && (typedProps.streamingAnimation || [view hasRenderedMarkdown:currentMarkdown])) {
+    if (view && (typedProps.streamingAnimation || ([view hasRenderedMarkdown:currentMarkdown] &&
+                                                   [view hasRenderedWithStyleFingerprint:styleFingerprint]))) {
       size = [view measureSize:maxWidth];
     } else {
       ViewT *mockView = createMockView(maxWidth);

--- a/ios/renderer/AttributedRenderer.m
+++ b/ios/renderer/AttributedRenderer.m
@@ -83,7 +83,8 @@
 
   // 2. Trim trailing characters
   NSUInteger logicalEnd = NSMaxRange(lastContent);
-  if (isLastElementCodeBlock(output)) {
+  BOOL isCodeBlock = isLastElementCodeBlock(output);
+  if (isCodeBlock) {
     NSRange codeRange;
     [output attribute:CodeBlockAttributeName atIndex:lastContent.location effectiveRange:&codeRange];
     logicalEnd = NSMaxRange(codeRange);
@@ -94,7 +95,7 @@
   }
 
   // 3. Zero out internal spacing for the last element (if not a code block)
-  if (!isLastElementCodeBlock(output)) {
+  if (!isCodeBlock) {
     NSRange styleRange;
     NSParagraphStyle *style = [output attribute:NSParagraphStyleAttributeName
                                         atIndex:lastContent.location

--- a/ios/renderer/ParagraphRenderer.m
+++ b/ios/renderer/ParagraphRenderer.m
@@ -62,6 +62,7 @@
   if (shouldApplyMargin) {
     marginBottom = isBlockImage ? _config.imageMarginBottom : _config.paragraphMarginBottom;
   }
+
   applyParagraphSpacingAfter(output, start, marginBottom);
 }
 


### PR DESCRIPTION
### What/Why?
When markdownStyle overrides (e.g., paragraph.marginTop or paragraph.marginBottom) change at runtime, the Fabric shadow node's measurement function could read stale attributed text from the real view — the async re-render hadn't completed yet. This produced an incorrect height for Yoga, causing layout oscillation, clipping, or white-screen bugs.

The fix adds a style fingerprint check alongside the existing markdown-string check in the measurement path. When the fingerprint doesn't match (style changed but re-render is still in flight), measurement falls through to a fresh mock view that always produces the correct result.



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

