### PR TITLE
fix: remove podfile lock removal from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         with:
           path: |
             **/ios/Pods
-          key: ${{ steps.cocoapods-cache.outputs.cache-key }}
+          key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
 
       - name: Build example for iOS
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           xcode-version: '16.4'
 
       - name: Reset build folder and pods
-        run: rm -rf apps/example/build apps/example/ios/Pods apps/example/ios/Podfile.lock
+        run: rm -rf apps/example/build apps/example/ios/Pods
 
       - name: Cache turborepo for iOS
         uses: actions/cache@v4


### PR DESCRIPTION
### What/Why?

The iOS CI build was never using turborepo or cocoapods caches due to Podfile.lock being deleted before the cache check steps ran.        
                                                                     
The reset step was running `rm -rf apps/example/build apps/example/ios/Pods apps/example/ios/Podfile.lock` which caused two issues:                                                              
                                                                       
1. Turborepo cache miss — Podfile.lock is part of turborepo's build:ios inputs (ios/**). Deleting it before the dry-run check caused turborepo to compute a different hash than what was stored →  miss every run.                                                      
2. Cocoapods cache miss — the cocoapods cache key is `hashFiles('apps/example/ios/Podfile.lock')`. With the file deleted, the hash was empty → miss every run.                                 
                                                                       
Keeping Podfile.lock is correct for CI since it's committed to git and ensures reproducible pod version resolution.                     
                                                                       
#### Testing                                                              
                                                                       
No functional change — CI should now correctly hit turborepo and cocoapods caches on runs where no iOS-related files changed.

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

