### PR TITLE
fix(android): measure rendered plain text in InputMeasurementStore.initialMeasure, not raw markdown

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputMeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputMeasurementStore.kt
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.yoga.YogaMeasureMode
 import com.facebook.yoga.YogaMeasureOutput
+import com.swmansion.enriched.markdown.input.formatting.InputParser
 import java.util.concurrent.ConcurrentHashMap
 
 object InputMeasurementStore {
@@ -93,7 +94,12 @@ object InputMeasurementStore {
     width: Float,
     props: ReadableMap?,
   ): Long {
-    val text = props?.getString("defaultValue") ?: props?.getString("placeholder") ?: "I"
+    // Measure the rendered plain text, not the raw markdown. A mention link such as
+    // [Label](placeholder://x) hides its URL in the source, so measuring the markdown counts those
+    // invisible characters and over-estimates the height into extra lines, until the next text
+    // change forces a re-measure. Parsing first matches what the editor actually renders.
+    val markdown = props?.getString("defaultValue") ?: props?.getString("placeholder") ?: "I"
+    val text = InputParser.parseToPlainTextAndRanges(markdown).plainText
     val fontSize = props?.getDouble("fontSize")?.toFloat() ?: 16f
     val spSize = kotlin.math.ceil(PixelUtil.toPixelFromSP(fontSize).toDouble()).toFloat()
 


### PR DESCRIPTION
## Summary

On Android, an auto-grow `EnrichedMarkdownTextInput` (`scrollEnabled={false}`) reports a height that is too tall on first render, leaving empty space below the content. It self-corrects on the first keystroke. iOS is unaffected.

The first measure counts the hidden URLs of mention/link placeholders, which aren't rendered. This parses the markdown into its rendered plain text **before** measuring, using the parser the library already uses elsewhere.

Fixes #421

## Problem

With a `defaultValue` that contains a mention/link:

```tsx
<ScrollView>
  <EnrichedMarkdownTextInput
    scrollEnabled={false}
    style={{ flexGrow: 1 }}
    defaultValue={"Hi [Label](placeholder://a.very.long.token.address.here)!"}
  />
</ScrollView>
```

- Before: the input is taller than its rendered text on open (empty space below); it snaps to the correct height on the first keystroke.
- Observed: ~652dp on open → ~554dp after one keystroke, same content.

## Root cause

`InputMeasurementStore.initialMeasure` measures the raw markdown string instead of the rendered plain text:

```kotlin
val text = props?.getString("defaultValue") ?: props?.getString("placeholder") ?: "I"
return measure(width, text, paint)
```

For a mention the source is `[Label](placeholder://...)`: the URL is invisible on screen but counted by the measure, over-estimating the height into extra lines. Yoga caches this first measure until a text change forces a re-measure (which goes through `store()` with the already-parsed `view.text`), which is why typing corrects it.

## Fix

Parse the markdown into rendered plain text before measuring, using the existing `InputParser.parseToPlainTextAndRanges(...)` (the same one used by `setValueFromJS`):

```kotlin
import com.swmansion.enriched.markdown.input.formatting.InputParser
// ...
val markdown = props?.getString("defaultValue") ?: props?.getString("placeholder") ?: "I"
val text = InputParser.parseToPlainTextAndRanges(markdown).plainText
```

## Why this approach

- Reuses the library's existing parser, so the measure uses the same representation as the actual render (no duplicated parsing logic).
- Touches only the `initialMeasure` path (the first measure); subsequent measures already go through `store()` with the parsed text and are unchanged.
- Same family as #281 / #366 (incorrect Android measurement, iOS correct), but on the input component those fixes didn't cover.

## Test plan

- Auto-grow input (`scrollEnabled={false}`) with a `defaultValue` containing a mention/link with a long URL, inside a `ScrollView`.
- Before: extra height on open, snaps shorter on the first keystroke.
- After: correct height on open; no change on keystroke.
- iOS: no regression (the path is Android-only).

## Notes

- Android-only; iOS measures via TextKit on the already-rendered attributed string, so it doesn't have the issue.
- No public API change; internal to measurement.
