### PR TITLE
feat(ios): input element detect RTL 

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
@@ -296,6 +296,15 @@ class EnrichedMarkdownTextInputManager :
     view?.setMentionIndicators(indicators)
   }
 
+  @ReactProp(name = "writingDirection")
+  override fun setWritingDirection(
+    view: EnrichedMarkdownTextInputView?,
+    value: String?,
+  ) {
+    // No-op on Android — EditText resolves direction per paragraph via
+    // TEXT_DIRECTION_FIRST_STRONG (the platform default).
+  }
+
   override fun updateProperties(
     view: EnrichedMarkdownTextInputView,
     props: ReactStylesDiffMap,

--- a/apps/example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/props/WritingDirection.stories.tsx
+++ b/apps/example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/props/WritingDirection.stories.tsx
@@ -44,7 +44,7 @@ export const Default: InputStory<WritingDirectionStoryExtra> = {
   render: ({ writingDirection, ...args }) => (
     <EnrichedMarkdownTextInputStory
       title="Writing Direction"
-      description="iOS only. Type Arabic/Hebrew/Persian to see per-paragraph auto-detection; switch modes to compare against 'auto' (RN parity — follows the app's UI direction), and forced 'ltr'/'rtl'. Android always uses first-strong via the platform EditText."
+      description="iOS only. Type Arabic/Hebrew/Persian to see per-paragraph auto-detection; switch modes to compare against 'auto' (RN parity - follows the app's UI direction), and forced 'ltr'/'rtl'. Android always uses first-strong via the platform EditText."
       {...args}
       writingDirection={writingDirection}
     />

--- a/apps/example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/props/WritingDirection.stories.tsx
+++ b/apps/example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/props/WritingDirection.stories.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { EnrichedMarkdownTextInputStory } from '../EnrichedMarkdownTextInputStory';
+import { storyMeta } from '../shared/storyMeta';
+import type { InputStory } from '../shared/storyTypes';
+
+type WritingDirection = 'auto' | 'ltr' | 'rtl' | 'first-strong';
+
+type WritingDirectionStoryExtra = {
+  writingDirection: WritingDirection;
+};
+
+const INITIAL_MARKDOWN = `# عنوان عربي
+
+هذه فقرة عربية تتبع اتجاه اليمين إلى اليسار تلقائيًا حسب أول حرف قوي فيها.
+
+This English paragraph stays left-to-right in the same document.
+
+123 456 789.`;
+
+const WRITING_DIRECTION_OPTIONS: WritingDirection[] = [
+  'first-strong',
+  'auto',
+  'ltr',
+  'rtl',
+];
+
+const argTypes = {
+  writingDirection: {
+    options: WRITING_DIRECTION_OPTIONS,
+    control: { type: 'inline-radio' as const },
+    description:
+      "'first-strong' (default): resolve per paragraph from its first strong directional character; neutral-only paragraphs fall back to the view's layout direction. 'auto': React Native parity, follows the app's UI layout direction. 'ltr'/'rtl': force base direction on every paragraph.",
+  },
+};
+
+export default storyMeta('Props', 'Writing Direction');
+
+export const Default: InputStory<WritingDirectionStoryExtra> = {
+  args: {
+    initialMarkdown: INITIAL_MARKDOWN,
+    writingDirection: 'first-strong',
+  },
+  argTypes,
+  render: ({ writingDirection, ...args }) => (
+    <EnrichedMarkdownTextInputStory
+      title="Writing Direction"
+      description="iOS only. Type Arabic/Hebrew/Persian to see per-paragraph auto-detection; switch modes to compare against 'auto' (RN parity — follows the app's UI direction), and forced 'ltr'/'rtl'. Android always uses first-strong via the platform EditText."
+      {...args}
+      writingDirection={writingDirection}
+    />
+  ),
+};

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -2489,7 +2489,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: 52e1e04154c2786defb1149ebf593d495dae2ae3
+  hermes-engine: 7a5738e17537a638701b58a7488ab83a72cddf11
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc
   RCTSwiftUI: 239ed2eb9e73de5a6f518810630f0c95e01c8702
@@ -2498,7 +2498,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 6147d6e420f7eafc5b747002205a958e115878ca
+  React-Core-prebuilt: 300f1f7da5b63a2c480bde8dfc5cde8843905766
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 9af1e96a6069c996e3d9f1e493603e74bc9f1593
@@ -2562,7 +2562,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: 7016a2114079361a2f1536b3c91a15ceb8eb7ca4
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: 75a2f59992523e6ad820ee08850c05a865d2dc63
+  ReactNativeDependencies: c6c22887dcb9997b770c6751e2a8b7c528e29363
   ReactNativeEnrichedMarkdown: 15ee1297ff2df94e80d06b7d86c13e5fbbcb806a
   RNCAsyncStorage: 7d913885caaae13f5fb62dd0bd04c674ea8bf97b
   RNDateTimePicker: afe0288e6c7855994f7f2617b7b2c05799fea7f3

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -617,6 +617,20 @@ Fires when the active mention flow ends.
 | ---- | ------------- | -------- |
 | `(event: { indicator: string }) => void` | - | Both |
 
+### `writingDirection`
+
+Paragraph writing direction in the input. iOS only — Android's `EditText` already resolves direction per paragraph via `TEXT_DIRECTION_FIRST_STRONG` and is unaffected by this prop.
+
+| Type                                            | Default Value    | Platform |
+| ----------------------------------------------- | ---------------- | -------- |
+| `'auto' \| 'ltr' \| 'rtl' \| 'first-strong'`    | `'first-strong'` | iOS      |
+
+- **`'first-strong'`** (default): each paragraph resolves its base direction from its first strong directional character. Neutral-only paragraphs fall back to the view's Yoga-resolved layout direction. Mirrors Android's platform behavior.
+- **`'auto'`**: React Native parity. TextKit follows the app's `userInterfaceLayoutDirection`; mixed-direction paragraphs do not auto-resolve.
+- **`'ltr'` / `'rtl'`**: forces the base direction on every paragraph in the input.
+
+See [INPUT — RTL Support](INPUT.md#rtl-support) for caveats (placeholder direction, mixed-paragraph typing).
+
 ### `contextMenuItems`
 
 Custom items to add to the text selection context menu. Items appear before the system actions (Copy, Cut, etc.). Items with `visible: false` are hidden from the menu.

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -169,6 +169,38 @@ You can find some examples in the [usage section](#usage) or in the example app.
 - [onChangeMarkdown](API_REFERENCE.md#onchangemarkdown) - returns the Markdown string parsed from current input text and styles anytime it would change. As parsing the Markdown on each input change can be expensive, not assigning the event's callback will skip the serialization for better performance.
 - [onChangeSelection](API_REFERENCE.md#onchangeselection) - returns `{ start, end }` of the current selection, useful for working with [links](#links).
 
+## RTL Support
+
+`EnrichedMarkdownTextInput` resolves writing direction **per paragraph**, matching the read-only [`EnrichedMarkdownText`](RTL.md) renderer. Arabic, Hebrew, and Persian content right-aligns automatically as the user types — even mixed with English paragraphs in the same input.
+
+### Platform setup
+
+No setup is required. Both platforms autodetect direction per paragraph out of the box.
+
+- **Android** — `EditText` resolves direction per paragraph via `View.TEXT_DIRECTION_FIRST_STRONG` (the platform default). The [`writingDirection`](#writingdirection-prop-ios) prop is accepted but has no effect.
+- **iOS** — TextKit's `NSWritingDirectionNatural` follows the app's global UI layout direction and does not do per-paragraph first-strong. The library applies first-strong itself after every formatting pass. The mode is controlled by [`writingDirection`](#writingdirection-prop-ios) and defaults to `'first-strong'`.
+
+### `writingDirection` prop (iOS)
+
+| Value | Behavior |
+|---|---|
+| `'first-strong'` (default) | Per-paragraph autodetection. Neutral-only paragraphs fall back to the view's resolved layout direction. Matches Android. |
+| `'auto'` | React Native parity. TextKit follows the app's `userInterfaceLayoutDirection`; mixed-direction documents do not auto-resolve. |
+| `'ltr'` | Forces LTR on every paragraph. |
+| `'rtl'` | Forces RTL on every paragraph. |
+
+```tsx
+<EnrichedMarkdownTextInput writingDirection="rtl" placeholder="اكتب هنا..." />
+```
+
+### Known limitations
+
+- **Placeholder** follows the host view's layout direction, not the prop. If you need an RTL placeholder, wrap the input in `<View style={{ direction: 'rtl' }}>` or set `I18nManager.forceRTL(true)`.
+- **Mixed paragraphs while typing** — newly inserted characters in an empty paragraph briefly inherit the previous paragraph's direction; the first-strong pass corrects this on the next input event.
+- **Code blocks, tables, blockquotes, lists** are not supported in the input (it's a flat inline-formatting surface). For those, use [`EnrichedMarkdownText`](TEXT.md).
+
+See [RTL Support](RTL.md) for the full per-element behavior on the rendered output side.
+
 ## Customizing \<EnrichedMarkdownTextInput /> Styles
 
 `EnrichedMarkdownTextInput` accepts a `markdownStyle` prop for customizing how formatted text appears in the input:

--- a/docs/RTL.md
+++ b/docs/RTL.md
@@ -2,6 +2,8 @@
 
 `react-native-enriched-markdown` resolves writing direction **per paragraph** on both platforms: each paragraph picks its own base direction from its first strong directional character. Arabic, Hebrew, and Persian content right-aligns automatically, even inside an LTR app and even when mixed with English paragraphs in the same document.
 
+This document describes the read-only [`EnrichedMarkdownText`](TEXT.md) renderer. The rich [`EnrichedMarkdownTextInput`](INPUT.md#rtl-support) follows the same per-paragraph rules — see its [RTL section](INPUT.md#rtl-support) for input-specific caveats (placeholder, code blocks, etc.).
+
 ## Platform Setup
 
 No setup is required. Both platforms autodetect direction per paragraph out of the box.

--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -607,12 +607,10 @@ using namespace facebook::react;
   _isApplyingFormatting = NO;
 }
 
-/// Per-paragraph first-strong (or forced ltr/rtl) pass over the input's text storage.
-/// 'auto' is a no-op — TextKit follows the app's UI layout direction in that mode.
 - (void)applyWritingDirection
 {
   NSTextStorage *textStorage = _textView.textStorage;
-  if (textStorage.length == 0 || _writingDirectionMode == ENRMWritingDirectionModeAuto) {
+  if (textStorage.length == 0) {
     return;
   }
   [textStorage beginEditing];

--- a/ios/input/EnrichedMarkdownTextInput.mm
+++ b/ios/input/EnrichedMarkdownTextInput.mm
@@ -17,7 +17,9 @@
 #import "ENRMUIKit.h"
 #import "ENRMWordsUtils.h"
 #import "InputStylePropsUtils.h"
+#import "ParagraphStyleUtils.h"
 #import "SelectionColorUtils.h"
+#import <React/RCTI18nUtil.h>
 #if TARGET_OS_OSX
 #import <React/RCTBackedTextInputDelegate.h>
 #endif
@@ -84,6 +86,9 @@ using namespace facebook::react;
 
   ENRMAutoLinkDetector *_autoLinkDetector;
   ENRMDetectorPipeline *_detectorPipeline;
+
+  ENRMWritingDirectionMode _writingDirectionMode;
+  NSWritingDirection _resolvedLayoutDirection;
 }
 
 #pragma mark - Fabric lifecycle
@@ -117,6 +122,10 @@ using namespace facebook::react;
     _mentionIndicators = @[];
     _activeMentionRange = NSMakeRange(NSNotFound, 0);
     _activeMentionText = @"";
+
+    _writingDirectionMode = ENRMWritingDirectionModeFirstStrong;
+    _resolvedLayoutDirection =
+        [[RCTI18nUtil sharedInstance] isRTL] ? NSWritingDirectionRightToLeft : NSWritingDirectionLeftToRight;
 
     [self setupTextView];
 
@@ -210,6 +219,29 @@ using namespace facebook::react;
 - (void)requestHeightUpdate
 {
   ENRMRequestHeightUpdate<EnrichedMarkdownTextInputState>(_state, _heightUpdateCounter, self);
+}
+
+/// Yoga-resolved direction inherited from any ancestor `direction` style.
+/// In FirstStrong mode this feeds the neutral-paragraph fallback, so a change
+/// requires re-resolving per-paragraph directions over the current text.
+- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics
+{
+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+
+  NSWritingDirection resolved = _resolvedLayoutDirection;
+  if (layoutMetrics.layoutDirection == LayoutDirection::RightToLeft) {
+    resolved = NSWritingDirectionRightToLeft;
+  } else if (layoutMetrics.layoutDirection == LayoutDirection::LeftToRight) {
+    resolved = NSWritingDirectionLeftToRight;
+  }
+
+  if (resolved != _resolvedLayoutDirection) {
+    _resolvedLayoutDirection = resolved;
+    if (_writingDirectionMode == ENRMWritingDirectionModeFirstStrong && _textView.textStorage.length > 0) {
+      [self applyFormatting];
+    }
+  }
 }
 
 #pragma mark - Measurement
@@ -335,6 +367,13 @@ using namespace facebook::react;
 
   BOOL styleChanged = applyInputStyleProps(_formatterStyle, newViewProps, oldViewProps);
 
+  BOOL writingDirectionChanged = NO;
+  if (newViewProps.writingDirection != oldViewProps.writingDirection) {
+    NSString *value = [[NSString alloc] initWithUTF8String:newViewProps.writingDirection.c_str()];
+    _writingDirectionMode = ENRMResolveWritingDirectionMode(value);
+    writingDirectionChanged = YES;
+  }
+
   if (newViewProps.defaultValue != oldViewProps.defaultValue) {
     if (!newViewProps.defaultValue.empty() && oldViewProps.defaultValue.empty()) {
       NSString *markdown = [NSString stringWithUTF8String:newViewProps.defaultValue.c_str()];
@@ -352,6 +391,8 @@ using namespace facebook::react;
     }
 
     [self requestHeightUpdate];
+  } else if (writingDirectionChanged && _textView.textStorage.length > 0) {
+    [self applyFormatting];
   }
 
   [super updateProps:props oldProps:oldProps];
@@ -556,6 +597,7 @@ using namespace facebook::react;
 
   [_formatter applyFormattingRanges:_formattingStore.allRanges toTextView:_textView style:_formatterStyle];
   [_detectorPipeline refreshAllStyling];
+  [self applyWritingDirection];
 
   NSUInteger textLen = ENRMGetPlainText(_textView).length;
   if (savedSelection.location + savedSelection.length <= textLen) {
@@ -563,6 +605,19 @@ using namespace facebook::react;
   }
 
   _isApplyingFormatting = NO;
+}
+
+/// Per-paragraph first-strong (or forced ltr/rtl) pass over the input's text storage.
+/// 'auto' is a no-op — TextKit follows the app's UI layout direction in that mode.
+- (void)applyWritingDirection
+{
+  NSTextStorage *textStorage = _textView.textStorage;
+  if (textStorage.length == 0 || _writingDirectionMode == ENRMWritingDirectionModeAuto) {
+    return;
+  }
+  [textStorage beginEditing];
+  ENRMApplyWritingDirectionMode(textStorage, _writingDirectionMode, _resolvedLayoutDirection);
+  [textStorage endEditing];
 }
 
 #pragma mark - Commands

--- a/ios/utils/ParagraphStyleUtils.m
+++ b/ios/utils/ParagraphStyleUtils.m
@@ -73,6 +73,7 @@ void ENRMApplyWritingDirectionMode(NSMutableAttributedString *output, ENRMWritin
 {
   switch (mode) {
     case ENRMWritingDirectionModeAuto:
+      ENRMApplyWritingDirectionToParagraphStyles(output, NSWritingDirectionNatural);
       break;
     case ENRMWritingDirectionModeLTR:
       ENRMApplyWritingDirectionToParagraphStyles(output, NSWritingDirectionLeftToRight);
@@ -133,7 +134,7 @@ void ENRMApplyFirstStrongParagraphDirections(NSMutableAttributedString *output, 
 
 void ENRMApplyWritingDirectionToParagraphStyles(NSMutableAttributedString *output, NSWritingDirection writingDirection)
 {
-  if (output.length == 0 || writingDirection == NSWritingDirectionNatural) {
+  if (output.length == 0) {
     return;
   }
   [output enumerateAttribute:NSParagraphStyleAttributeName

--- a/src/EnrichedMarkdownTextInput.tsx
+++ b/src/EnrichedMarkdownTextInput.tsx
@@ -143,6 +143,23 @@ export interface EnrichedMarkdownTextInputProps extends Omit<
   onBlur?: () => void;
   contextMenuItems?: ContextMenuItem[];
   linkRegex?: RegExp | null;
+  /**
+   * Paragraph writing direction.
+   * - `'first-strong'` (default): resolves each paragraph from its first strong
+   *   directional character. Neutral-only paragraphs fall back to the view's
+   *   resolved layout direction (inherits ancestor `direction` style). Library
+   *   extension — matches Android's `TEXT_DIRECTION_FIRST_STRONG`.
+   * - `'auto'`: React Native parity. iOS TextKit follows the app's
+   *   `userInterfaceLayoutDirection`; mixed-direction paragraphs do not
+   *   auto-resolve.
+   * - `'ltr'` / `'rtl'`: force base direction on every paragraph.
+   *
+   * Android ignores this prop; the platform's `EditText` always uses
+   * `TEXT_DIRECTION_FIRST_STRONG` per paragraph.
+   * @default 'first-strong'
+   * @platform ios
+   */
+  writingDirection?: 'auto' | 'ltr' | 'rtl' | 'first-strong';
 }
 
 type PendingRequest<T> = {
@@ -187,6 +204,7 @@ export const EnrichedMarkdownTextInput = ({
   onBlur,
   contextMenuItems,
   linkRegex: _linkRegex,
+  writingDirection = 'first-strong',
   ...rest
 }: EnrichedMarkdownTextInputProps) => {
   const nativeRef = useRef<NativeRef | null>(null);
@@ -448,6 +466,7 @@ export const EnrichedMarkdownTextInput = ({
         handleContextMenuItemPress as NativeProps['onContextMenuItemPress']
       }
       linkRegex={linkRegex}
+      writingDirection={writingDirection}
       onStartMention={handleStartMention as NativeProps['onStartMention']}
       onChangeMention={handleChangeMention as NativeProps['onChangeMention']}
       onEndMention={handleEndMention as NativeProps['onEndMention']}

--- a/src/EnrichedMarkdownTextInputNativeComponent.ts
+++ b/src/EnrichedMarkdownTextInputNativeComponent.ts
@@ -210,6 +210,18 @@ export interface NativeProps extends ViewProps {
    */
   mentionIndicators?: ReadonlyArray<string>;
 
+  /**
+   * Paragraph writing direction.
+   * - 'first-strong' (default): resolves each paragraph from its first strong directional character;
+   *   neutral-only paragraphs fall back to the view's resolved layout direction. Library extension —
+   *   matches Android's TEXT_DIRECTION_FIRST_STRONG.
+   * - 'auto': React Native parity; iOS TextKit follows the app's userInterfaceLayoutDirection.
+   * - 'ltr' / 'rtl': force base direction on every paragraph.
+   * @default 'first-strong'
+   * @platform ios
+   */
+  writingDirection?: CodegenTypes.WithDefault<string, 'first-strong'>;
+
   // Events
   onChangeText?: CodegenTypes.DirectEventHandler<OnChangeTextEvent>;
   onChangeMarkdown?: CodegenTypes.DirectEventHandler<OnChangeMarkdownEvent>;


### PR DESCRIPTION
### What/Why?
Introduces automatic _RTL_ detection for `EnrichedMarkdownTextInput`, it relies on the same logic as #398. This pr mainly handles wiring props into the component and triggering the correct writingDirectionMode.

Additionaly updated `storybook` and `docs`


### Testing
Easiest way to test it is via `storybook` - created a story that shows the behaviour of the prop. On Android it should be no-op

#### Screenshots
https://github.com/user-attachments/assets/6fdac227-f0de-4137-a841-934eac97d6c0

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

closes #331
