### PR TITLE
feat: add writingToolsBehavior prop to EnrichedMarkdownTextInput (iOS 18+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Build library and generate codegen
+      - name: Build library
         run: yarn prepare
 
       - name: Set up Xcode
@@ -135,8 +135,8 @@ jobs:
         with:
           xcode-version: '16.4'
 
-      - name: Reset build folder
-        run: rm -rf apps/example/build
+      - name: Reset build folder and pods
+        run: rm -rf apps/example/build apps/example/ios/Pods apps/example/ios/Podfile.lock
 
       - name: Cache turborepo for iOS
         uses: actions/cache@v4
@@ -166,9 +166,8 @@ jobs:
             ${{ runner.os }}-cocoapods-
 
       - name: Install cocoapods
-        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
+        if: env.turbo_cache_hit != 1
         run: |
-          rm -rf apps/example/ios/Pods
           cd apps/example/ios
           pod install
         env:

--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
@@ -296,6 +296,14 @@ class EnrichedMarkdownTextInputManager :
     view?.setMentionIndicators(indicators)
   }
 
+  @ReactProp(name = "writingToolsBehavior")
+  override fun setWritingToolsBehavior(
+    view: EnrichedMarkdownTextInputView?,
+    value: String?,
+  ) {
+    // iOS-only prop, no-op on Android
+  }
+
   override fun updateProperties(
     view: EnrichedMarkdownTextInputView,
     props: ReactStylesDiffMap,

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -442,6 +442,37 @@ Style for the input view. Accepts `ViewStyle` and `TextStyle` properties (e.g., 
 | ----------------------- | ------------- | -------- |
 | `ViewStyle \| TextStyle` | -             | Both     |
 
+### `writingToolsBehavior`
+
+Controls the Writing Tools experience (rewrite, proofread, etc.) in the text selection menu. Maps to `UIWritingToolsBehavior` (iOS 18+). On earlier iOS versions and on Android, this prop is ignored.
+
+| Type                                              | Default Value | Platform |
+| ------------------------------------------------- | ------------- | -------- |
+| `'default' \| 'none' \| 'limited' \| 'complete'` | `'default'`   | iOS      |
+
+**Values:**
+
+- **`'default'`** — system chooses the appropriate experience for the current device.
+- **`'none'`** — disable Writing Tools for this field entirely.
+- **`'limited'`** — panel-only experience (no inline rewrite).
+- **`'complete'`** — full experience including inline rewrite.
+
+**Example:**
+
+```tsx
+// Disable Writing Tools for a sensitive input
+<EnrichedMarkdownTextInput
+  writingToolsBehavior="none"
+  placeholder="Enter password..."
+/>
+
+// Full inline Writing Tools experience
+<EnrichedMarkdownTextInput
+  writingToolsBehavior="complete"
+  placeholder="Write something..."
+/>
+```
+
 ### Events
 
 ### `onChangeText`

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -457,22 +457,6 @@ Controls the Writing Tools experience (rewrite, proofread, etc.) in the text sel
 - **`'limited'`** — panel-only experience (no inline rewrite).
 - **`'complete'`** — full experience including inline rewrite.
 
-**Example:**
-
-```tsx
-// Disable Writing Tools for a sensitive input
-<EnrichedMarkdownTextInput
-  writingToolsBehavior="none"
-  placeholder="Enter password..."
-/>
-
-// Full inline Writing Tools experience
-<EnrichedMarkdownTextInput
-  writingToolsBehavior="complete"
-  placeholder="Write something..."
-/>
-```
-
 ### Events
 
 ### `onChangeText`

--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -274,6 +274,24 @@ using namespace facebook::react;
     _textView.textContainer.lineBreakMode =
         newViewProps.multiline ? NSLineBreakByWordWrapping : NSLineBreakByTruncatingTail;
   }
+
+  if (newViewProps.writingToolsBehavior != oldViewProps.writingToolsBehavior) {
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 180000
+    if (@available(iOS 18.0, *)) {
+      id<UITextInputTraits> textInputTraits = (id<UITextInputTraits>)_textView;
+      NSString *value = [NSString stringWithUTF8String:newViewProps.writingToolsBehavior.c_str()];
+      if ([value isEqualToString:@"none"]) {
+        textInputTraits.writingToolsBehavior = UIWritingToolsBehaviorNone;
+      } else if ([value isEqualToString:@"limited"]) {
+        textInputTraits.writingToolsBehavior = UIWritingToolsBehaviorLimited;
+      } else if ([value isEqualToString:@"complete"]) {
+        textInputTraits.writingToolsBehavior = UIWritingToolsBehaviorComplete;
+      } else {
+        textInputTraits.writingToolsBehavior = UIWritingToolsBehaviorDefault;
+      }
+    }
+#endif
+  }
 #endif
 
   if (newViewProps.placeholder != oldViewProps.placeholder) {

--- a/src/EnrichedMarkdownTextInput.tsx
+++ b/src/EnrichedMarkdownTextInput.tsx
@@ -139,6 +139,18 @@ export interface EnrichedMarkdownTextInputProps {
   onBlur?: () => void;
   contextMenuItems?: ContextMenuItem[];
   linkRegex?: RegExp | null;
+  /**
+   * Controls the Writing Tools experience (rewrite, proofread, etc.) in the text
+   * selection menu. Maps to `UIWritingToolsBehavior` (iOS 18+).
+   *
+   * - `'default'`: system chooses the appropriate experience
+   * - `'none'`: disable Writing Tools for this field
+   * - `'limited'`: panel-only experience (no inline rewrite)
+   * - `'complete'`: full experience including inline rewrite
+   *
+   * @platform ios
+   */
+  writingToolsBehavior?: 'default' | 'none' | 'limited' | 'complete';
 }
 
 type PendingRequest<T> = {
@@ -183,6 +195,7 @@ export const EnrichedMarkdownTextInput = ({
   onBlur,
   contextMenuItems,
   linkRegex: _linkRegex,
+  writingToolsBehavior,
 }: EnrichedMarkdownTextInputProps) => {
   const nativeRef = useRef<NativeRef | null>(null);
 
@@ -446,6 +459,7 @@ export const EnrichedMarkdownTextInput = ({
       onStartMention={handleStartMention as NativeProps['onStartMention']}
       onChangeMention={handleChangeMention as NativeProps['onChangeMention']}
       onEndMention={handleEndMention as NativeProps['onEndMention']}
+      writingToolsBehavior={writingToolsBehavior}
     />
   );
 };

--- a/src/EnrichedMarkdownTextInputNativeComponent.ts
+++ b/src/EnrichedMarkdownTextInputNativeComponent.ts
@@ -210,6 +210,19 @@ export interface NativeProps extends ViewProps {
    */
   mentionIndicators?: ReadonlyArray<string>;
 
+  /**
+   * Controls the Writing Tools experience (rewrite, proofread, etc.) in the text
+   * selection menu. Maps to `UIWritingToolsBehavior` (iOS 18+).
+   *
+   * - `'default'`: system chooses the appropriate experience
+   * - `'none'`: disable Writing Tools for this field
+   * - `'limited'`: panel-only experience (no inline rewrite)
+   * - `'complete'`: full experience including inline rewrite
+   *
+   * @platform ios
+   */
+  writingToolsBehavior?: string;
+
   // Events
   onChangeText?: CodegenTypes.DirectEventHandler<OnChangeTextEvent>;
   onChangeMarkdown?: CodegenTypes.DirectEventHandler<OnChangeMarkdownEvent>;


### PR DESCRIPTION
### What/Why?
iOS 18 **introduced** Writing Tools (rewrite, proofread, etc.) in the text selection menu. This adds a writingToolsBehavior prop to EnrichedMarkdownTextInput so apps can control or disable this experience per field.

Maps to UIWritingToolsBehavior with values: 'default', 'none', 'limited', 'complete'. Safely ignored on iOS < 18 and Android.

Mirrors [facebook/react-native#57009](https://github.com/facebook/react-native/pull/57009)

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

