### PR TITLE
feat(ios): better RTL support for text

### DIFF
--- a/ReactNativeEnrichedMarkdown.podspec
+++ b/ReactNativeEnrichedMarkdown.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
     if defined?(:spm_dependency)
       spm_dependency(s,
         url: 'https://github.com/erweixin/RaTeX.git',
-        requirement: {kind: 'upToNextMajorVersion', minimumVersion: '0.1.10'},
+        requirement: {kind: 'upToNextMajorVersion', minimumVersion: '0.1.9'},
         products: ['RaTeX']
       )
     end

--- a/ReactNativeEnrichedMarkdown.podspec
+++ b/ReactNativeEnrichedMarkdown.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
     if defined?(:spm_dependency)
       spm_dependency(s,
         url: 'https://github.com/erweixin/RaTeX.git',
-        requirement: {kind: 'upToNextMajorVersion', minimumVersion: '0.1.9'},
+        requirement: {kind: 'upToNextMajorVersion', minimumVersion: '0.1.10'},
         products: ['RaTeX']
       )
     end

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -159,6 +159,14 @@ class EnrichedMarkdownManager :
     // No-op on Android — only used on iOS
   }
 
+  @ReactProp(name = "writingDirection")
+  override fun setWritingDirection(
+    view: EnrichedMarkdown?,
+    value: String?,
+  ) {
+    // No-op on Android — first-strong per-paragraph resolution is the platform default
+  }
+
   @ReactProp(name = "streamingAnimation", defaultBoolean = false)
   override fun setStreamingAnimation(
     view: EnrichedMarkdown?,

--- a/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -163,6 +163,14 @@ class EnrichedMarkdownTextManager :
     // No-op on Android — only used on iOS
   }
 
