### PR TITLE
refactor(text-input): omit children from props and spread rest last

### DIFF
--- a/src/EnrichedMarkdownTextInput.tsx
+++ b/src/EnrichedMarkdownTextInput.tsx
@@ -113,7 +113,7 @@ export interface EnrichedMarkdownTextInputInstance {
 }
 
 export interface EnrichedMarkdownTextInputProps
-  extends Omit<ViewProps, 'style'> {
+  extends Omit<ViewProps, 'style' | 'children'> {
   ref?: RefObject<EnrichedMarkdownTextInputInstance | null>;
   defaultValue?: string;
   placeholder?: string;
@@ -408,7 +408,6 @@ export const EnrichedMarkdownTextInput = ({
 
   return (
     <EnrichedMarkdownTextInputNativeComponent
-      {...rest}
       ref={nativeRef}
       style={style}
       markdownStyle={normalizedStyle}
@@ -450,6 +449,7 @@ export const EnrichedMarkdownTextInput = ({
       onStartMention={handleStartMention as NativeProps['onStartMention']}
       onChangeMention={handleChangeMention as NativeProps['onChangeMention']}
       onEndMention={handleEndMention as NativeProps['onEndMention']}
+      {...rest}
     />
   );
 };


### PR DESCRIPTION
### What/Why?
Omit children from EnrichedMarkdownTextInputProps — a text input doesn’t accept child content, so inheriting it from ViewProps was misleading. Also move {...rest} to the end of the native component props so explicit defaults aren’t accidentally overridden by spread props.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

