### PR TITLE
fix(android): defer setText until view is attached to prevent NPE in checkForResize

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -83,6 +83,8 @@ class EnrichedMarkdownText
       private set
     var spoilerOverlay: SpoilerOverlay = SpoilerOverlay.PARTICLES
 
+    private var pendingStyledText: CharSequence? = null
+
     private var selectionColor: Int? = null
     private var selectionHandleColor: Int? = null
     private var selectionMenuConfig = SelectionMenuConfig()
@@ -211,7 +213,7 @@ class EnrichedMarkdownText
         try {
           val ast =
             parser.parseMarkdown(markdown, md4cFlags) ?: run {
-              mainHandler.post { if (renderId == currentRenderId) text = "" }
+              mainHandler.post { if (renderId == currentRenderId && isAttachedToWindow) text = "" }
               return@execute
             }
 
@@ -220,12 +222,16 @@ class EnrichedMarkdownText
 
           mainHandler.post {
             if (renderId == currentRenderId) {
-              applyRenderedText(styledText)
+              if (isAttachedToWindow) {
+                applyRenderedText(styledText)
+              } else {
+                pendingStyledText = styledText
+              }
             }
           }
         } catch (e: Exception) {
           Log.e(TAG, "Render failed: ${e.message}", e)
-          mainHandler.post { if (renderId == currentRenderId) text = "" }
+          mainHandler.post { if (renderId == currentRenderId && isAttachedToWindow) text = "" }
         }
       }
     }
@@ -302,6 +308,14 @@ class EnrichedMarkdownText
 
     fun setOnTaskListItemPressCallback(callback: ((taskIndex: Int, checked: Boolean, itemText: String) -> Unit)?) {
       checkboxTouchHelper.onCheckboxTap = callback
+    }
+
+    override fun onAttachedToWindow() {
+      super.onAttachedToWindow()
+      pendingStyledText?.let {
+        pendingStyledText = null
+        applyRenderedText(it)
+      }
     }
 
     override fun onDetachedFromWindow() {


### PR DESCRIPTION
### What/Why?
Fixes: #338 

Fixes a NullPointerException crash in TextView.checkForResize() on Android. The async markdown renderer could complete and call setText before the view was attached to the window (no LayoutParams yet).

Now we store the result in pendingStyledText and apply it in onAttachedToWindow.

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

