### PR TITLE
fix(android): prevent duplicate input context menu items

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/input/toolbar/InputContextMenu.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/toolbar/InputContextMenu.kt
@@ -37,6 +37,8 @@ class InputContextMenu(
           mode: ActionMode,
           menu: Menu,
         ): Boolean {
+          menu.removeItem(MENU_FORMAT_ID)
+          menu.removeItem(MENU_COPY_MARKDOWN_ID)
           menu.removeGroup(FORMAT_MENU_GROUP_ID)
           menu.removeGroup(CUSTOM_MENU_GROUP_ID)
 


### PR DESCRIPTION
### What/Why?
Fixes: #346 

Fixes duplicate `Copy as Markdown` actions in the Android `EnrichedMarkdownTextInput` selection context menu.
Android may call `onPrepareActionMode` multiple times for the same selection menu. The input context menu now explicitly removes known menu items by ID before rebuilding the menu, making the preparation step idempotent and preventing duplicate actions from accumulating.

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

