### PR TITLE
fix(input): autoFocus on Android places caret at end and opens keyboard (parity with iOS)

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -67,6 +67,7 @@ class EnrichedMarkdownTextInputView(
 
   var emitMarkdown = false
   var autoFocusRequested = false
+  private var pendingAutoFocusKeyboard = false
   var stateWrapper: StateWrapper? = null
   val layoutManager = InputLayoutManager(this)
 
@@ -138,6 +139,13 @@ class EnrichedMarkdownTextInputView(
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
     runAsATransaction { super.setTextIsSelectable(true) }
+  }
+
+  override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
+    super.onWindowFocusChanged(hasWindowFocus)
+    // The autofocus keyboard request may run before the window has IME focus (e.g. while a modal is
+    // still presenting), where showSoftInput() is dropped. Retry once the window actually gains focus.
+    if (hasWindowFocus) showAutoFocusKeyboardIfPending()
   }
 
   override fun clearFocus() {
@@ -641,11 +649,27 @@ class EnrichedMarkdownTextInputView(
     setSelection(selectionStart.coerceAtLeast(0))
   }
 
+  private fun showAutoFocusKeyboardIfPending() {
+    if (!pendingAutoFocusKeyboard || !hasWindowFocus()) return
+    pendingAutoFocusKeyboard = false
+    inputMethodManager?.showSoftInput(this, 0)
+  }
+
   fun afterUpdateTransaction() {
     updateTypeface()
     if (autoFocusRequested) {
       autoFocusRequested = false
-      requestFocusProgrammatically()
+      pendingAutoFocusKeyboard = true
+      // afterUpdateTransaction runs during the mount, before onAttachedToWindow, when the view is not
+      // attached yet: requestFocus()/showSoftInput() are dropped so the keyboard never opens, and
+      // onAttachedToWindow's setTextIsSelectable(true) resets the caret to 0. Defer to the next loop,
+      // once attached, to grant focus and place the caret at the end like iOS. The keyboard is shown only
+      // when the window has IME focus (now, or later via onWindowFocusChanged).
+      post {
+        requestFocus()
+        setSelection(text?.length ?: 0)
+        showAutoFocusKeyboardIfPending()
+      }
     }
   }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -67,9 +67,9 @@ class EnrichedMarkdownTextInputView(
 
   var emitMarkdown = false
   var autoFocusRequested = false
-  private var pendingAutoFocusKeyboard = false
   var stateWrapper: StateWrapper? = null
   val layoutManager = InputLayoutManager(this)
+  private var pendingAutoFocusKeyboard = false
 
   private var typefaceDirty = false
   private var fontFamilyValue: String? = null

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -145,7 +145,7 @@ class EnrichedMarkdownTextInputView(
     super.onWindowFocusChanged(hasWindowFocus)
     // The autofocus keyboard request may run before the window has IME focus (e.g. while a modal is
     // still presenting), where showSoftInput() is dropped.
-    if (hasWindowFocus) showAutoFocusKeyboardIfPending()
+    showAutoFocusKeyboardIfPending()
   }
 
   override fun clearFocus() {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -660,12 +660,10 @@ class EnrichedMarkdownTextInputView(
     if (autoFocusRequested) {
       autoFocusRequested = false
       pendingAutoFocusKeyboard = true
-      // afterUpdateTransaction runs during the mount, before onAttachedToWindow, when the view is not
-      // attached yet: requestFocus()/showSoftInput() are dropped so the keyboard never opens, and
-      // onAttachedToWindow's setTextIsSelectable(true) resets the caret to 0. Defer to the next loop,
-      // once attached, to grant focus and place the caret at the end like iOS. The keyboard is shown only
-      // when the window has IME focus (now, or later via onWindowFocusChanged).
       post {
+        // afterUpdateTransaction runs before onAttachedToWindow, where requestFocus()/showSoftInput()
+        // are dropped and setTextIsSelectable(true) would reset the caret to 0. Defer to the next loop
+        // so focus sticks and the caret lands at end (matching iOS).
         requestFocus()
         setSelection(text?.length ?: 0)
         showAutoFocusKeyboardIfPending()

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -144,7 +144,7 @@ class EnrichedMarkdownTextInputView(
   override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
     super.onWindowFocusChanged(hasWindowFocus)
     // The autofocus keyboard request may run before the window has IME focus (e.g. while a modal is
-    // still presenting), where showSoftInput() is dropped. Retry once the window actually gains focus.
+    // still presenting), where showSoftInput() is dropped.
     if (hasWindowFocus) showAutoFocusKeyboardIfPending()
   }
 


### PR DESCRIPTION
## Summary

On Android, an autofocused `EnrichedMarkdownTextInput` lands the caret at index 0 (not the end like iOS) and often does not open the soft keyboard. iOS places the caret at the end of the text and raises the keyboard. This aligns Android with iOS.

## Problem

```tsx
<EnrichedMarkdownTextInput autoFocus defaultValue={"Hello world"} />
```

- iOS: caret at the end (`Hello world|`), keyboard open.
- Android: caret at the start (`|Hello world`), keyboard closed (the field is focused but you have to tap it to type).

It is worse inside a modal / a screen that is still presenting, where `showSoftInput` is dropped because the window does not yet have IME focus.

## Root cause

`afterUpdateTransaction()` runs during mount, before the view is attached to the window:

```kotlin
if (autoFocusRequested) {
  autoFocusRequested = false
  requestFocusProgrammatically()
}
```

At that point the view is not attached and the window may not have IME focus yet, so `requestFocus()` / `showSoftInput()` are dropped. And `onAttachedToWindow()` runs afterwards and calls `setTextIsSelectable(true)`, which internally re-sets the text and resets the selection to 0, clobbering the end position that `setValueFromJS` had set.

## Fix

Defer the autofocus work to the next loop (after `onAttachedToWindow`), move the caret to the text end, and show the keyboard only once the window has IME focus — immediately if it already does, otherwise from `onWindowFocusChanged` (covers the case where a modal is still presenting):

```kotlin
if (autoFocusRequested) {
  autoFocusRequested = false
  pendingAutoFocusKeyboard = true
  post {
    requestFocus()
    setSelection(text?.length ?: 0)
    showAutoFocusKeyboardIfPending()
  }
}

private fun showAutoFocusKeyboardIfPending() {
  if (!pendingAutoFocusKeyboard || !hasWindowFocus()) return
  pendingAutoFocusKeyboard = false
  inputMethodManager?.showSoftInput(this, 0)
}

override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
  super.onWindowFocusChanged(hasWindowFocus)
  if (hasWindowFocus) showAutoFocusKeyboardIfPending()
}
```

The imperative `focus()` command path (`requestFocusProgrammatically()`) is unchanged.

## Why this approach

- `post {}` runs after `onAttachedToWindow` (the run queue is flushed there), so placing the caret at the end is the last thing to touch the selection and is not clobbered by `setTextIsSelectable(true)`.
- Gating `showSoftInput` on `hasWindowFocus()` plus an `onWindowFocusChanged` retry makes the keyboard deterministic whether the window already has IME focus or gains it slightly later (e.g. a modal still presenting).
- Scoped to the `autoFocus` branch only; the imperative `focus()` keeps its current behavior.

## Test plan

- `EnrichedMarkdownTextInput` with `autoFocus` and a non-empty `defaultValue`, including inside a modal.
- Before: caret at index 0, keyboard closed on Android.
- After: caret at the end, keyboard open — matching iOS.
- iOS: no regression (the change is Android-only).

## Notes

- Android-only; iOS already places the caret at the end and raises the keyboard via its own `becomeFirstResponder` path.
- No public API change.
