### PR TITLE
fix(plugin): use named imports from @expo/config-plugins so the plugin loads under tsx/cjs

### DIFF
--- a/src/plugin/withAndroidMath.ts
+++ b/src/plugin/withAndroidMath.ts
@@ -1,6 +1,4 @@
-import configPlugins, { type ConfigPlugin } from '@expo/config-plugins';
-
-const { withGradleProperties } = configPlugins;
+import { withGradleProperties, type ConfigPlugin } from '@expo/config-plugins';
 
 export const withAndroidMath: ConfigPlugin<{ enableMath?: boolean }> = (
   config,

--- a/src/plugin/withIosMath.ts
+++ b/src/plugin/withIosMath.ts
@@ -1,8 +1,6 @@
-import configPlugins, { type ConfigPlugin } from '@expo/config-plugins';
+import { withDangerousMod, type ConfigPlugin } from '@expo/config-plugins';
 import fs from 'fs';
 import path from 'path';
-
-const { withDangerousMod } = configPlugins;
 
 const IOS_MATH_OPTION = "ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] = '0'";
 


### PR DESCRIPTION
## Summary

The Expo config plugin files use a default-import + destructure pattern against `@expo/config-plugins`:

```ts
import configPlugins, { type ConfigPlugin } from '@expo/config-plugins';
const { withDangerousMod } = configPlugins;
```

`@expo/config-plugins` is a pure CJS module with named exports and **no default export**. The published `lib/module/plugin/*.js` keeps these as raw ESM `import` statements, so when a consumer's `app.config.ts` uses `tsx/cjs` (a very common Expo setup), the default import resolves to `undefined` and the top-level destructure throws at module load — before the plugin's own `enableMath: false` check can run.

The trace from #192:

```
PluginError: Unable to resolve a valid config plugin for react-native-enriched-markdown.
TypeError: Cannot destructure property 'withDangerousMod' of 'import_config_plugins.default' as it is undefined.
  at fs (.../lib/module/plugin/withIosMath.js:7:3)
```

Switching to named imports compiles to direct property access — no `__importDefault` interop helper needed, no `default` lookup at runtime.

## How to reproduce

1. Expo SDK 55 project with an `app.config.ts` whose first line is `import 'tsx/cjs';`.
2. Add the plugin to `plugins`: `['react-native-enriched-markdown', { enableMath: false }]`.
3. `npx expo prebuild` → error above.

After this patch, prebuild runs through, `enableMath: false` is honoured, and the generated `ios/Podfile` and `android/gradle.properties` contain the expected `ENRICHED_MARKDOWN_ENABLE_MATH=0` / `enrichedMarkdown.enableMath=false` entries.

## Risks

None functional — the change is purely import shape. The compiled output drops a level of indirection but produces the same `withDangerousMod`/`withGradleProperties` references at call time. `yarn typecheck`, `yarn lint`, and `yarn prepare` all pass locally.

Closes #192.