+  @ReactProp(name = "writingDirection")
+  override fun setWritingDirection(
+    view: EnrichedMarkdownText?,
+    value: String?,
+  ) {
+    // No-op on Android — first-strong per-paragraph resolution is the platform default
+  }
+
   @ReactProp(name = "streamingAnimation", defaultBoolean = false)
   override fun setStreamingAnimation(
     view: EnrichedMarkdownText?,

--- a/apps/example/.rnstorybook/stories/components/EnrichedMarkdownText/props/WritingDirection.stories.tsx
+++ b/apps/example/.rnstorybook/stories/components/EnrichedMarkdownText/props/WritingDirection.stories.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { EnrichedMarkdownTextStory } from '../EnrichedMarkdownTextStory';
+import { storyMeta } from '../shared/storyMeta';
+import type { TextStory } from '../shared/storyTypes';
+
+type WritingDirection = 'auto' | 'ltr' | 'rtl' | 'first-strong';
+
+type WritingDirectionStoryExtra = {
+  writingDirection: WritingDirection;
+};
+
+const MARKDOWN = `# عنوان عربي
+
+هذه فقرة عربية تتبع اتجاه اليمين إلى اليسار تلقائيًا حسب أول حرف قوي فيها.
+
+This English paragraph stays left-to-right in the same document.
+
+- عنصر عربي في القائمة
+- English list item
+
+> اقتباس عربي لاختبار موضع الحد الجانبي للاقتباس.
+
+123 456 789.`;
+
+const WRITING_DIRECTION_OPTIONS: WritingDirection[] = [
+  'first-strong',
+  'auto',
+  'ltr',
+  'rtl',
+];
+
+const argTypes = {
+  writingDirection: {
+    options: WRITING_DIRECTION_OPTIONS,
+    control: { type: 'inline-radio' as const },
+    description:
+      "'first-strong' (default): resolve per paragraph from its first strong directional character; neutral-only paragraphs fall back to the view's layout direction. 'auto': React Native parity, follows the app's UI layout direction. 'ltr'/'rtl': force base direction on every paragraph. Code blocks always stay LTR.",
+  },
+};
+
+export default storyMeta('Props', 'Writing Direction');
+
+export const Default: TextStory<WritingDirectionStoryExtra> = {
+  args: {
+    markdown: MARKDOWN,
+    writingDirection: 'first-strong',
+    flavor: 'github',
+  },
+  argTypes,
+  render: ({ writingDirection, ...args }) => (
+    <EnrichedMarkdownTextStory
+      title="Writing Direction"
+      description="iOS only. Compare 'first-strong' (per-paragraph autodetection, matches Android) against 'auto' (RN parity — follows the app's UI direction), and the forced 'ltr'/'rtl' modes. Mixed Arabic/English content makes the difference visible at a glance."
+      {...args}
+      writingDirection={writingDirection}
+    />
+  ),
+};

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -2489,7 +2489,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: 7a5738e17537a638701b58a7488ab83a72cddf11
+  hermes-engine: 52e1e04154c2786defb1149ebf593d495dae2ae3
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc
   RCTSwiftUI: 239ed2eb9e73de5a6f518810630f0c95e01c8702
@@ -2498,7 +2498,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 300f1f7da5b63a2c480bde8dfc5cde8843905766
+  React-Core-prebuilt: 6147d6e420f7eafc5b747002205a958e115878ca
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 9af1e96a6069c996e3d9f1e493603e74bc9f1593
@@ -2562,7 +2562,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: 7016a2114079361a2f1536b3c91a15ceb8eb7ca4
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: c6c22887dcb9997b770c6751e2a8b7c528e29363
+  ReactNativeDependencies: 75a2f59992523e6ad820ee08850c05a865d2dc63
   ReactNativeEnrichedMarkdown: 15ee1297ff2df94e80d06b7d86c13e5fbbcb806a
   RNCAsyncStorage: 7d913885caaae13f5fb62dd0bd04c674ea8bf97b
   RNDateTimePicker: afe0288e6c7855994f7f2617b7b2c05799fea7f3
@@ -2575,4 +2575,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: b36622aa0f914440818675c0f57fee5851155a82
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -2489,7 +2489,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: 52e1e04154c2786defb1149ebf593d495dae2ae3
+  hermes-engine: 7a5738e17537a638701b58a7488ab83a72cddf11
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc
   RCTSwiftUI: 239ed2eb9e73de5a6f518810630f0c95e01c8702
@@ -2498,7 +2498,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 6147d6e420f7eafc5b747002205a958e115878ca
+  React-Core-prebuilt: 300f1f7da5b63a2c480bde8dfc5cde8843905766
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 9af1e96a6069c996e3d9f1e493603e74bc9f1593
@@ -2562,7 +2562,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: 7016a2114079361a2f1536b3c91a15ceb8eb7ca4
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: 75a2f59992523e6ad820ee08850c05a865d2dc63
+  ReactNativeDependencies: c6c22887dcb9997b770c6751e2a8b7c528e29363
   ReactNativeEnrichedMarkdown: 15ee1297ff2df94e80d06b7d86c13e5fbbcb806a
   RNCAsyncStorage: 7d913885caaae13f5fb62dd0bd04c674ea8bf97b
   RNDateTimePicker: afe0288e6c7855994f7f2617b7b2c05799fea7f3
@@ -2575,4 +2575,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: b36622aa0f914440818675c0f57fee5851155a82
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/apps/example/src/sampleMarkdown.ts
+++ b/apps/example/src/sampleMarkdown.ts
@@ -376,6 +376,24 @@ The image below is loaded at full resolution (4000+ pixels wide) to test downsam
 
 ---
 
+## Right-to-Left Text Samples
+
+Short samples for testing RTL rendering, line measurement, and inline formatting across scripts.
+
+Arabic: الغابات تغطي حوالي **31%** من سطح اليابسة، وتوفر موطناً لعدد لا يحصى من الأنواع.
+
+Hebrew: יערות מכסים כ-**31%** משטח היבשה של כדור הארץ ומספקים בית ל*מיליוני* מינים.
+
+Mixed LTR/RTL in one line: The Hebrew word for "forest" is יַעַר and the Arabic word is غابة — both appear inline with English.
+
+A longer RTL paragraph to exercise line wrapping and measurement:
+
+> هذه فقرة طويلة باللغة العربية تهدف إلى اختبار كيفية تعامل المكوّن مع التفاف الأسطر والقياس عندما يكون النص طويلاً بما يكفي ليمتد عبر عدّة أسطر، مع وجود **تنسيق غامق** و*مائل* و[رابط](https://example.com) داخل النص.
+
+זוהי פסקה ארוכה בעברית שמטרתה לבדוק את אופן הטיפול בשבירת שורות ובמדידה כאשר הטקסט ארוך מספיק כדי להתפרס על פני מספר שורות, עם **טקסט מודגש** ו*נטוי* ו[קישור](https://example.com) בתוך הפסקה.
+
+---
+
 ## Conclusion
 
 Forests are ***irreplaceable ecosystems*** that sustain life on Earth. From the microscopic fungi beneath our feet to the towering giants that touch the sky, every element plays a crucial role.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -201,6 +201,36 @@ Controls iOS line-breaking refinements. Mirrors the prop of the same name on Rea
 - **`'hangul-word'`**: prefers breaking at Korean word boundaries.
 - **`'push-out'`**: avoids orphaned short trailing lines by pushing words to the next line.
 
+### `writingDirection`
+
+Paragraph writing direction. iOS only — Android already resolves direction per paragraph via the platform Bidi heuristic and is unaffected by this prop.
+
+| Type                                            | Default Value    | Platform |
+| ----------------------------------------------- | ---------------- | -------- |
+| `'auto' \| 'ltr' \| 'rtl' \| 'first-strong'`    | `'first-strong'` | iOS      |
+
+- **`'first-strong'`** (default): library extension. Each paragraph resolves its base direction from its first strong directional character — mixed Arabic/Hebrew/English documents render correctly out of the box. Paragraphs with no strong character (numbers, punctuation, block spacers) fall back to the view's Yoga-resolved layout direction, which inherits from any ancestor `<View style={{ direction: 'rtl' }}>` (defaults to `I18nManager.isRTL`). Mirrors Android's `TEXT_DIRECTION_FIRST_STRONG`.
+- **`'auto'`**: React Native parity (matches `<Text writingDirection="auto">`). TextKit follows the app's `userInterfaceLayoutDirection`; mixed-direction paragraphs do not auto-resolve.
+- **`'ltr'` / `'rtl'`**: forces the base direction on every paragraph in the document.
+
+Code blocks are always rendered left-to-right regardless of this prop. Per-paragraph direction also drives list markers, blockquote borders, task-list tap targets, and the `dir` attribute emitted when copying as HTML. See [RTL Support](RTL.md) for the full behavior matrix and the copy-as-HTML caveat for mixed-direction documents.
+
+**Example:**
+
+```tsx
+// Mixed-direction document — each paragraph picks its own side.
+<EnrichedMarkdownText
+  markdown={
+    'هذه فقرة عربية\n\n' +
+    'This English paragraph stays LTR.\n\n' +
+    '123 456 789.' // neutral — follows the view's layout direction
+  }
+/>
+
+// Force RTL on every paragraph regardless of content.
+<EnrichedMarkdownText writingDirection="rtl" markdown={content} />
+```
+
 ### `flavor`
 
 Markdown flavor. Set to `'github'` to enable GitHub Flavored Markdown table support.

--- a/docs/RTL.md
+++ b/docs/RTL.md
@@ -1,39 +1,80 @@
 # RTL Support
 
-`react-native-enriched-markdown` fully supports right-to-left (RTL) languages such as Arabic, Hebrew, and Persian. The library automatically detects RTL content and mirrors the layout of all elements accordingly.
+`react-native-enriched-markdown` resolves writing direction **per paragraph** on both platforms: each paragraph picks its own base direction from its first strong directional character. Arabic, Hebrew, and Persian content right-aligns automatically, even inside an LTR app and even when mixed with English paragraphs in the same document.
 
 ## Platform Setup
 
+No setup is required. Both platforms autodetect direction per paragraph out of the box.
+
 ### Android
 
-RTL works automatically on Android. The platform's text system detects RTL characters (Arabic, Hebrew, etc.) and renders them right-to-left with no additional configuration needed.
+Uses Android's `TEXT_DIRECTION_FIRST_STRONG` heuristic on every `StaticLayout`. Paragraphs with no strong character fall back to the view's resolved layout direction (inherits ancestor `<View style={{ direction: 'rtl' }}>` and `I18nManager.isRTL`).
 
 ### iOS
 
-iOS requires explicit RTL configuration. You must call `I18nManager.forceRTL(true)` early in your app lifecycle (before the root component mounts) and restart the app for the change to take effect.
+iOS TextKit's `NSWritingDirectionNatural` does **not** do per-paragraph first-strong — it follows the app's global UI layout direction. The library implements first-strong itself as a post-render pass, matching Android's behavior. The mode is controlled by the [`writingDirection`](#writingdirection-prop-ios) prop and defaults to `'first-strong'`.
+
+> **Note:** Earlier versions documented `I18nManager.forceRTL(true)` as a requirement on iOS. That is no longer needed for content direction — `first-strong` resolves each paragraph from its content. `I18nManager.forceRTL` still affects the surrounding app layout (Yoga direction, navigation, etc.) and remains useful if you want the whole app in RTL mode, but it's no longer a precondition for Markdown to render right-aligned.
+
+## `writingDirection` prop (iOS)
+
+| Value | Behavior |
+|---|---|
+| `'first-strong'` (default) | Per-paragraph autodetection. Neutral-only paragraphs fall back to the view's resolved layout direction. Matches Android. |
+| `'auto'` | React Native parity. TextKit follows the app's `userInterfaceLayoutDirection`; mixed-direction documents do not auto-resolve. |
+| `'ltr'` | Forces LTR on every paragraph. |
+| `'rtl'` | Forces RTL on every paragraph. |
+
+Code blocks always render LTR regardless of this prop.
+
+Android ignores the prop; it always uses first-strong via the platform.
 
 ```tsx
-import { I18nManager } from 'react-native';
+// Default — mixed Arabic/English document renders each paragraph correctly.
+<EnrichedMarkdownText markdown={mixedContent} />
 
-// Call this before your app renders (e.g., in index.js or App.tsx)
-// Required for iOS, Android handles RTL automatically
-I18nManager.forceRTL(true);
+// Force RTL for the whole document (e.g. forms or admin UI in an Arabic locale).
+<EnrichedMarkdownText writingDirection="rtl" markdown={content} />
 ```
-
-> **Important:** On iOS, `I18nManager.forceRTL(true)` affects the entire app's layout direction, not just the Markdown component. Make sure this aligns with your app's RTL requirements.
 
 ## Element RTL Behavior
 
-When RTL content is rendered, the following elements automatically mirror their layout:
+Each element follows the **paragraph it belongs to**, not a global flag — so a single document can mix sides cleanly.
 
-| Element | RTL Behavior |
-|---------|-------------|
-| **Paragraphs & Headings** | Right-aligned with RTL writing direction |
-| **Unordered lists** | Bullets on the right, text indented from the right |
-| **Ordered lists** | Numbers on the right, text indented from the right |
-| **Task lists** | Checkboxes on the right, tappable in RTL |
-| **Blockquotes** | Border on the right side |
-| **Tables** | Columns ordered right-to-left, scrolls to show first column |
-| **Code blocks** | Always LTR (code is inherently left-to-right) |
-| **Inline code** | Positioned correctly within RTL text flow |
-| **Copy as HTML** | Exported HTML includes `dir="rtl"` for correct rendering in paste targets |
+| Element | Behavior |
+|---|---|
+| **Paragraphs & headings** | Base direction set per paragraph from first-strong (or forced by the prop). |
+| **Unordered lists** | Bullet drawn on the side that matches the item's paragraph direction. |
+| **Ordered lists** | Number drawn on the side that matches the item's paragraph direction. |
+| **Task lists** | Checkbox drawn on the matching side; tap hit-test follows the same side. |
+| **Blockquotes** | Border drawn on the side that matches the quoted paragraph. |
+| **Tables** (`flavor="github"`) | Each cell resolves its own direction independently from cell content. |
+| **Code blocks** | Always LTR. |
+| **Inline code** | Inherits its paragraph's direction; characters flow correctly via TextKit Bidi. |
+
+## Yoga layout-direction inheritance
+
+For paragraphs with no strong directional character (digits, punctuation, block spacers), the library falls back to the view's **Yoga-resolved layout direction**. That means:
+
+```tsx
+// "123 456 789." has no strong character. Inside an RTL ancestor view,
+// it right-aligns; otherwise it left-aligns.
+<View style={{ direction: 'rtl' }}>
+  <EnrichedMarkdownText markdown="123 456 789." />
+</View>
+```
+
+This mirrors Android's first-strong fallback and lets you place an LTR app in an RTL screen (or vice versa) without surprises for neutral content.
+
+## Copy-as-HTML caveat
+
+When you copy markdown content to the clipboard, the HTML representation carries a single `dir` attribute on `<html>` (or on `<table>` for table copies). That attribute is read from the document's first paragraph:
+
+- `first-strong` document starting with Arabic → `<html dir="rtl">`
+- `first-strong` document starting with English → `<html dir="ltr">`
+- `'auto'` → `<html dir="auto">` (receivers do best-effort first-strong)
+- `'ltr'` / `'rtl'` → forced
+
+**Receivers (Gmail, Notes, Word, etc.) apply their own Bidi algorithm to the pasted HTML.** Mixed-direction documents may not visually reproduce the per-paragraph layout you see in-app — receivers can only honor what the markup encodes, and HTML's `dir` attribute is scoped to elements, not paragraphs within them. The plain-text and Markdown clipboard representations are unaffected and round-trip cleanly.
+
+If you need precise mixed-direction output in a specific receiver, the rendered HTML carries no per-`<p>` `dir` attribute today — that would be a future enhancement.

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -60,6 +60,7 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   ENRMDirtyNone = 0,
   ENRMDirtyRecreateSegments = 1 << 0,
   ENRMDirtyForceHeight = 1 << 1,
+  ENRMDirtyRender = 1 << 2,
 };
 
 static char kENRMSegmentFadeAnimatorKey;
@@ -685,19 +686,19 @@ static char kENRMSegmentFadeAnimatorKey;
   const auto &oldViewProps = *std::static_pointer_cast<EnrichedMarkdownProps const>(_props);
   const auto &newViewProps = *std::static_pointer_cast<EnrichedMarkdownProps const>(props);
 
-  BOOL stylePropChanged = NO;
   BOOL markdownChanged = oldViewProps.markdown != newViewProps.markdown;
+  if (markdownChanged) {
+    _dirtyFlags |= ENRMDirtyRender;
+  }
 
   if (_config == nil) {
     _config = [[StyleConfig alloc] init];
     [_config setFontScaleMultiplier:_fontScaleObserver.effectiveFontScale];
   }
 
-  stylePropChanged = applyMarkdownStyleToConfig(_config, newViewProps.markdownStyle, oldViewProps.markdownStyle);
-
-  if (stylePropChanged) {
+  if (applyMarkdownStyleToConfig(_config, newViewProps.markdownStyle, oldViewProps.markdownStyle)) {
     [ENRMImageAttachment clearAttachmentRegistry];
-    _dirtyFlags |= ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
     if (!markdownChanged) {
       _dirtyFlags |= ENRMDirtyRecreateSegments;
     }
@@ -719,8 +720,7 @@ static char kENRMSegmentFadeAnimatorKey;
     if (_config != nil) {
       [_config setFontScaleMultiplier:_fontScaleObserver.effectiveFontScale];
     }
-    stylePropChanged = YES;
-    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight | ENRMDirtyRender;
   }
 
   if (newViewProps.maxFontSizeMultiplier != oldViewProps.maxFontSizeMultiplier) {
@@ -728,49 +728,40 @@ static char kENRMSegmentFadeAnimatorKey;
     if (_config != nil) {
       [_config setMaxFontSizeMultiplier:_maxFontSizeMultiplier];
     }
-    stylePropChanged = YES;
-    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight | ENRMDirtyRender;
   }
 
   if (newViewProps.allowTrailingMargin != oldViewProps.allowTrailingMargin) {
     _allowTrailingMargin = newViewProps.allowTrailingMargin;
-    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight | ENRMDirtyRender;
   }
 
-  BOOL md4cFlagsChanged = NO;
   if (newViewProps.md4cFlags.underline != oldViewProps.md4cFlags.underline) {
     _md4cFlags.underline = newViewProps.md4cFlags.underline;
-    md4cFlagsChanged = YES;
-    _dirtyFlags |= ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
   }
   if (newViewProps.md4cFlags.superscript != oldViewProps.md4cFlags.superscript) {
     _md4cFlags.superscript = newViewProps.md4cFlags.superscript;
-    md4cFlagsChanged = YES;
-    _dirtyFlags |= ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
   }
   if (newViewProps.md4cFlags.subscript != oldViewProps.md4cFlags.subscript) {
     _md4cFlags.subscript = newViewProps.md4cFlags.subscript;
-    md4cFlagsChanged = YES;
-    _dirtyFlags |= ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
   }
   if (newViewProps.md4cFlags.latexMath != oldViewProps.md4cFlags.latexMath) {
     _md4cFlags.latexMath = newViewProps.md4cFlags.latexMath;
-    md4cFlagsChanged = YES;
-    _dirtyFlags |= ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
   }
   if (newViewProps.md4cFlags.highlight != oldViewProps.md4cFlags.highlight) {
     _md4cFlags.highlight = newViewProps.md4cFlags.highlight;
-    md4cFlagsChanged = YES;
-    _dirtyFlags |= ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
   }
-  BOOL allowTrailingMarginChanged = newViewProps.allowTrailingMargin != oldViewProps.allowTrailingMargin;
 
   _enableLinkPreview = newViewProps.enableLinkPreview;
 
-  BOOL streamingAnimationChanged = newViewProps.streamingAnimation != oldViewProps.streamingAnimation;
-  if (streamingAnimationChanged) {
+  if (newViewProps.streamingAnimation != oldViewProps.streamingAnimation) {
     _streamingAnimation = newViewProps.streamingAnimation;
-    _dirtyFlags |= ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
     if (!_streamingAnimation) {
       for (RCTUIView *segment in _segmentViews) {
         if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
@@ -784,13 +775,11 @@ static char kENRMSegmentFadeAnimatorKey;
     }
   }
 
-  BOOL streamingConfigChanged = NO;
   if (newViewProps.streamingConfig.tableMode != oldViewProps.streamingConfig.tableMode) {
     NSString *tableModeStr = [[NSString alloc] initWithUTF8String:newViewProps.streamingConfig.tableMode.c_str()];
     _tableStreamingMode =
         [tableModeStr isEqualToString:@"hidden"] ? ENRMTableStreamingModeHidden : ENRMTableStreamingModeProgressive;
-    streamingConfigChanged = YES;
-    _dirtyFlags |= ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
   }
 
   if (ENRMContextMenuItemsChanged(oldViewProps.contextMenuItems, newViewProps.contextMenuItems)) {
@@ -822,27 +811,25 @@ static char kENRMSegmentFadeAnimatorKey;
     }
   }
 
-  BOOL lineBreakStrategyChanged = newViewProps.lineBreakStrategyIOS != oldViewProps.lineBreakStrategyIOS;
-  if (lineBreakStrategyChanged) {
+  if (newViewProps.lineBreakStrategyIOS != oldViewProps.lineBreakStrategyIOS) {
     NSString *strategy = [[NSString alloc] initWithUTF8String:newViewProps.lineBreakStrategyIOS.c_str()];
     _lineBreakStrategy = ENRMResolveLineBreakStrategy(strategy);
-    _dirtyFlags |= ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
   }
 
-  BOOL writingDirectionChanged = newViewProps.writingDirection != oldViewProps.writingDirection;
-  if (writingDirectionChanged) {
+  if (newViewProps.writingDirection != oldViewProps.writingDirection) {
     NSString *value = [[NSString alloc] initWithUTF8String:newViewProps.writingDirection.c_str()];
     _writingDirectionMode = ENRMResolveWritingDirectionMode(value);
-    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight;
+    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight | ENRMDirtyRender;
     [self pushWritingDirectionToTableSegments];
   }
 
-  if (markdownChanged || stylePropChanged || md4cFlagsChanged || allowTrailingMarginChanged ||
-      streamingAnimationChanged || streamingConfigChanged || lineBreakStrategyChanged || writingDirectionChanged) {
+  if (_dirtyFlags & ENRMDirtyRender) {
     _pendingStyleFingerprint =
         computeStyleFingerprint(newViewProps.markdownStyle) ^ std::hash<bool>{}(newViewProps.allowTrailingMargin);
     NSString *markdownString = [[NSString alloc] initWithUTF8String:newViewProps.markdown.c_str()];
     [self renderMarkdownContent:markdownString];
+    _dirtyFlags &= ~ENRMDirtyRender;
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/EnrichedMarkdown.mm
+++ b/ios/EnrichedMarkdown.mm
@@ -52,6 +52,7 @@
 #import "RCTFabricComponentsPlugins.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFont.h>
+#import <React/RCTI18nUtil.h>
 
 using namespace facebook::react;
 
@@ -108,6 +109,9 @@ static char kENRMSegmentFadeAnimatorKey;
   ENRMSpoilerOverlay _spoilerOverlay;
 
   NSLineBreakStrategy _lineBreakStrategy;
+
+  ENRMWritingDirectionMode _writingDirectionMode;
+  NSWritingDirection _resolvedLayoutDirection;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -140,6 +144,9 @@ static char kENRMSegmentFadeAnimatorKey;
     _tableStreamingMode = ENRMTableStreamingModeProgressive;
     _selectionMenuConfig = (ENRMSelectionMenuConfig){.copyAsMarkdown = YES, .copyImageURL = YES};
     _lineBreakStrategy = NSLineBreakStrategyNone;
+    _writingDirectionMode = ENRMWritingDirectionModeFirstStrong;
+    _resolvedLayoutDirection =
+        [[RCTI18nUtil sharedInstance] isRTL] ? NSWritingDirectionRightToLeft : NSWritingDirectionLeftToRight;
 
     _fontScaleObserver = [[FontScaleObserver alloc] init];
     __weak EnrichedMarkdown *weakSelf = self;
@@ -344,6 +351,42 @@ static char kENRMSegmentFadeAnimatorKey;
   }
 }
 
+/// Yoga-resolved direction inherited from any ancestor `direction` style.
+/// In FirstStrong mode this feeds the neutral-paragraph fallback, so a change
+/// requires segment recreation.
+- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics
+{
+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+
+  NSWritingDirection resolved = _resolvedLayoutDirection;
+  if (layoutMetrics.layoutDirection == LayoutDirection::RightToLeft) {
+    resolved = NSWritingDirectionRightToLeft;
+  } else if (layoutMetrics.layoutDirection == LayoutDirection::LeftToRight) {
+    resolved = NSWritingDirectionLeftToRight;
+  }
+
+  if (resolved != _resolvedLayoutDirection) {
+    _resolvedLayoutDirection = resolved;
+    [self pushWritingDirectionToTableSegments];
+    if (_writingDirectionMode == ENRMWritingDirectionModeFirstStrong && _cachedMarkdown.length > 0) {
+      _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight;
+      [self renderMarkdownContent:_cachedMarkdown];
+    }
+  }
+}
+
+- (void)pushWritingDirectionToTableSegments
+{
+  for (RCTUIView *segment in _segmentViews) {
+    if ([segment isKindOfClass:[TableContainerView class]]) {
+      TableContainerView *tableView = (TableContainerView *)segment;
+      tableView.writingDirectionMode = _writingDirectionMode;
+      tableView.resolvedLayoutDirection = _resolvedLayoutDirection;
+    }
+  }
+}
+
 - (void)requestHeightUpdate
 {
   ENRMRequestHeightUpdate<EnrichedMarkdownState>(_state, _heightUpdateCounter, self);
@@ -366,6 +409,8 @@ static char kENRMSegmentFadeAnimatorKey;
   BOOL streamingAnimation = _streamingAnimation;
   ENRMTableStreamingMode tableStreamingMode = _tableStreamingMode;
   NSLineBreakStrategy lineBreakStrategy = _lineBreakStrategy;
+  ENRMWritingDirectionMode writingDirectionMode = _writingDirectionMode;
+  NSWritingDirection resolvedLayoutDirection = _resolvedLayoutDirection;
 
   __block NSArray<ENRMRenderedSegment *> *renderedSegments = nil;
   __block NSString *renderableMarkdown = nil;
@@ -386,6 +431,12 @@ static char kENRMSegmentFadeAnimatorKey;
 
         renderedSegments = ENRMRenderSegmentsFromAST(ast, config, allowTrailingMargin, allowFontScaling,
                                                      maxFontSizeMultiplier, lineBreakStrategy);
+        for (ENRMRenderedSegment *segment in renderedSegments) {
+          if (segment.kind == ENRMSegmentKindText && segment.textResult) {
+            ENRMApplyWritingDirectionMode(segment.textResult.attributedText, writingDirectionMode,
+                                          resolvedLayoutDirection);
+          }
+        }
         return YES;
       }
       apply:^{
@@ -401,8 +452,15 @@ static char kENRMSegmentFadeAnimatorKey;
     return nil;
   }
 
-  return ENRMRenderSegmentsFromAST(ast, _config, _allowTrailingMargin, _fontScaleObserver.allowFontScaling,
-                                   _maxFontSizeMultiplier, _lineBreakStrategy);
+  NSArray<ENRMRenderedSegment *> *segments =
+      ENRMRenderSegmentsFromAST(ast, _config, _allowTrailingMargin, _fontScaleObserver.allowFontScaling,
+                                _maxFontSizeMultiplier, _lineBreakStrategy);
+  for (ENRMRenderedSegment *segment in segments) {
+    if (segment.kind == ENRMSegmentKindText && segment.textResult) {
+      ENRMApplyWritingDirectionMode(segment.textResult.attributedText, _writingDirectionMode, _resolvedLayoutDirection);
+    }
+  }
+  return segments;
 }
 
 /// Synchronous rendering for mock view measurement (no UI updates needed).
@@ -538,6 +596,8 @@ static char kENRMSegmentFadeAnimatorKey;
   tableView.allowFontScaling = _fontScaleObserver.allowFontScaling;
   tableView.maxFontSizeMultiplier = _maxFontSizeMultiplier;
   tableView.enableLinkPreview = _enableLinkPreview;
+  tableView.writingDirectionMode = _writingDirectionMode;
+  tableView.resolvedLayoutDirection = _resolvedLayoutDirection;
 
   __weak EnrichedMarkdown *weakSelf = self;
 
@@ -560,6 +620,8 @@ static char kENRMSegmentFadeAnimatorKey;
 
 - (void)updateTableView:(TableContainerView *)view withSegment:(ENRMTableSegment *)tableSegment
 {
+  view.writingDirectionMode = _writingDirectionMode;
+  view.resolvedLayoutDirection = _resolvedLayoutDirection;
   NSUInteger previousRowCount = view.rowCount;
   [view applyTableNode:tableSegment.tableNode];
 
@@ -767,8 +829,16 @@ static char kENRMSegmentFadeAnimatorKey;
     _dirtyFlags |= ENRMDirtyForceHeight;
   }
 
+  BOOL writingDirectionChanged = newViewProps.writingDirection != oldViewProps.writingDirection;
+  if (writingDirectionChanged) {
+    NSString *value = [[NSString alloc] initWithUTF8String:newViewProps.writingDirection.c_str()];
+    _writingDirectionMode = ENRMResolveWritingDirectionMode(value);
+    _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight;
+    [self pushWritingDirectionToTableSegments];
+  }
+
   if (markdownChanged || stylePropChanged || md4cFlagsChanged || allowTrailingMarginChanged ||
-      streamingAnimationChanged || streamingConfigChanged || lineBreakStrategyChanged) {
+      streamingAnimationChanged || streamingConfigChanged || lineBreakStrategyChanged || writingDirectionChanged) {
     _pendingStyleFingerprint =
         computeStyleFingerprint(newViewProps.markdownStyle) ^ std::hash<bool>{}(newViewProps.allowTrailingMargin);
     NSString *markdownString = [[NSString alloc] initWithUTF8String:newViewProps.markdown.c_str()];

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -39,6 +39,11 @@
 
 using namespace facebook::react;
 
+typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
+  ENRMDirtyNone = 0,
+  ENRMDirtyRender = 1 << 0,
+};
+
 @interface EnrichedMarkdownText () <RCTEnrichedMarkdownTextViewProtocol, UITextViewDelegate>
 - (void)setupTextView;
 - (void)renderMarkdownContent:(NSString *)markdownString;
@@ -100,6 +105,8 @@ using namespace facebook::react;
 
   ENRMWritingDirectionMode _writingDirectionMode;
   NSWritingDirection _resolvedLayoutDirection;
+
+  ENRMDirtyFlags _dirtyFlags;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -189,6 +196,7 @@ using namespace facebook::react;
     _writingDirectionMode = ENRMWritingDirectionModeFirstStrong;
     _resolvedLayoutDirection =
         [[RCTI18nUtil sharedInstance] isRTL] ? NSWritingDirectionRightToLeft : NSWritingDirectionLeftToRight;
+    _dirtyFlags = ENRMDirtyNone;
 
     _fontScaleObserver = [[FontScaleObserver alloc] init];
     __weak EnrichedMarkdownText *weakSelf = self;
@@ -433,7 +441,9 @@ using namespace facebook::react;
   const auto &oldViewProps = *std::static_pointer_cast<EnrichedMarkdownTextProps const>(_props);
   const auto &newViewProps = *std::static_pointer_cast<EnrichedMarkdownTextProps const>(props);
 
-  BOOL stylePropChanged = NO;
+  if (oldViewProps.markdown != newViewProps.markdown) {
+    _dirtyFlags |= ENRMDirtyRender;
+  }
 
   if (_config == nil) {
     _config = [[StyleConfig alloc] init];
@@ -441,11 +451,10 @@ using namespace facebook::react;
     _spoilerManager = [[ENRMSpoilerOverlayManager alloc] initWithTextView:_textView config:_config];
   }
 
-  stylePropChanged = applyMarkdownStyleToConfig(_config, newViewProps.markdownStyle, oldViewProps.markdownStyle);
-
-  if (stylePropChanged) {
+  if (applyMarkdownStyleToConfig(_config, newViewProps.markdownStyle, oldViewProps.markdownStyle)) {
     [ENRMImageAttachment clearAttachmentRegistry];
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
   }
 
   NSLayoutManager *layoutManager = _textView.layoutManager;
@@ -471,8 +480,8 @@ using namespace facebook::react;
       [_config setFontScaleMultiplier:_fontScaleObserver.effectiveFontScale];
     }
 
-    stylePropChanged = YES;
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
   }
 
   if (newViewProps.maxFontSizeMultiplier != oldViewProps.maxFontSizeMultiplier) {
@@ -482,43 +491,41 @@ using namespace facebook::react;
       [_config setMaxFontSizeMultiplier:_maxFontSizeMultiplier];
     }
 
-    stylePropChanged = YES;
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
   }
 
   if (newViewProps.allowTrailingMargin != oldViewProps.allowTrailingMargin) {
     _allowTrailingMargin = newViewProps.allowTrailingMargin;
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
   }
 
-  BOOL md4cFlagsChanged = NO;
   if (newViewProps.md4cFlags.underline != oldViewProps.md4cFlags.underline) {
     _md4cFlags.underline = newViewProps.md4cFlags.underline;
-    md4cFlagsChanged = YES;
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
   }
   if (newViewProps.md4cFlags.superscript != oldViewProps.md4cFlags.superscript) {
     _md4cFlags.superscript = newViewProps.md4cFlags.superscript;
-    md4cFlagsChanged = YES;
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
   }
   if (newViewProps.md4cFlags.subscript != oldViewProps.md4cFlags.subscript) {
     _md4cFlags.subscript = newViewProps.md4cFlags.subscript;
-    md4cFlagsChanged = YES;
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
   }
   if (newViewProps.md4cFlags.latexMath != oldViewProps.md4cFlags.latexMath) {
     _md4cFlags.latexMath = newViewProps.md4cFlags.latexMath;
-    md4cFlagsChanged = YES;
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
   }
   if (newViewProps.md4cFlags.highlight != oldViewProps.md4cFlags.highlight) {
     _md4cFlags.highlight = newViewProps.md4cFlags.highlight;
-    md4cFlagsChanged = YES;
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
   }
-  BOOL markdownChanged = oldViewProps.markdown != newViewProps.markdown;
-  BOOL allowTrailingMarginChanged = newViewProps.allowTrailingMargin != oldViewProps.allowTrailingMargin;
 
   _enableLinkPreview = newViewProps.enableLinkPreview;
 
@@ -548,26 +555,26 @@ using namespace facebook::react;
     _spoilerManager.spoilerOverlay = ENRMSpoilerOverlayFromString(modeStr);
   }
 
-  BOOL lineBreakStrategyChanged = newViewProps.lineBreakStrategyIOS != oldViewProps.lineBreakStrategyIOS;
-  if (lineBreakStrategyChanged) {
+  if (newViewProps.lineBreakStrategyIOS != oldViewProps.lineBreakStrategyIOS) {
     NSString *strategy = [[NSString alloc] initWithUTF8String:newViewProps.lineBreakStrategyIOS.c_str()];
     _lineBreakStrategy = ENRMResolveLineBreakStrategy(strategy);
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
   }
 
-  BOOL writingDirectionChanged = newViewProps.writingDirection != oldViewProps.writingDirection;
-  if (writingDirectionChanged) {
+  if (newViewProps.writingDirection != oldViewProps.writingDirection) {
     NSString *value = [[NSString alloc] initWithUTF8String:newViewProps.writingDirection.c_str()];
     _writingDirectionMode = ENRMResolveWritingDirectionMode(value);
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
   }
 
-  if (markdownChanged || stylePropChanged || md4cFlagsChanged || allowTrailingMarginChanged ||
-      lineBreakStrategyChanged || writingDirectionChanged) {
+  if (_dirtyFlags & ENRMDirtyRender) {
     _pendingStyleFingerprint =
         computeStyleFingerprint(newViewProps.markdownStyle) ^ std::hash<bool>{}(newViewProps.allowTrailingMargin);
     NSString *markdownString = [[NSString alloc] initWithUTF8String:newViewProps.markdown.c_str()];
     [self renderMarkdownContent:markdownString];
+    _dirtyFlags &= ~ENRMDirtyRender;
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/EnrichedMarkdownText.mm
+++ b/ios/EnrichedMarkdownText.mm
@@ -35,6 +35,7 @@
 #import "RCTFabricComponentsPlugins.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFont.h>
+#import <React/RCTI18nUtil.h>
 
 using namespace facebook::react;
 
@@ -96,6 +97,9 @@ using namespace facebook::react;
   ENRMSpoilerOverlayManager *_spoilerManager;
 
   NSLineBreakStrategy _lineBreakStrategy;
+
+  ENRMWritingDirectionMode _writingDirectionMode;
+  NSWritingDirection _resolvedLayoutDirection;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -135,6 +139,29 @@ using namespace facebook::react;
   }
 }
 
+/// Yoga-resolved direction inherited from any ancestor `direction` style.
+/// In FirstStrong mode this feeds the neutral-paragraph fallback, so a change
+/// requires a re-render of the cached markdown.
+- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics
+{
+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+
+  NSWritingDirection resolved = _resolvedLayoutDirection;
+  if (layoutMetrics.layoutDirection == LayoutDirection::RightToLeft) {
+    resolved = NSWritingDirectionRightToLeft;
+  } else if (layoutMetrics.layoutDirection == LayoutDirection::LeftToRight) {
+    resolved = NSWritingDirectionLeftToRight;
+  }
+
+  if (resolved != _resolvedLayoutDirection) {
+    _resolvedLayoutDirection = resolved;
+    if (_writingDirectionMode == ENRMWritingDirectionModeFirstStrong && _cachedMarkdown.length > 0) {
+      [self renderMarkdownContent:_cachedMarkdown];
+    }
+  }
+}
+
 - (void)requestHeightUpdate
 {
   ENRMRequestHeightUpdate<EnrichedMarkdownTextState>(_state, _heightUpdateCounter, self);
@@ -159,6 +186,9 @@ using namespace facebook::react;
     _forceHeightUpdateOnNextRender = NO;
     _selectionMenuConfig = (ENRMSelectionMenuConfig){.copyAsMarkdown = YES, .copyImageURL = YES};
     _lineBreakStrategy = NSLineBreakStrategyNone;
+    _writingDirectionMode = ENRMWritingDirectionModeFirstStrong;
+    _resolvedLayoutDirection =
+        [[RCTI18nUtil sharedInstance] isRTL] ? NSWritingDirectionRightToLeft : NSWritingDirectionLeftToRight;
 
     _fontScaleObserver = [[FontScaleObserver alloc] init];
     __weak EnrichedMarkdownText *weakSelf = self;
@@ -260,8 +290,8 @@ using namespace facebook::react;
   CGFloat maxFontSizeMultiplier = _maxFontSizeMultiplier;
   BOOL allowTrailingMargin = _allowTrailingMargin;
   NSLineBreakStrategy lineBreakStrategy = _lineBreakStrategy;
-
-  NSWritingDirection writingDirection = currentWritingDirection();
+  ENRMWritingDirectionMode writingDirectionMode = _writingDirectionMode;
+  NSWritingDirection resolvedLayoutDirection = _resolvedLayoutDirection;
 
   __block ENRMRenderResult *result = nil;
 
@@ -272,7 +302,8 @@ using namespace facebook::react;
           return NO;
 
         result = ENRMRenderASTNodes(ast.children, config, allowTrailingMargin, allowFontScaling, maxFontSizeMultiplier,
-                                    writingDirection, lineBreakStrategy);
+                                    lineBreakStrategy);
+        ENRMApplyWritingDirectionMode(result.attributedText, writingDirectionMode, resolvedLayoutDirection);
         return YES;
       }
       apply:^{
@@ -292,7 +323,8 @@ using namespace facebook::react;
 
   ENRMRenderResult *result =
       ENRMRenderASTNodes(ast.children, _config, _allowTrailingMargin, _fontScaleObserver.allowFontScaling,
-                         _maxFontSizeMultiplier, currentWritingDirection(), _lineBreakStrategy);
+                         _maxFontSizeMultiplier, _lineBreakStrategy);
+  ENRMApplyWritingDirectionMode(result.attributedText, _writingDirectionMode, _resolvedLayoutDirection);
 
   _lastElementMarginBottom = result.lastElementMarginBottom;
   _accessibilityInfo = result.accessibilityInfo;
@@ -523,8 +555,15 @@ using namespace facebook::react;
     _forceHeightUpdateOnNextRender = YES;
   }
 
+  BOOL writingDirectionChanged = newViewProps.writingDirection != oldViewProps.writingDirection;
+  if (writingDirectionChanged) {
+    NSString *value = [[NSString alloc] initWithUTF8String:newViewProps.writingDirection.c_str()];
+    _writingDirectionMode = ENRMResolveWritingDirectionMode(value);
+    _forceHeightUpdateOnNextRender = YES;
+  }
+
   if (markdownChanged || stylePropChanged || md4cFlagsChanged || allowTrailingMarginChanged ||
-      lineBreakStrategyChanged) {
+      lineBreakStrategyChanged || writingDirectionChanged) {
     _pendingStyleFingerprint =
         computeStyleFingerprint(newViewProps.markdownStyle) ^ std::hash<bool>{}(newViewProps.allowTrailingMargin);
     NSString *markdownString = [[NSString alloc] initWithUTF8String:newViewProps.markdown.c_str()];

--- a/ios/renderer/ListItemRenderer.m
+++ b/ios/renderer/ListItemRenderer.m
@@ -106,7 +106,6 @@ NSString *const TaskIndexAttribute = @"TaskIndex";
                     }
 
                     NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
-                    style.baseWritingDirection = currentWritingDirection();
                     style.firstLineHeadIndent = totalIndent;
                     style.headIndent = totalIndent;
 

--- a/ios/renderer/RenderContext.h
+++ b/ios/renderer/RenderContext.h
@@ -44,7 +44,6 @@ typedef NS_ENUM(NSInteger, ListType) { ListTypeUnordered, ListTypeOrdered };
 @property (nonatomic, assign) BOOL allowFontScaling;
 @property (nonatomic, assign) CGFloat maxFontSizeMultiplier;
 @property (nonatomic, assign) NSInteger taskItemCount;
-@property (nonatomic, assign) NSWritingDirection writingDirection;
 
 - (instancetype)init;
 - (void)reset;

--- a/ios/renderer/RenderContext.m
+++ b/ios/renderer/RenderContext.m
@@ -80,7 +80,6 @@
 - (NSMutableParagraphStyle *)spacerStyleWithHeight:(CGFloat)height spacing:(CGFloat)spacing
 {
   NSMutableParagraphStyle *style = [_baseSpacerTemplate mutableCopy];
-  style.baseWritingDirection = _writingDirection;
   style.minimumLineHeight = height;
   style.maximumLineHeight = height;
   style.paragraphSpacing = spacing;
@@ -90,7 +89,6 @@
 - (NSMutableParagraphStyle *)blockSpacerStyleWithMargin:(CGFloat)margin
 {
   NSMutableParagraphStyle *style = [_baseBlockSpacerTemplate mutableCopy];
-  style.baseWritingDirection = _writingDirection;
   style.paragraphSpacing = margin;
   return style;
 }

--- a/ios/utils/BlockquoteBorder.m
+++ b/ios/utils/BlockquoteBorder.m
@@ -1,6 +1,6 @@
 #import "BlockquoteBorder.h"
+#import "ParagraphStyleUtils.h"
 #import "StyleConfig.h"
-#import <React/RCTI18nUtil.h>
 
 // Attribute constants for identifying blockquote segments in text storage
 NSString *const BlockquoteDepthAttributeName = @"BlockquoteDepth";
@@ -41,9 +41,6 @@ NSString *const BlockquoteBackgroundColorAttributeName = @"BlockquoteBackgroundC
   RCTUIColor *defaultBgColor = c.blockquoteBackgroundColor;
   RCTUIColor *borderColor = c.blockquoteBorderColor;
 
-  BOOL isRTL = [[RCTI18nUtil sharedInstance] isRTL];
-
-  // Use a Bezier path to batch all vertical border rectangles into a single GPU draw call
   UIBezierPath *borderPath = [UIBezierPath bezierPath];
 
   [layoutManager
@@ -69,6 +66,7 @@ NSString *const BlockquoteBackgroundColorAttributeName = @"BlockquoteBackgroundC
 
                                  NSInteger depth = [depthNum integerValue];
                                  CGFloat baseY = origin.y + rect.origin.y;
+                                 BOOL isRTL = ENRMParagraphIsRTL(attrs[NSParagraphStyleAttributeName]);
 
                                  // 1. Draw Background (Painter's algorithm: draw backgrounds before borders)
                                  RCTUIColor *bgColor = attrs[BlockquoteBackgroundColorAttributeName] ?: defaultBgColor;

--- a/ios/utils/ENRMTextRenderer.h
+++ b/ios/utils/ENRMTextRenderer.h
@@ -21,7 +21,7 @@ extern "C" {
 
 ENRMRenderResult *ENRMRenderASTNodes(NSArray<MarkdownASTNode *> *nodes, StyleConfig *config, BOOL allowTrailingMargin,
                                      BOOL allowFontScaling, CGFloat maxFontSizeMultiplier,
-                                     NSWritingDirection writingDirection, NSLineBreakStrategy lineBreakStrategy);
+                                     NSLineBreakStrategy lineBreakStrategy);
 
 #ifdef __cplusplus
 }

--- a/ios/utils/ENRMTextRenderer.m
+++ b/ios/utils/ENRMTextRenderer.m
@@ -11,7 +11,7 @@
 
 ENRMRenderResult *ENRMRenderASTNodes(NSArray<MarkdownASTNode *> *nodes, StyleConfig *config, BOOL allowTrailingMargin,
                                      BOOL allowFontScaling, CGFloat maxFontSizeMultiplier,
-                                     NSWritingDirection writingDirection, NSLineBreakStrategy lineBreakStrategy)
+                                     NSLineBreakStrategy lineBreakStrategy)
 {
   MarkdownASTNode *root = [[MarkdownASTNode alloc] initWithType:MarkdownNodeTypeDocument];
   for (MarkdownASTNode *node in nodes) {
@@ -24,7 +24,6 @@ ENRMRenderResult *ENRMRenderASTNodes(NSArray<MarkdownASTNode *> *nodes, StyleCon
   RenderContext *context = [RenderContext new];
   context.allowFontScaling = allowFontScaling;
   context.maxFontSizeMultiplier = maxFontSizeMultiplier;
-  context.writingDirection = writingDirection;
 
   NSMutableAttributedString *attributedText = [renderer renderRoot:root context:context];
   [context applyLinkAttributesToString:attributedText];

--- a/ios/utils/HTMLGenerator.h
+++ b/ios/utils/HTMLGenerator.h
@@ -11,9 +11,11 @@ extern "C" {
 #endif
 
 /// Generates semantic HTML with inline styles (email-client compatible).
+/// Document direction is read from the first paragraph style of `attributedString`.
 NSString *_Nullable generateHTML(NSAttributedString *attributedString, StyleConfig *styleConfig);
 
 /// Generates an HTML `<table>` with inline styles from rows of cell dictionaries.
+/// Table direction is read from the first paragraph style of the first non-empty cell.
 NSString *_Nullable generateTableHTML(NSArray<NSArray<NSDictionary *> *> *rows, StyleConfig *styleConfig);
 
 #ifdef __cplusplus

--- a/ios/utils/HTMLGenerator.m
+++ b/ios/utils/HTMLGenerator.m
@@ -794,6 +794,14 @@ static void handleParagraph(NSMutableString *html, NSMutableString *inlineConten
 
 #pragma mark - Main Generator
 
+static NSString *dirAttrFromParagraphStyle(NSParagraphStyle *_Nullable style)
+{
+  if (!style || style.baseWritingDirection == NSWritingDirectionNatural) {
+    return @"auto";
+  }
+  return style.baseWritingDirection == NSWritingDirectionRightToLeft ? @"rtl" : @"ltr";
+}
+
 NSString *_Nullable generateHTML(NSAttributedString *attributedString, StyleConfig *styleConfig)
 {
   if (!attributedString || attributedString.length == 0)
@@ -801,17 +809,16 @@ NSString *_Nullable generateHTML(NSAttributedString *attributedString, StyleConf
 
   CachedStyles *styles = cacheStyles(styleConfig);
 
-  BOOL isRTL = currentWritingDirection() == NSWritingDirectionRightToLeft;
-  NSString *dirAttr = isRTL ? @" dir=\"rtl\"" : @"";
+  NSParagraphStyle *firstParagraphStyle = [attributedString attribute:NSParagraphStyleAttributeName
+                                                              atIndex:0
+                                                       effectiveRange:NULL];
+  NSString *dirAttr = dirAttrFromParagraphStyle(firstParagraphStyle);
 
   NSMutableString *html = [NSMutableString stringWithCapacity:attributedString.length * 2];
   [html appendFormat:
-            @"<!DOCTYPE html><html%@><head><meta charset=\"UTF-8\"></head><body "
+            @"<!DOCTYPE html><html dir=\"%@\"><head><meta charset=\"UTF-8\"></head><body "
             @"style=\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;\">",
             dirAttr];
-  if (isRTL) {
-    [html appendString:@"<div dir=\"rtl\" style=\"direction: rtl; text-align: right;\">"];
-  }
 
   NSUInteger paragraphCount = 0;
   NSData *paragraphsData = collectParagraphsData(attributedString, &paragraphCount);
@@ -885,9 +892,6 @@ NSString *_Nullable generateHTML(NSAttributedString *attributedString, StyleConf
   closeBlockquotes(html, state);
   closeLists(html, state);
 
-  if (isRTL) {
-    [html appendString:@"</div>"];
-  }
   [html appendString:@"</body></html>"];
 
   return html;
@@ -931,6 +935,21 @@ static NSString *styleForCell(BOOL isHeader, NSUInteger rowIndex, StyleConfig *s
                        colorToCSS(styleConfig.tableBorderColor), isHeader ? @"bold" : @"normal"];
 }
 
+static NSString *tableDirAttrFromRows(NSArray<NSArray<NSDictionary *> *> *rows)
+{
+  for (NSArray<NSDictionary *> *row in rows) {
+    for (NSDictionary *cell in row) {
+      NSAttributedString *cellText = cell[@"attributedText"];
+      if (cellText.length == 0) {
+        continue;
+      }
+      NSParagraphStyle *style = [cellText attribute:NSParagraphStyleAttributeName atIndex:0 effectiveRange:NULL];
+      return dirAttrFromParagraphStyle(style);
+    }
+  }
+  return @"auto";
+}
+
 HTMLString _Nullable generateTableHTML(NSArray<NSArray<NSDictionary *> *> *rows, StyleConfig *styleConfig)
 {
   if (rows.count == 0)
@@ -939,11 +958,13 @@ HTMLString _Nullable generateTableHTML(NSArray<NSArray<NSDictionary *> *> *rows,
   CachedStyles *cachedStyles = cacheStyles(styleConfig);
   NSMutableString *htmlOutput = [NSMutableString stringWithCapacity:rows.count * 250];
 
+  NSString *dirAttr = tableDirAttrFromRows(rows);
+
   [htmlOutput appendFormat:
-                  @"<table style=\"border-collapse: separate; border-spacing: 0; "
+                  @"<table dir=\"%@\" style=\"border-collapse: separate; border-spacing: 0; "
                    "border: %.0fpx solid %@; border-radius: %.0fpx; overflow: hidden; font-size: %.0fpx;\">",
-                  styleConfig.tableBorderWidth, colorToCSS(styleConfig.tableBorderColor), styleConfig.tableBorderRadius,
-                  styleConfig.tableFontSize];
+                  dirAttr, styleConfig.tableBorderWidth, colorToCSS(styleConfig.tableBorderColor),
+                  styleConfig.tableBorderRadius, styleConfig.tableFontSize];
 
   BOOL hasOpenedBody = NO;
   NSUInteger bodyRowIndex = 0;

--- a/ios/utils/ListMarkerDrawer.m
+++ b/ios/utils/ListMarkerDrawer.m
@@ -1,9 +1,9 @@
 #import "ListMarkerDrawer.h"
 #import "ENRMUIKit.h"
 #import "ListItemRenderer.h"
+#import "ParagraphStyleUtils.h"
 #import "RenderContext.h"
 #import "StyleConfig.h"
-#import <React/RCTI18nUtil.h>
 
 extern NSString *const ListDepthAttribute;
 extern NSString *const ListTypeAttribute;
@@ -32,8 +32,6 @@ extern NSString *const TaskCheckedAttribute;
   if (!storage || storage.length == 0)
     return;
 
-  // Cache gap and track paragraphs to prevent double-drawing on wrapped lines
-  BOOL isRTL = [[RCTI18nUtil sharedInstance] isRTL];
   CGFloat gap = [_config effectiveListGapWidth];
   NSMutableSet *drawnParagraphs = [NSMutableSet set];
 
@@ -59,7 +57,8 @@ extern NSString *const TaskCheckedAttribute;
                                    return;
                                  [drawnParagraphs addObject:@(paraRange.location)];
 
-                                 // 3. Calculate Layout Coordinates
+                                 BOOL isRTL = ENRMParagraphIsRTL(attrs[NSParagraphStyleAttributeName]);
+
                                  CGPoint glyphLoc = [layoutManager locationForGlyphAtIndex:glyphRange.location];
                                  CGFloat baselineY = origin.y + rect.origin.y + glyphLoc.y;
                                  CGFloat markerX;

--- a/ios/utils/ParagraphStyleUtils.h
+++ b/ios/utils/ParagraphStyleUtils.h
@@ -7,10 +7,36 @@ __BEGIN_DECLS
 
 extern NSAttributedString *kNewlineAttributedString;
 
-NSWritingDirection currentWritingDirection(void);
 NSLineBreakStrategy ENRMResolveLineBreakStrategy(NSString *_Nullable strategy);
 void ENRMApplyLineBreakStrategyToParagraphStyles(NSMutableAttributedString *output,
                                                  NSLineBreakStrategy lineBreakStrategy);
+
+/// Auto/LTR/RTL match React Native's writingDirection prop.
+/// FirstStrong is the library extension: resolve each paragraph from its first strong
+/// directional character (matches Android's TEXT_DIRECTION_FIRST_STRONG).
+typedef NS_ENUM(NSInteger, ENRMWritingDirectionMode) {
+  ENRMWritingDirectionModeAuto,
+  ENRMWritingDirectionModeLTR,
+  ENRMWritingDirectionModeRTL,
+  ENRMWritingDirectionModeFirstStrong,
+};
+
+ENRMWritingDirectionMode ENRMResolveWritingDirectionMode(NSString *_Nullable value);
+
+void ENRMApplyWritingDirectionToParagraphStyles(NSMutableAttributedString *output, NSWritingDirection writingDirection);
+
+NSWritingDirection ENRMFirstStrongDirection(NSString *text);
+
+/// Paragraphs without a strong character fall back to `fallback`. Code blocks are skipped.
+void ENRMApplyFirstStrongParagraphDirections(NSMutableAttributedString *output, NSWritingDirection fallback);
+
+/// Falls back to the app's UI layout direction when the style is missing or Natural.
+BOOL ENRMParagraphIsRTL(NSParagraphStyle *_Nullable style);
+
+/// Dispatch entry point used after every render pass. `layoutDirection` is the
+/// fallback for FirstStrong neutral paragraphs and is unused for the other modes.
+void ENRMApplyWritingDirectionMode(NSMutableAttributedString *output, ENRMWritingDirectionMode mode,
+                                   NSWritingDirection layoutDirection);
 
 NSMutableParagraphStyle *getOrCreateParagraphStyle(NSMutableAttributedString *output, NSUInteger index);
 void applyParagraphSpacingAfter(NSMutableAttributedString *output, NSUInteger start, CGFloat marginBottom);

--- a/ios/utils/ParagraphStyleUtils.m
+++ b/ios/utils/ParagraphStyleUtils.m
@@ -1,4 +1,5 @@
 #import "ParagraphStyleUtils.h"
+#import "LastElementUtils.h"
 #import <React/RCTI18nUtil.h>
 
 NSAttributedString *kNewlineAttributedString;
@@ -26,17 +27,140 @@ __attribute__((constructor)) static void initParagraphStyleUtils(void)
   kBlockSpacerTemplate = [template copy];
 }
 
-NSWritingDirection currentWritingDirection(void)
+ENRMWritingDirectionMode ENRMResolveWritingDirectionMode(NSString *value)
 {
-  BOOL isRTL = [[RCTI18nUtil sharedInstance] isRTL];
-  return isRTL ? NSWritingDirectionRightToLeft : NSWritingDirectionLeftToRight;
+  if ([value isEqualToString:@"ltr"]) {
+    return ENRMWritingDirectionModeLTR;
+  }
+  if ([value isEqualToString:@"rtl"]) {
+    return ENRMWritingDirectionModeRTL;
+  }
+  if ([value isEqualToString:@"auto"]) {
+    return ENRMWritingDirectionModeAuto;
+  }
+  return ENRMWritingDirectionModeFirstStrong;
+}
+
+static BOOL ENRMIsStrongRTLChar(unichar c)
+{
+  return (c >= 0x0590 && c <= 0x08FF) || (c >= 0xFB1D && c <= 0xFDFF) || (c >= 0xFE70 && c <= 0xFEFF);
+}
+
+NSWritingDirection ENRMFirstStrongDirection(NSString *text)
+{
+  NSCharacterSet *letters = [NSCharacterSet letterCharacterSet];
+  NSUInteger length = text.length;
+  for (NSUInteger i = 0; i < length; i++) {
+    unichar c = [text characterAtIndex:i];
+    if (ENRMIsStrongRTLChar(c)) {
+      return NSWritingDirectionRightToLeft;
+    }
+    if ([letters characterIsMember:c]) {
+      return NSWritingDirectionLeftToRight;
+    }
+  }
+  return NSWritingDirectionNatural;
+}
+
+BOOL ENRMParagraphIsRTL(NSParagraphStyle *style)
+{
+  if (style && style.baseWritingDirection != NSWritingDirectionNatural) {
+    return style.baseWritingDirection == NSWritingDirectionRightToLeft;
+  }
+  return [[RCTI18nUtil sharedInstance] isRTL];
+}
+
+void ENRMApplyWritingDirectionMode(NSMutableAttributedString *output, ENRMWritingDirectionMode mode,
+                                   NSWritingDirection layoutDirection)
+{
+  switch (mode) {
+    case ENRMWritingDirectionModeAuto:
+      break;
+    case ENRMWritingDirectionModeLTR:
+      ENRMApplyWritingDirectionToParagraphStyles(output, NSWritingDirectionLeftToRight);
+      break;
+    case ENRMWritingDirectionModeRTL:
+      ENRMApplyWritingDirectionToParagraphStyles(output, NSWritingDirectionRightToLeft);
+      break;
+    case ENRMWritingDirectionModeFirstStrong:
+      ENRMApplyFirstStrongParagraphDirections(output, layoutDirection);
+      break;
+  }
+}
+
+void ENRMApplyFirstStrongParagraphDirections(NSMutableAttributedString *output, NSWritingDirection fallback)
+{
+  if (output.length == 0) {
+    return;
+  }
+  NSString *string = output.string;
+  NSUInteger length = string.length;
+  NSUInteger position = 0;
+  while (position < length) {
+    NSRange paragraphRange = [string paragraphRangeForRange:NSMakeRange(position, 0)];
+    if (NSMaxRange(paragraphRange) <= position) {
+      break;
+    }
+    position = NSMaxRange(paragraphRange);
+
+    NSNumber *isCodeBlock = [output attribute:CodeBlockAttributeName
+                                      atIndex:paragraphRange.location
+                               effectiveRange:nil];
+    if (isCodeBlock.boolValue) {
+      continue;
+    }
+
+    NSWritingDirection direction = ENRMFirstStrongDirection([string substringWithRange:paragraphRange]);
+    if (direction == NSWritingDirectionNatural) {
+      direction = fallback;
+    }
+    if (direction == NSWritingDirectionNatural) {
+      continue;
+    }
+
+    [output enumerateAttribute:NSParagraphStyleAttributeName
+                       inRange:paragraphRange
+                       options:0
+                    usingBlock:^(NSParagraphStyle *style, NSRange range, BOOL *stop) {
+                      if (style != nil && style.baseWritingDirection == direction) {
+                        return;
+                      }
+                      NSMutableParagraphStyle *updated =
+                          style ? [style mutableCopy] : [[NSMutableParagraphStyle alloc] init];
+                      updated.baseWritingDirection = direction;
+                      [output addAttribute:NSParagraphStyleAttributeName value:updated range:range];
+                    }];
+  }
+}
+
+void ENRMApplyWritingDirectionToParagraphStyles(NSMutableAttributedString *output, NSWritingDirection writingDirection)
+{
+  if (output.length == 0 || writingDirection == NSWritingDirectionNatural) {
+    return;
+  }
+  [output enumerateAttribute:NSParagraphStyleAttributeName
+                     inRange:NSMakeRange(0, output.length)
+                     options:0
+                  usingBlock:^(NSParagraphStyle *style, NSRange range, BOOL *stop) {
+                    if (!style) {
+                      return;
+                    }
+                    NSNumber *isCodeBlock = [output attribute:CodeBlockAttributeName
+                                                      atIndex:range.location
+                                               effectiveRange:nil];
+                    if (isCodeBlock.boolValue) {
+                      return;
+                    }
+                    NSMutableParagraphStyle *mutable = [style mutableCopy];
+                    mutable.baseWritingDirection = writingDirection;
+                    [output addAttribute:NSParagraphStyleAttributeName value:mutable range:range];
+                  }];
 }
 
 NSMutableParagraphStyle *getOrCreateParagraphStyle(NSMutableAttributedString *output, NSUInteger index)
 {
   NSParagraphStyle *existing = [output attribute:NSParagraphStyleAttributeName atIndex:index effectiveRange:NULL];
   NSMutableParagraphStyle *style = existing ? [existing mutableCopy] : [[NSMutableParagraphStyle alloc] init];
-  style.baseWritingDirection = currentWritingDirection();
   return style;
 }
 
@@ -69,7 +193,6 @@ NSUInteger applyParagraphSpacingBefore(NSMutableAttributedString *output, NSRang
   CGFloat extraGap = marginTop - prevMarginBottom;
 
   NSMutableParagraphStyle *spacerStyle = [kBlockSpacerTemplate mutableCopy];
-  spacerStyle.baseWritingDirection = currentWritingDirection();
   spacerStyle.paragraphSpacing = MAX(0, extraGap - 1.0);
 
   NSDictionary *attrs = @{NSParagraphStyleAttributeName : spacerStyle};
@@ -95,7 +218,6 @@ NSUInteger applyBlockSpacingBefore(NSMutableAttributedString *output, NSUInteger
   }
 
   NSMutableParagraphStyle *spacerStyle = [kBlockSpacerTemplate mutableCopy];
-  spacerStyle.baseWritingDirection = currentWritingDirection();
   spacerStyle.paragraphSpacing = spacing;
 
   NSAttributedString *spacer =
@@ -115,7 +237,6 @@ void applyBlockSpacingAfter(NSMutableAttributedString *output, CGFloat marginBot
   [output appendAttributedString:kNewlineAttributedString];
 
   NSMutableParagraphStyle *spacerStyle = [kBlockSpacerTemplate mutableCopy];
-  spacerStyle.baseWritingDirection = currentWritingDirection();
   spacerStyle.paragraphSpacing = marginBottom;
 
   [output addAttribute:NSParagraphStyleAttributeName value:spacerStyle range:NSMakeRange(spacerLocation, 1)];

--- a/ios/utils/ParagraphStyleUtils.m
+++ b/ios/utils/ParagraphStyleUtils.m
@@ -52,12 +52,10 @@ NSWritingDirection ENRMFirstStrongDirection(NSString *text)
   NSUInteger length = text.length;
   for (NSUInteger i = 0; i < length; i++) {
     unichar c = [text characterAtIndex:i];
-    if (ENRMIsStrongRTLChar(c)) {
-      return NSWritingDirectionRightToLeft;
+    if (![letters characterIsMember:c]) {
+      continue;
     }
-    if ([letters characterIsMember:c]) {
-      return NSWritingDirectionLeftToRight;
-    }
+    return ENRMIsStrongRTLChar(c) ? NSWritingDirectionRightToLeft : NSWritingDirectionLeftToRight;
   }
   return NSWritingDirectionNatural;
 }

--- a/ios/utils/SegmentRenderer.m
+++ b/ios/utils/SegmentRenderer.m
@@ -60,9 +60,8 @@ NSArray<ENRMRenderedSegment *> *ENRMRenderSegmentsFromAST(MarkdownASTNode *ast, 
   for (id segment in segments) {
     if ([segment isKindOfClass:[ENRMTextSegment class]]) {
       ENRMTextSegment *textSegment = (ENRMTextSegment *)segment;
-      ENRMRenderResult *rendered =
-          ENRMRenderASTNodes(textSegment.nodes, config, allowTrailingMargin, allowFontScaling, maxFontSizeMultiplier,
-                             currentWritingDirection(), lineBreakStrategy);
+      ENRMRenderResult *rendered = ENRMRenderASTNodes(textSegment.nodes, config, allowTrailingMargin, allowFontScaling,
+                                                      maxFontSizeMultiplier, lineBreakStrategy);
       uint64_t signature = ENRMSignatureForNodes(textSegment.nodes) ^ kTextKindSalt;
       [renderedSegments addObject:[ENRMRenderedSegment textSegmentWithResult:rendered signature:signature]];
     } else if ([segment isKindOfClass:[ENRMTableSegment class]]) {

--- a/ios/utils/TaskListTapUtils.m
+++ b/ios/utils/TaskListTapUtils.m
@@ -1,8 +1,8 @@
 #import "TaskListTapUtils.h"
 #import "ENRMUIKit.h"
 #import "ListItemRenderer.h"
+#import "ParagraphStyleUtils.h"
 #import "StyleConfig.h"
-#import <React/RCTI18nUtil.h>
 #include <TargetConditionals.h>
 
 TaskListHitTestResult taskListHitTest(ENRMPlatformTextView *textView, ENRMTapRecognizer *recognizer)
@@ -31,7 +31,7 @@ TaskListHitTestResult taskListHitTest(ENRMPlatformTextView *textView, ENRMTapRec
   NSParagraphStyle *style = attributes[NSParagraphStyleAttributeName];
   CGFloat checkboxWidth = style ? style.firstLineHeadIndent : 0;
 
-  BOOL isRTL = [[RCTI18nUtil sharedInstance] isRTL];
+  BOOL isRTL = ENRMParagraphIsRTL(style);
   if (isRTL) {
     CGFloat viewWidth = textView.bounds.size.width;
     if (tapPoint.x <= viewWidth - checkboxWidth) {

--- a/ios/views/TableContainerView.h
+++ b/ios/views/TableContainerView.h
@@ -1,5 +1,6 @@
 #pragma once
 #import "ENRMUIKit.h"
+#import "ParagraphStyleUtils.h"
 #import "StyleConfig.h"
 
 @class MarkdownASTNode;
@@ -25,6 +26,9 @@ typedef void (^TableLinkPressBlock)(NSString *url);
 @property (nonatomic, copy, nullable) TableLinkPressBlock onLinkLongPress;
 
 @property (nonatomic, assign) BOOL enableLinkPreview;
+
+@property (nonatomic, assign) ENRMWritingDirectionMode writingDirectionMode;
+@property (nonatomic, assign) NSWritingDirection resolvedLayoutDirection;
 
 @property (nonatomic, readonly) NSUInteger rowCount;
 

--- a/ios/views/TableContainerView.m
+++ b/ios/views/TableContainerView.m
@@ -57,6 +57,8 @@
     _allowFontScaling = YES;
     _maxFontSizeMultiplier = 0;
     _enableLinkPreview = YES;
+    _writingDirectionMode = ENRMWritingDirectionModeFirstStrong;
+    _resolvedLayoutDirection = NSWritingDirectionLeftToRight;
     [self setupScrollView];
   }
   return self;
@@ -138,6 +140,8 @@
 
   [context applyLinkAttributesToString:attributedText];
 
+  ENRMApplyWritingDirectionMode(attributedText, _writingDirectionMode, _resolvedLayoutDirection);
+
   if (alignment != NSTextAlignmentLeft && attributedText.length > 0) {
     NSRange fullRange = NSMakeRange(0, attributedText.length);
     [attributedText
@@ -147,7 +151,6 @@
                 usingBlock:^(NSParagraphStyle *paragraphStyle, NSRange range, BOOL *stop) {
                   NSMutableParagraphStyle *mutableStyle =
                       paragraphStyle ? [paragraphStyle mutableCopy] : [[NSMutableParagraphStyle alloc] init];
-                  mutableStyle.baseWritingDirection = currentWritingDirection();
                   mutableStyle.alignment = alignment;
                   [attributedText addAttribute:NSParagraphStyleAttributeName value:mutableStyle range:range];
                 }];

--- a/src/EnrichedMarkdownNativeComponent.ts
+++ b/src/EnrichedMarkdownNativeComponent.ts
@@ -411,6 +411,17 @@ export interface NativeProps extends ViewProps {
    * @platform ios
    */
   lineBreakStrategyIOS?: CodegenTypes.WithDefault<string, 'none'>;
+  /**
+   * Paragraph writing direction.
+   * - 'first-strong' (default): resolves each paragraph from its first strong directional character;
+   *   neutral-only paragraphs fall back to the view's resolved layout direction. Library extension —
+   *   matches Android's TEXT_DIRECTION_FIRST_STRONG.
+   * - 'auto': React Native parity; iOS TextKit follows the app's userInterfaceLayoutDirection.
+   * - 'ltr' / 'rtl': force base direction on every paragraph. Code blocks always stay LTR.
+   * @default 'first-strong'
+   * @platform ios
+   */
+  writingDirection?: CodegenTypes.WithDefault<string, 'first-strong'>;
 }
 
 export default codegenNativeComponent<NativeProps>('EnrichedMarkdown', {

--- a/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/src/EnrichedMarkdownTextNativeComponent.ts
@@ -410,6 +410,17 @@ export interface NativeProps extends ViewProps {
    * @platform ios
    */
   lineBreakStrategyIOS?: CodegenTypes.WithDefault<string, 'none'>;
+  /**
+   * Paragraph writing direction.
+   * - 'first-strong' (default): resolves each paragraph from its first strong directional character;
+   *   neutral-only paragraphs fall back to the view's resolved layout direction. Library extension —
+   *   matches Android's TEXT_DIRECTION_FIRST_STRONG.
+   * - 'auto': React Native parity; iOS TextKit follows the app's userInterfaceLayoutDirection.
+   * - 'ltr' / 'rtl': force base direction on every paragraph. Code blocks always stay LTR.
+   * @default 'first-strong'
+   * @platform ios
+   */
+  writingDirection?: CodegenTypes.WithDefault<string, 'first-strong'>;
 }
 
 export default codegenNativeComponent<NativeProps>('EnrichedMarkdownText', {

--- a/src/native/EnrichedMarkdownText.tsx
+++ b/src/native/EnrichedMarkdownText.tsx
@@ -58,6 +58,7 @@ export const EnrichedMarkdownText = ({
   selectionHandleColor,
   textBreakStrategy,
   lineBreakStrategyIOS,
+  writingDirection = 'first-strong',
   ...rest
 }: EnrichedMarkdownTextProps) => {
   const normalizedStyleRef = useRef<MarkdownStyleInternal | null>(null);
@@ -172,6 +173,7 @@ export const EnrichedMarkdownText = ({
     selectionHandleColor,
     textBreakStrategy,
     lineBreakStrategyIOS,
+    writingDirection,
     ...rest,
   };
 

--- a/src/types/MarkdownTextProps.ts
+++ b/src/types/MarkdownTextProps.ts
@@ -235,4 +235,19 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    * @platform ios
    */
   lineBreakStrategyIOS?: 'none' | 'standard' | 'hangul-word' | 'push-out';
+  /**
+   * Paragraph writing direction.
+   * - `'first-strong'` (default): resolves each paragraph from its first strong
+   *   directional character. Neutral-only paragraphs fall back to the view's
+   *   resolved layout direction (inherits ancestor `direction` style). Library
+   *   extension beyond React Native — matches Android's `TEXT_DIRECTION_FIRST_STRONG`.
+   * - `'auto'`: React Native parity. iOS TextKit follows the app's
+   *   `userInterfaceLayoutDirection`; mixed-direction paragraphs do not
+   *   auto-resolve.
+   * - `'ltr'` / `'rtl'`: force base direction on every paragraph. Code blocks
+   *   always stay LTR.
+   * @default 'first-strong'
+   * @platform ios
+   */
+  writingDirection?: 'auto' | 'ltr' | 'rtl' | 'first-strong';
 }


### PR DESCRIPTION
### What/Why?
iOS had no per-paragraph writing direction auto-detection. Every paragraph (and every piece of chrome - list markers, blockquote borders, task-list tap targets, copy-as-HTML) was forced to a single direction read from the app-global `RCTI18nUtil.isRTL`. That's broken for mixed-direction content: an LLM chat with an English UI receiving Arabic answers would render those answers left-aligned with LTR chrome, while Android renders them correctly via `TEXT_DIRECTION_FIRST_STRONG`.

This PR adds a `writingDirection` prop (iOS only) and makes iOS match Android by default:
| Value | Behavior |
|---|---|
| `'first-strong'` (default) | New library extension. Resolves each paragraph from its first strong directional character; neutral-only paragraphs (digits, punctuation) fall back to the view's Yoga-resolved layout direction (inherits ancestor `<View style={{ direction: 'rtl' }}>`, defaults to `I18nManager.isRTL`). Mirrors Android's `TEXT_DIRECTION_FIRST_STRONG`. |
| `'auto'` | React Native parity. iOS TextKit follows the app's `userInterfaceLayoutDirection`. |
| `'ltr'` / `'rtl'` | Forces base direction on every paragraph. |

Code blocks always stay LTR. Chrome (list markers, blockquote borders, task-list tap hit-tests, copy-as-HTML `dir` attribute) now reads the per-paragraph baked direction instead of the global flag, so a single document with mixed-direction paragraphs renders correctly piece by piece.

Android already does per-paragraph first-strong via the platform `StaticLayout` default and is intentionally unchanged. The prop is a no-op there. The previous app-global `currentWritingDirection()` indirection is removed.

#### Additional changes
- added dirty flag that replaces big if (clause || clause2 || ... ) blocks from prop update logic


### Testing

##### Storybook 
new story at `EnrichedMarkdownText > Props > Writing Direction`. Flip between all four values with mixed Arabic/English markdown and verify each mode renders as documented.

##### Manual checks
- Mixed Arabic/English doc in `first-strong` mode → each paragraph picks its own side; list markers, blockquote borders, and task-list checkboxes follow per paragraph.
- Pure-Arabic paragraph in an LTR app → right-aligned (was left-aligned before).
- Neutral-only paragraph (`123 456 789.`) inside `<View style={{ direction: 'rtl' }}>` → right-aligned (Yoga fallback).
- `writingDirection="rtl"` → every paragraph forced RTL; code blocks still LTR.
- `writingDirection="ltr"` → every paragraph forced LTR.
- `writingDirection="auto"` → RN parity (follows app UI direction).
- Copy-as-HTML on iOS → `dir` attribute on `<html>` reflects the rendered first paragraph's direction.
- Android: switch through all four values; nothing changes (prop is inert), no regressions on existing markdown content.



#### Screenshots
Keeping this to one video for simplicity (android is no-op)

https://github.com/user-attachments/assets/17b80269-b7d1-4c7b-95c6-93ec267037ad

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

closes #394 
closes #330 

