### PR TITLE
fix(android): prevent colorsToPreserve from blocking inline style colors

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/SpanStyleCache.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/SpanStyleCache.kt
@@ -52,10 +52,10 @@ class SpanStyleCache(
     val paragraphColor = style.paragraphStyle.color
     return buildList {
       style.strongStyle.color
-        ?.takeIf { it != 0 }
+        ?.takeIf { it != 0 && it != paragraphColor }
         ?.let { add(it) }
       style.emphasisStyle.color
-        ?.takeIf { it != 0 }
+        ?.takeIf { it != 0 && it != paragraphColor }
         ?.let { add(it) }
       style.linkStyle.color
         .takeIf { it != 0 && it != paragraphColor }
@@ -68,10 +68,10 @@ class SpanStyleCache(
       style
         .codeStyle
         .color
-        .takeIf { it != 0 }
+        .takeIf { it != 0 && it != paragraphColor }
         ?.let { add(it) }
       style.taskListStyle.checkedTextColor
-        .takeIf { it != 0 }
+        .takeIf { it != 0 && it != paragraphColor }
         ?.let { add(it) }
     }.toIntArray()
   }


### PR DESCRIPTION
### What/Why?
When code.color, strong.color, or em.color matched paragraph.color, the value was added to colorsToPreserve causing applyColorPreserving to incorrectly skip applying inline colors like em.color.

Closes: #416 

### Testing
<!-- How to test changed code? What testing has been done? -->

#### Screenshots

| Before | After |
| - | - |
| <img src="https://github.com/user-attachments/assets/3a5518a4-f664-4412-ad70-7773e68e83c7" width=300 /> | <img src="https://github.com/user-attachments/assets/eaafd3da-cfc0-4074-a78b-65b6be4b9636" width=300 /> |

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

