### PR TITLE
fix(ios): preserve active formatting during predictive text suggestions

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable ENRMFormattingRange *)rangeOfType:(ENRMInputStyleType)type containingPosition:(NSUInteger)position;
 - (BOOL)isStyleActive:(ENRMInputStyleType)type atPosition:(NSUInteger)position;
 - (BOOL)isStyleActive:(ENRMInputStyleType)type inRange:(NSRange)range;
+- (BOOL)isStyleAdjacentBefore:(ENRMInputStyleType)type position:(NSUInteger)position;
 - (NSArray<ENRMFormattingRange *> *)rangesOfType:(ENRMInputStyleType)type;
 
 - (void)addRange:(ENRMFormattingRange *)range;

--- a/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.mm
@@ -114,6 +114,15 @@ static EditOverlap classifyOverlap(NSUInteger rangeStart, NSUInteger rangeEnd, N
   return NO;
 }
 
+- (BOOL)isStyleAdjacentBefore:(ENRMInputStyleType)type position:(NSUInteger)position
+{
+  if (position == 0) {
+    return NO;
+  }
+  return [self rangeOfType:type containingPosition:position] != nil ||
+         [self rangeOfType:type containingPosition:position - 1] != nil;
+}
+
 - (void)addRange:(ENRMFormattingRange *)newRange
 {
   NSMutableIndexSet *mergeIndexes = [NSMutableIndexSet indexSet];

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -1,4 +1,5 @@
 #import "EnrichedMarkdownTextInput.h"
+#import <QuartzCore/CABase.h>
 #import "ContextMenuUtils.h"
 #import "ENRMAutoLinkDetector.h"
 #import "ENRMDetectorPipeline.h"
@@ -60,6 +61,7 @@ using namespace facebook::react;
   BOOL _isApplyingFormatting;
   BOOL _isTextChanging;
   BOOL _emitMarkdown;
+  CFTimeInterval _lastTextChangeTime;
 
   ENRMPlaceholderLabel *_placeholderLabel;
 
@@ -738,6 +740,7 @@ using namespace facebook::react;
   }
 
   [self applyFormatting];
+  [self syncTypingAttributesWithPendingStyles];
   [self emitFormattingChanged];
 }
 
@@ -939,6 +942,60 @@ using namespace facebook::react;
     return YES;
   }
   return inRange;
+}
+
+- (void)syncTypingAttributesWithPendingStyles
+{
+  UIFontDescriptorSymbolicTraits traits = 0;
+  if ([_pendingStyles containsObject:@(ENRMInputStyleTypeStrong)]) {
+    traits |= UIFontDescriptorTraitBold;
+  }
+  if ([_pendingStyles containsObject:@(ENRMInputStyleTypeEmphasis)]) {
+    traits |= UIFontDescriptorTraitItalic;
+  }
+
+  NSMutableDictionary *attrs = [_textView.typingAttributes mutableCopy];
+  attrs[NSFontAttributeName] = [_formatterStyle fontForTraits:traits];
+  _textView.typingAttributes = attrs;
+}
+
+- (void)resetPendingStylesForSelectionChange
+{
+  // Skip system-driven selection adjustments (e.g., predictive text) that fire
+  // immediately after a text edit.
+  static const CFTimeInterval kPostEditGracePeriod = 0.1;
+  BOOL isPostEditAdjustment = (_lastTextChangeTime > 0 &&
+                               (CACurrentMediaTime() - _lastTextChangeTime) < kPostEditGracePeriod);
+  if (isPostEditAdjustment) {
+    return;
+  }
+  [_pendingStyles removeAllObjects];
+  [_pendingStyleRemovals removeAllObjects];
+  [self rebuildPendingStylesFromContext];
+  [self syncTypingAttributesWithPendingStyles];
+}
+
+- (void)rebuildPendingStylesFromContext
+{
+  NSUInteger cursor = _textView.selectedRange.location;
+  if (_textView.selectedRange.length > 0 || cursor == 0) {
+    return;
+  }
+
+  static const ENRMInputStyleType inlineStyles[] = {
+      ENRMInputStyleTypeStrong,
+      ENRMInputStyleTypeEmphasis,
+      ENRMInputStyleTypeUnderline,
+      ENRMInputStyleTypeStrikethrough,
+      ENRMInputStyleTypeSpoiler,
+  };
+
+  for (NSUInteger i = 0; i < sizeof(inlineStyles) / sizeof(inlineStyles[0]); i++) {
+    ENRMInputStyleType type = inlineStyles[i];
+    if ([_formattingStore isStyleAdjacentBefore:type position:cursor]) {
+      [_pendingStyles addObject:@(type)];
+    }
+  }
 }
 
 #pragma mark - Event emitters
