### PR TITLE
fix(ci): fix iOS build by removing stale codegen reset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Build library and generate codegen
+      - name: Build library
         run: yarn prepare
 
       - name: Set up Xcode
@@ -135,8 +135,8 @@ jobs:
         with:
           xcode-version: '16.4'
 
-      - name: Reset build folder
-        run: rm -rf apps/example/build
+      - name: Reset build folder and pods
+        run: rm -rf apps/example/build apps/example/ios/Pods apps/example/ios/Podfile.lock
 
       - name: Cache turborepo for iOS
         uses: actions/cache@v4
@@ -166,9 +166,8 @@ jobs:
             ${{ runner.os }}-cocoapods-
 
       - name: Install cocoapods
-        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
+        if: env.turbo_cache_hit != 1
         run: |
-          rm -rf apps/example/ios/Pods
           cd apps/example/ios
           pod install
         env:


### PR DESCRIPTION
### What/Why?

The iOS CI build was failing with:
```
[!] No podspec found for `ReactAppDependencyProvider` in `build/generated/ios/ReactAppDependencyProvider`
```

The cocoapods cache could restore `Pods/` without the corresponding `build/generated/ios/` artifacts, causing `pod install` to be skipped while codegen files were missing. When `react-native build-ios` then ran its own `pod install`, it failed because `ReactAppDependencyProvider` didn't exist.

### Changes

- Reset `build/`, `Pods/`, and `Podfile.lock` together
- Always run `pod install` when turbo cache misses — deleting `Podfile.lock` ensures the cocoapods cache primary key never matches, so `pod install` always regenerates app codegen artifacts (`ReactAppDependencyProvider`)
- Keep cocoapods cache restore via `restore-keys` prefix match as a warm start for faster installs
- Keep `yarn prepare` (needed for library codegen — `EventEmitters.h`, `Props.h`)