### PR TITLE
fix(android): task list press not working

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -1,7 +1,6 @@
 package com.swmansion.enriched.markdown
 
 import android.content.Context
-import android.util.Log
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -1,6 +1,7 @@
 package com.swmansion.enriched.markdown
 
 import android.content.Context
+import android.util.Log
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
@@ -38,6 +39,23 @@ class EnrichedMarkdownManager :
     view.onContextMenuItemPressCallback = { itemText, selectedText, selectionStart, selectionEnd ->
       emitContextMenuItemPress(view, itemText, selectedText, selectionStart, selectionEnd)
     }
+
+    view.setOnLinkPressCallback { url ->
+      emitLinkPress(view, url)
+    }
+
+    view.setOnLinkLongPressCallback { url ->
+      emitLinkLongPress(view, url)
+    }
+
+    view.setOnTaskListItemPressCallback { taskIndex, checked, itemText ->
+      val newChecked = !checked
+      val updatedMarkdown = TaskListToggleUtils.toggleAtIndex(view.currentMarkdown, taskIndex, newChecked)
+      view.setMarkdownContent(updatedMarkdown)
+      view.commitProps()
+      emitTaskListItemPress(view, taskIndex, newChecked, itemText)
+    }
+
     return view
   }
 
@@ -60,21 +78,6 @@ class EnrichedMarkdownManager :
     view: EnrichedMarkdown?,
     markdown: String?,
   ) {
-    view?.setOnLinkPressCallback { url ->
-      emitLinkPress(view, url)
-    }
-
-    view?.setOnLinkLongPressCallback { url ->
-      emitLinkLongPress(view, url)
-    }
-
-    view?.setOnTaskListItemPressCallback { taskIndex, checked, itemText ->
-      val newChecked = !checked
-      val updatedMarkdown = TaskListToggleUtils.toggleAtIndex(view.currentMarkdown, taskIndex, newChecked)
-      view.setMarkdownContent(updatedMarkdown)
-      emitTaskListItemPress(view, taskIndex, newChecked, itemText)
-    }
-
     view?.setMarkdownContent(markdown ?: "")
   }
 

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -38,31 +38,16 @@ class EnrichedMarkdownTextManager :
     view.onContextMenuItemPressCallback = { itemText, selectedText, selectionStart, selectionEnd ->
       emitContextMenuItemPress(view, itemText, selectedText, selectionStart, selectionEnd)
     }
-    return view
-  }
 
-  override fun onDropViewInstance(view: EnrichedMarkdownText) {
-    super.onDropViewInstance(view)
-    MeasurementStore.clearFontScalingSettings(view.id)
-    view.layoutManager.releaseMeasurementStore()
-  }
-
-  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> = markdownEventTypeConstants()
-
-  @ReactProp(name = "markdown")
-  override fun setMarkdown(
-    view: EnrichedMarkdownText?,
-    markdown: String?,
-  ) {
-    view?.setOnLinkPressCallback { url ->
+    view.setOnLinkPressCallback { url ->
       emitLinkPress(view, url)
     }
 
-    view?.setOnLinkLongPressCallback { url ->
+    view.setOnLinkLongPressCallback { url ->
       emitLinkLongPress(view, url)
     }
 
-    view?.setOnTaskListItemPressCallback { taskIndex, checked, itemText ->
+    view.setOnTaskListItemPressCallback { taskIndex, checked, itemText ->
       val newChecked = !checked
 
       val styleConfig = view.markdownStyle
@@ -80,8 +65,23 @@ class EnrichedMarkdownTextManager :
 
       emitTaskListItemPress(view, taskIndex, newChecked, itemText)
     }
+    return view
+  }
 
-    view?.setMarkdownContent(markdown ?: "No markdown content")
+  override fun onDropViewInstance(view: EnrichedMarkdownText) {
+    super.onDropViewInstance(view)
+    MeasurementStore.clearFontScalingSettings(view.id)
+    view.layoutManager.releaseMeasurementStore()
+  }
+
+  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> = markdownEventTypeConstants()
+
+  @ReactProp(name = "markdown")
+  override fun setMarkdown(
+    view: EnrichedMarkdownText?,
+    markdown: String?,
+  ) {
+    view?.setMarkdownContent(markdown ?: "")
   }
 
   @ReactProp(name = "markdownStyle")


### PR DESCRIPTION
### What/Why?
Fix task list checkbox toggle not re-rendering in flavor="github" on Android.

In the _github_ flavor (`EnrichedMarkdown`), `setMarkdownContent` only sets a `renderPending` flag - the actual render is deferred until `commitProps()` is called, which only happens during a React prop update cycle (`onAfterUpdateTransaction`). When a checkbox was tapped, the callback called `setMarkdownContent(updatedMarkdown)` but `commitProps()` was never called, so the render never fired.

Additionally, event callbacks (link press, link long press, task list item press) were incorrectly set inside the `@ReactProp setMarkdown` setter in both `EnrichedMarkdownManager` and `EnrichedMarkdownTextManager`, causing them to be re-registered on every React prop update. Moved all callbacks to `createViewInstance` where one-time view setup belongs.

### Testing
Open playground
Create any task list for example

```
- [ ] test
- [x] test2
```

### Android

https://github.com/user-attachments/assets/fdf2f134-e478-4aa6-af60-a09082d920eb

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