@@ -1446,6 +1503,7 @@ using namespace facebook::react;
   }
   [self handleTextChanged];
   _isTextChanging = NO;
+  _lastTextChangeTime = CACurrentMediaTime();
   _lastSelectedRange = textView.selectedRange;
 }
 
@@ -1470,12 +1528,15 @@ using namespace facebook::react;
     return;
   }
 
+  if (ENRMHasMarkedText(_textView)) {
+    return;
+  }
+
   BOOL selectionMoved =
       newSelection.location != previousSelection.location || newSelection.length != previousSelection.length;
 
   if (selectionMoved) {
-    [_pendingStyles removeAllObjects];
-    [_pendingStyleRemovals removeAllObjects];
+    [self resetPendingStylesForSelectionChange];
   }
 
   [self manageSelectionBasedChanges];
@@ -1543,19 +1604,30 @@ using namespace facebook::react;
   }
   [self handleTextChanged];
   _isTextChanging = NO;
+  _lastTextChangeTime = CACurrentMediaTime();
   _lastSelectedRange = _textView.selectedRange;
 }
 
 - (void)textInputDidChangeSelection
 {
-  _lastSelectedRange = _textView.selectedRange;
+  NSRange newSelection = _textView.selectedRange;
+  NSRange previousSelection = _lastSelectedRange;
+  _lastSelectedRange = newSelection;
 
   if (_isApplyingFormatting || _isTextChanging) {
     return;
   }
 
-  [_pendingStyles removeAllObjects];
-  [_pendingStyleRemovals removeAllObjects];
+  if (ENRMHasMarkedText(_textView)) {
+    return;
+  }
+
+  BOOL selectionMoved =
+      newSelection.location != previousSelection.location || newSelection.length != previousSelection.length;
+
+  if (selectionMoved) {
+    [self resetPendingStylesForSelectionChange];
+  }
 
   [self emitOnChangeSelection];
   [self updateActiveMention];


### PR DESCRIPTION
### What/Why?

iOS predictive text suggestions were causing active formatting (bold, italic, etc.) to be unexpectedly lost while typing. When the system displayed an inline prediction, it triggered selection change delegate callbacks that cleared the `_pendingStyles` set — the mechanism that tracks the user's formatting intent for subsequent text insertion. Once cleared, new text would no longer inherit the active style.

This PR fixes the issue with a multi-layered approach:

1. **Post-edit grace period** — Selection changes within 100ms of a text edit are recognized as system-driven (prediction adjustments) and don't clear pending formatting state.
2. **Marked text guard** — Selection changes during IME composition are skipped entirely.
3. **Context-based style rebuild** — When pending styles are legitimately cleared (user moves cursor), they're immediately re-derived from the formatting store by checking if the cursor is adjacent to or inside a formatting range.
4. **Typing attributes sync** — `typingAttributes` is kept in sync with `_pendingStyles` so that prediction ghost text renders with the correct font weight/style from the first keystroke.

Closes: #397 

### Testing
<!-- How to test changed code? What testing has been done? -->

#### Screenshots

https://github.com/user-attachments/assets/84c1a27c-1519-4060-a076-b86ff8a41d90

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

