### PR TITLE
feat: forward nativeID and testID to the native input

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -442,6 +442,22 @@ Style for the input view. Accepts `ViewStyle` and `TextStyle` properties (e.g., 
 | ----------------------- | ------------- | -------- |
 | `ViewStyle \| TextStyle` | -             | Both     |
 
+### `nativeID`
+
+Identifier forwarded to the underlying native view. Useful for integrations that need to reference the input natively, e.g. `react-native-keyboard-controller`'s `textInputNativeID`.
+
+| Type     | Default Value | Platform |
+| -------- | ------------- | -------- |
+| `string` | -             | Both     |
+
+### `testID`
+
+Identifier forwarded to the underlying native view for use in end-to-end and unit tests.
+
+| Type     | Default Value | Platform |
+| -------- | ------------- | -------- |
+| `string` | -             | Both     |
+
 ### Events
 
 ### `onChangeText`

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -442,22 +442,6 @@ Style for the input view. Accepts `ViewStyle` and `TextStyle` properties (e.g., 
 | ----------------------- | ------------- | -------- |
 | `ViewStyle \| TextStyle` | -             | Both     |
 
-### `nativeID`
-
-Identifier forwarded to the underlying native view. Useful for integrations that need to reference the input natively, e.g. `react-native-keyboard-controller`'s `textInputNativeID`.
-
-| Type     | Default Value | Platform |
-| -------- | ------------- | -------- |
-| `string` | -             | Both     |
-
-### `testID`
-
-Identifier forwarded to the underlying native view for use in end-to-end and unit tests.
-
-| Type     | Default Value | Platform |
-| -------- | ------------- | -------- |
-| `string` | -             | Both     |
-
 ### Events
 
 ### `onChangeText`

--- a/src/EnrichedMarkdownTextInput.tsx
+++ b/src/EnrichedMarkdownTextInput.tsx
@@ -31,6 +31,7 @@ export type {
 import type {
   HostInstance,
   NativeSyntheticEvent,
+  ViewProps,
   ViewStyle,
   TextStyle,
   ColorValue,
@@ -111,7 +112,8 @@ export interface EnrichedMarkdownTextInputInstance {
   getCaretRect: () => Promise<CaretRect>;
 }
 
-export interface EnrichedMarkdownTextInputProps {
+export interface EnrichedMarkdownTextInputProps
+  extends Omit<ViewProps, 'style'> {
   ref?: RefObject<EnrichedMarkdownTextInputInstance | null>;
   defaultValue?: string;
   placeholder?: string;
@@ -125,10 +127,6 @@ export interface EnrichedMarkdownTextInputProps {
   selectionColor?: ColorValue;
   markdownStyle?: MarkdownTextInputStyle;
   style?: ViewStyle | TextStyle;
-  /** Native identifier forwarded to the underlying view (e.g. for `react-native-keyboard-controller`'s `textInputNativeID`). */
-  nativeID?: string;
-  /** Test identifier forwarded to the underlying view. */
-  testID?: string;
   onChangeText?: (text: string) => void;
   onChangeMarkdown?: (markdown: string) => void;
   onChangeSelection?: (selection: { start: number; end: number }) => void;
@@ -163,8 +161,6 @@ export const EnrichedMarkdownTextInput = ({
   ref,
   markdownStyle,
   style,
-  nativeID,
-  testID,
   defaultValue,
   placeholder,
   placeholderTextColor,
@@ -189,6 +185,7 @@ export const EnrichedMarkdownTextInput = ({
   onBlur,
   contextMenuItems,
   linkRegex: _linkRegex,
+  ...rest
 }: EnrichedMarkdownTextInputProps) => {
   const nativeRef = useRef<NativeRef | null>(null);
 
@@ -411,10 +408,9 @@ export const EnrichedMarkdownTextInput = ({
 
   return (
     <EnrichedMarkdownTextInputNativeComponent
+      {...rest}
       ref={nativeRef}
       style={style}
-      nativeID={nativeID}
-      testID={testID}
       markdownStyle={normalizedStyle}
       defaultValue={defaultValue}
       placeholder={placeholder}

--- a/src/EnrichedMarkdownTextInput.tsx
+++ b/src/EnrichedMarkdownTextInput.tsx
@@ -125,6 +125,10 @@ export interface EnrichedMarkdownTextInputProps {
   selectionColor?: ColorValue;
   markdownStyle?: MarkdownTextInputStyle;
   style?: ViewStyle | TextStyle;
+  /** Native identifier forwarded to the underlying view (e.g. for `react-native-keyboard-controller`'s `textInputNativeID`). */
+  nativeID?: string;
+  /** Test identifier forwarded to the underlying view. */
+  testID?: string;
   onChangeText?: (text: string) => void;
   onChangeMarkdown?: (markdown: string) => void;
   onChangeSelection?: (selection: { start: number; end: number }) => void;
@@ -159,6 +163,8 @@ export const EnrichedMarkdownTextInput = ({
   ref,
   markdownStyle,
   style,
+  nativeID,
+  testID,
   defaultValue,
   placeholder,
   placeholderTextColor,
@@ -407,6 +413,8 @@ export const EnrichedMarkdownTextInput = ({
     <EnrichedMarkdownTextInputNativeComponent
       ref={nativeRef}
       style={style}
+      nativeID={nativeID}
+      testID={testID}
       markdownStyle={normalizedStyle}
       defaultValue={defaultValue}
       placeholder={placeholder}


### PR DESCRIPTION
### What/Why?

`EnrichedMarkdownTextInput`'s wrapper forwards only an explicit allow-list of props to `EnrichedMarkdownTextInputNativeComponent` and drops everything else, so `nativeID` and `testID` never reach the underlying native view — even though `NativeProps extends ViewProps` already supports them.

This forwards both props through.

Concrete motivation for `nativeID`: `react-native-keyboard-controller`'s `KeyboardGestureArea` / `KeyboardChatScrollView` link a composer input via a `textInputNativeID`. With a chat input built on `EnrichedMarkdownTextInput`, that linkage is impossible today because the `nativeID` is dropped before it reaches the native view. `testID` is forwarded alongside it as the other standard identifier prop, useful for E2E/unit targeting.

### Testing

- Set `nativeID` / `testID` on `<EnrichedMarkdownTextInput>` — both now reach `EnrichedMarkdownTextInputNativeComponent`, whose `NativeProps` already extends `ViewProps` (so no native changes are needed).
- JS-only change. I wasn't able to run the example app / E2E suite locally, so I'd appreciate CI confirming lint/typecheck. Happy to adjust naming, placement, or add a test if you'd prefer.

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
