### PR TITLE
latex: upgrade iosMath 2.2.0

### DIFF
--- a/ReactNativeEnrichedMarkdown.podspec
+++ b/ReactNativeEnrichedMarkdown.podspec
@@ -22,11 +22,15 @@ Pod::Spec.new do |s|
   preprocessor_defs = '$(inherited) MD4C_USE_UTF8=1'
   if enable_math
     preprocessor_defs += ' ENRICHED_MARKDOWN_MATH=1'
-    s.dependency 'iosMath', '~> 0.9'
+     spm_dependency(s,
+      url: 'https://github.com/kostub/iosMath.git',
+      requirement: { kind: 'upToNextMajorVersion', minimumVersion: '2.2.0' },
+      products: ['iosMath']
+    )
   end
 
   s.pod_target_xcconfig = {
-    'HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)/cpp/md4c" "$(PODS_TARGET_SRCROOT)/cpp/parser" "$(PODS_TARGET_SRCROOT)/ios/internals" "$(PODS_TARGET_SRCROOT)/ios/input/internals"',
+    'HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)/cpp/md4c" "$(PODS_TARGET_SRCROOT)/cpp/parser" "$(PODS_TARGET_SRCROOT)/ios/internals" "$(PODS_TARGET_SRCROOT)/ios/input/internals" "$(SYMROOT)/../../SourcePackages/checkouts/iosMath/iosMath/lib" "$(SYMROOT)/../../SourcePackages/checkouts/iosMath/iosMath/render" "$(SYMROOT)/../../SourcePackages/checkouts/iosMath/iosMath/render/internal"',
     'GCC_PREPROCESSOR_DEFINITIONS' => preprocessor_defs,
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17'
   }

--- a/ios/attachments/ENRMMathInlineAttachmentShared.h
+++ b/ios/attachments/ENRMMathInlineAttachmentShared.h
@@ -3,7 +3,7 @@
 #import "ENRMMathInlineAttachment.h"
 
 #if ENRICHED_MARKDOWN_MATH
-#import <IosMath/IosMath.h>
+@import iosMath;
 
 @interface ENRMMathInlineAttachment () {
   CGSize _cachedSize;

--- a/ios/views/ENRMMathContainerView.m
+++ b/ios/views/ENRMMathContainerView.m
@@ -4,7 +4,7 @@
 
 #if ENRICHED_MARKDOWN_MATH
 #import "PasteboardUtils.h"
-#import <IosMath/IosMath.h>
+@import iosMath;
 #if TARGET_OS_OSX
 #import "ENRMMenuAction.h"
 #endif


### PR DESCRIPTION
### What/Why?
Upgrade iosMath which has recently fixed many math rendering issues 
https://github.com/kostub/iosMath/releases

The recent package is published on SPM only, switching to SPM works but requires adding the header search paths (iosMath resolves 3 sibling directories). 

Note: 
The flag set [here](https://github.com/software-mansion-labs/react-native-enriched-markdown/blob/af2d2f863fde6b7d6c21064433fb3274ae2c7496/ios/utils/ENRMFeatureFlags.h#L4) will only rely on the flag set in cocoapods spec, the check on `<iosMath.h` won't work 
