### PR TITLE
fix(android): avoid duplicate libc++ in instrumentation builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,6 +47,17 @@ android {
     }
   }
 
+  packaging {
+    jniLibs {
+      // Android test APK builds merge native libraries from this module and
+      // react-android. AndroidMath also ships libc++_shared.so, so keep a
+      // single copy to avoid duplicate native library failures in Detox and
+      // other instrumentation builds. Remove this workaround after migrating
+      // away from AndroidMath if the new math backend does not package it.
+      pickFirsts += ["**/libc++_shared.so"]
+    }
+  }
+
   lintOptions {
     disable "GradleCompatible"
   }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,14 @@ android {
       // away from AndroidMath if the new math backend does not package it.
       pickFirsts += ["**/libc++_shared.so"]
     }
+
+    resources {
+      // AndroidMath pulls in appcompat/lifecycle dependencies that can bring
+      // both coroutines-core and coroutines-android into androidTest packaging.
+      // They ship the same ProGuard metadata file, so keep one copy to avoid
+      // mergeDebugAndroidTestJavaResource failures. Revisit with AndroidMath.
+      pickFirsts += ["META-INF/com.android.tools/proguard/coroutines.pro"]
+    }
   }
 
   lintOptions {


### PR DESCRIPTION
### What/Why?

Fixes: #342 

Adds an Android packaging rule for `libc++_shared.so` in the library module. `AndroidMath` and `react-android` both package the shared C++ runtime, which can make Android instrumentation or Detox test builds fail during native library merging.

Keeping a single copy avoids the duplicate native library error for consumers while AndroidMath is still used as the Android math backend.

### Testing
<!-- How to test changed code? What testing has been done? -->


<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

