### PR TITLE
chore: update GitHub org links to software-mansion

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature Request 💡
-    url: https://github.com/software-mansion-labs/react-native-enriched-markdown/discussions/new?category=ideas
+    url: https://github.com/software-mansion/react-native-enriched-markdown/discussions/new?category=ideas
     about: If you have a feature request, please create a new discussion on GitHub.
   - name: Discussions on GitHub 💬
-    url: https://github.com/software-mansion-labs/react-native-enriched-markdown/discussions
+    url: https://github.com/software-mansion/react-native-enriched-markdown/discussions
     about: If this library works as promised but you need help, please ask questions there.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   npm-build:
-    if: github.repository == 'software-mansion-labs/react-native-enriched-markdown'
+    if: github.repository == 'software-mansion/react-native-enriched-markdown'
     runs-on: ubuntu-latest
 
     permissions:
@@ -51,7 +51,7 @@ jobs:
 
       - name: Publish manual release
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: software-mansion-labs/npm-package-publish@main
+        uses: software-mansion/npm-package-publish@main
         with:
           package-name: 'react-native-enriched-markdown'
           package-json-path: 'package.json'
@@ -62,7 +62,7 @@ jobs:
 
       - name: Publish automatic nightly release
         if: ${{ github.event_name == 'schedule' }}
-        uses: software-mansion-labs/npm-package-publish@main
+        uses: software-mansion/npm-package-publish@main
         with:
           package-name: 'react-native-enriched-markdown'
           package-json-path: 'package.json'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ To get started with the project, make sure you have the correct version of [Node
 ### Cloning the Repository
 
 ```sh
-git clone https://github.com/software-mansion-labs/react-native-enriched-markdown.git
+git clone https://github.com/software-mansion/react-native-enriched-markdown.git
 cd react-native-enriched-markdown
 ```
 

--- a/ReactNativeEnrichedMarkdown.podspec
+++ b/ReactNativeEnrichedMarkdown.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported, :osx => '14.0' }
-  s.source       = { :git => "https://github.com/software-mansion-labs/react-native-enriched-markdown.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/software-mansion/react-native-enriched-markdown.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,cpp}", "cpp/md4c/*.{c,h}", "cpp/parser/*.{hpp,cpp}"
   s.private_header_files = "ios/**/*.h"

--- a/package.json
+++ b/package.json
@@ -72,14 +72,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/software-mansion-labs/react-native-enriched-markdown.git"
+    "url": "git+https://github.com/software-mansion/react-native-enriched-markdown.git"
   },
   "author": "Gregory Moskaliuk <mosckalyuck@gmail.com> (https://github.com/hryhoriiK97)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/software-mansion-labs/react-native-enriched-markdown/issues"
+    "url": "https://github.com/software-mansion/react-native-enriched-markdown/issues"
   },
-  "homepage": "https://github.com/software-mansion-labs/react-native-enriched-markdown#readme",
+  "homepage": "https://github.com/software-mansion/react-native-enriched-markdown#readme",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },


### PR DESCRIPTION
### What/Why?
Updates repo links and metadata from software-mansion-labs to software-mansion after the project moved to [software-mansion/react-native-enriched-markdown](https://github.com/software-mansion/react-native-enriched-markdown). Covers package.json, docs, CI workflows, and issue templates so clone URLs, npm metadata, and GitHub Actions point at the new org.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

