### PR TITLE
fix(android): preserve blank lines between paragraphs in input parser (parity with iOS)

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputParser.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputParser.kt
@@ -13,6 +13,9 @@ data class ParseResult(
 )
 
 object InputParser {
+  // A source paragraph break: a newline followed by one or more blank lines.
+  private val PARAGRAPH_BREAK_RE = Regex("\\n[ \\t]*(?:\\n[ \\t]*)+")
+
   fun parseToPlainTextAndRanges(markdown: String): ParseResult {
     if (markdown.isEmpty()) {
       return ParseResult("", emptyList())
@@ -25,7 +28,17 @@ object InputParser {
     val plainText = StringBuilder()
     val ranges = mutableListOf<FormattingRange>()
 
-    walkNode(ast, plainText, ranges, ArrayDeque())
+    // md4c collapses any blank-line run into a single break, unlike iOS which keeps them.
+    // Re-read the real runs so each break replays its original number of newlines.
+    val blankRuns =
+      ArrayDeque(
+        PARAGRAPH_BREAK_RE
+          .findAll(completed.trim())
+          .map { match -> match.value.count { it == '\n' } }
+          .toList(),
+      )
+
+    walkNode(ast, plainText, ranges, ArrayDeque(), blankRuns)
 
     return ParseResult(plainText.toString(), ranges)
   }
@@ -35,6 +48,7 @@ object InputParser {
     plainText: StringBuilder,
     ranges: MutableList<FormattingRange>,
     activeStyles: ArrayDeque<ActiveStyle>,
+    blankRuns: ArrayDeque<Int>,
   ) {
     val styleType = nodeTypeToStyleType(node.type)
 
@@ -49,8 +63,12 @@ object InputParser {
       plainText.append("\n")
     }
 
-    for (child in node.children) {
-      walkNode(child, plainText, ranges, activeStyles)
+    for ((index, child) in node.children.withIndex()) {
+      // Keep the source's blank lines between paragraphs (md4c drops them, iOS keeps them).
+      if (index > 0 && child.type == NodeType.Paragraph && plainText.isNotEmpty()) {
+        plainText.append("\n".repeat(blankRuns.removeFirstOrNull() ?: 2))
+      }
+      walkNode(child, plainText, ranges, activeStyles, blankRuns)
     }
 
     if (styleType != null) {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputParser.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputParser.kt
@@ -6,6 +6,7 @@ import com.swmansion.enriched.markdown.parser.MarkdownASTNode
 import com.swmansion.enriched.markdown.parser.MarkdownASTNode.NodeType
 import com.swmansion.enriched.markdown.parser.Md4cFlags
 import com.swmansion.enriched.markdown.parser.Parser
+import com.swmansion.enriched.markdown.parser.isTopLevelBlock
 
 data class ParseResult(
   val plainText: String,
@@ -64,8 +65,8 @@ object InputParser {
     }
 
     for ((index, child) in node.children.withIndex()) {
-      // Keep the source's blank lines between paragraphs (md4c drops them, iOS keeps them).
-      if (index > 0 && child.type == NodeType.Paragraph && plainText.isNotEmpty()) {
+      // Keep the source's blank lines between top-level blocks (md4c drops them, iOS keeps them).
+      if (index > 0 && child.type.isTopLevelBlock() && plainText.isNotEmpty()) {
         plainText.append("\n".repeat(blankRuns.removeFirstOrNull() ?: 2))
       }
       walkNode(child, plainText, ranges, activeStyles, blankRuns)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/parser/MarkdownASTNode.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/parser/MarkdownASTNode.kt
@@ -41,3 +41,20 @@ data class MarkdownASTNode(
 
   fun getAttribute(key: String): String? = attributes[key]
 }
+
+// A node type that md4c emits as a standalone block stacked vertically, as opposed to an inline span.
+internal fun MarkdownASTNode.NodeType.isTopLevelBlock(): Boolean =
+  when (this) {
+    MarkdownASTNode.NodeType.Paragraph,
+    MarkdownASTNode.NodeType.Heading,
+    MarkdownASTNode.NodeType.Blockquote,
+    MarkdownASTNode.NodeType.UnorderedList,
+    MarkdownASTNode.NodeType.OrderedList,
+    MarkdownASTNode.NodeType.CodeBlock,
+    MarkdownASTNode.NodeType.ThematicBreak,
+    MarkdownASTNode.NodeType.Table,
+    MarkdownASTNode.NodeType.LatexMathDisplay,
+    -> true
+
+    else -> false
+  }


### PR DESCRIPTION
## Summary

On **Android**, an `EnrichedMarkdownTextInput` loaded with a value that contains blank lines between
paragraphs drops them: every run of blank lines collapses and the paragraphs render run together.
**iOS keeps every blank line.**

The Android input parser rebuilds the plain text from the md4c AST and emits no separator between
paragraph nodes. This re-reads the original blank-line runs from the source and replays them at each
paragraph break, so the rendered text matches the source the way it already does on iOS.

## Problem

With a `defaultValue` that contains blank lines (plain text, no markdown features):

```tsx
<EnrichedMarkdownTextInput
  scrollEnabled={false}
  defaultValue={"First paragraph.\n\n\n\nSecond paragraph.\n\nThird paragraph."}
/>
```

- **Before (Android):** the paragraphs render run together (`First paragraph.Second paragraph...`,
  `...paragraph.Third paragraph...`), all blank lines dropped.
- **iOS:** a large gap (three blank lines), then a small gap (one blank line), preserved.

Minimal reproducible example (Expo SDK 56, RN 0.85.3, New Architecture, `react-native-enriched-markdown@0.6.0`
unpatched): https://github.com/andreavrr/enriched-markdown-android-blank-lines-mre

## Root cause

`InputParser.walkNode` builds the plain text by appending `Text` and `LineBreak` nodes but emits
nothing between `Paragraph` nodes:

```kotlin
for (child in node.children) {
  walkNode(child, plainText, ranges, activeStyles)
}
```

A blank line is a paragraph break in CommonMark, so md4c splits the text into separate `Paragraph`
nodes (and collapses any run of blank lines into a single break). With no separator emitted, the
paragraphs concatenate. iOS doesn't hit this because its input parser derives the plain text from the
original source buffer (removing only the syntax markers), so blank lines, which are content rather
than syntax, survive.

## Fix

Re-emit the source blank lines between paragraphs during the walk. md4c collapses the runs in the AST,
but the source string is still available in `parseToPlainTextAndRanges`, so read the real run lengths
from it and replay them at each paragraph break:

```kotlin
private val PARAGRAPH_BREAK_RE = Regex("\\n[ \\t]*(?:\\n[ \\t]*)+")
// ...
val blankRuns =
  ArrayDeque(
    PARAGRAPH_BREAK_RE
      .findAll(completed.trim())
      .map { match -> match.value.count { it == '\n' } }
      .toList(),
  )
// ...
for ((index, child) in node.children.withIndex()) {
  if (index > 0 && child.type == NodeType.Paragraph && plainText.isNotEmpty()) {
    plainText.append("\n".repeat(blankRuns.removeFirstOrNull() ?: 2))
  }
  walkNode(child, plainText, ranges, activeStyles, blankRuns)
}
```

## Why this approach

- Mirrors what iOS already produces (blank lines preserved) without reimplementing the iOS
  buffer-subtraction strategy on Android.
- Mention/style offsets stay consistent: they are computed live from `plainText.length` during the
  same walk, so emitting more newlines never desyncs them.
- Graceful fallback: a paragraph break with no matching source run (exotic input) emits a single
  blank line (the prior behaviour), never a crash.
- Touches only the parse path; serialization (`getMarkdown`) already preserves blank lines verbatim,
  so the round-trip stays consistent.

## Test plan

- Load a `defaultValue` with single and multiple blank lines between paragraphs (see the MRE above).
- **Before:** the paragraphs run together on Android.
- **After:** blank lines are preserved (single and multiple runs), matching iOS; a blank line deletes
  with one backspace.
- **iOS:** no regression (the path is Android-only).

## Notes

- Android-only; iOS derives the plain text from the source buffer, so it already preserves blank lines.
- md4c collapses multiple consecutive blank lines in the AST; the original run length is recovered
  from the source string, so 2+ blank lines round-trip as typed.
- No public API change; internal to the input parser.
