### PR TITLE
fix(ios): remove whitespace in code block for padding 0

### DIFF
--- a/ios/renderer/CodeBlockRenderer.m
+++ b/ios/renderer/CodeBlockRenderer.m
@@ -22,10 +22,13 @@
   blockStart += applyBlockSpacingBefore(output, blockStart, marginTop);
 
   // Top Padding: Inserted as a spacer character inside the background area
-  [output appendAttributedString:kNewlineAttributedString];
-  NSMutableParagraphStyle *topSpacerStyle = [context spacerStyleWithHeight:padding spacing:0];
-  topSpacerStyle.baseWritingDirection = NSWritingDirectionLeftToRight;
-  [output addAttribute:NSParagraphStyleAttributeName value:topSpacerStyle range:NSMakeRange(blockStart, 1)];
+  // apply only when positive
+  if (padding > 0) {
+    [output appendAttributedString:kNewlineAttributedString];
+    NSMutableParagraphStyle *topSpacerStyle = [context spacerStyleWithHeight:padding spacing:0];
+    topSpacerStyle.baseWritingDirection = NSWritingDirectionLeftToRight;
+    [output addAttribute:NSParagraphStyleAttributeName value:topSpacerStyle range:NSMakeRange(blockStart, 1)];
+  }
 
   NSUInteger contentStart = output.length;
   @try {
@@ -63,11 +66,16 @@
   [output addAttribute:NSParagraphStyleAttributeName value:baseStyle range:contentRange];
 
   // Bottom Padding: Inserted as a spacer character inside the background area
-  NSUInteger bottomPaddingStart = output.length;
-  [output appendAttributedString:kNewlineAttributedString];
-  NSMutableParagraphStyle *bottomPaddingStyle = [context spacerStyleWithHeight:padding spacing:0];
-  bottomPaddingStyle.baseWritingDirection = NSWritingDirectionLeftToRight;
-  [output addAttribute:NSParagraphStyleAttributeName value:bottomPaddingStyle range:NSMakeRange(bottomPaddingStart, 1)];
+  // apply it only when positive
+  if (padding > 0) {
+    NSUInteger bottomPaddingStart = output.length;
+    [output appendAttributedString:kNewlineAttributedString];
+    NSMutableParagraphStyle *bottomPaddingStyle = [context spacerStyleWithHeight:padding spacing:0];
+    bottomPaddingStyle.baseWritingDirection = NSWritingDirectionLeftToRight;
+    [output addAttribute:NSParagraphStyleAttributeName
+                   value:bottomPaddingStyle
+                   range:NSMakeRange(bottomPaddingStart, 1)];
+  }
 
   // Define the range for background rendering (includes padding, excludes margins)
   NSRange backgroundRange = NSMakeRange(blockStart, output.length - blockStart);


### PR DESCRIPTION
### What/Why?
When `padding: 0` is set for code block styles, an unexpected empty line appeared at the top and bottom of the code block. 

This happened because the top and bottom padding spacer newlines (`kNewlineAttributedString`) were unconditionally appended even when `padding` is `0`. TextKit still renders a paragraph for that newline using the font's minimum line height, resulting in a visible empty line.

### Testing
1. Open Playground
2. Type multiline code block (at least 2 lines)
3. Set `padding: 0` in code block styles (and remove other styles to isolate the result)
4. Render a markdown string with a multiline code block
5. Verify no empty line appears at the top or bottom of the code block

### Screenshots

| before | after |
| -- | -- |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/c9ced384-f14d-4b7a-9ac1-019b876db064" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/623c2a74-ae76-48e7-9635-d0d025a1c4a7" /> |

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

 closes #351 