### PR TITLE
refactor(ios): extract shared helper for selection menu config parsing

### DIFF
--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -106,13 +106,7 @@ static char kENRMSegmentFadeAnimatorKey;
   NSArray<NSString *> *_contextMenuItemTexts;
   NSArray<NSString *> *_contextMenuItemIcons;
   ENRMSelectionMenuConfig _selectionMenuConfig;
-  // Strong owners for the selection menu labels referenced (unretained) by
-  // _selectionMenuConfig. Kept alive for the view's lifetime.
-  NSString *_copyLabel;
-  NSString *_copyAsMarkdownLabel;
-  NSString *_copyImageUrlLabel;
-  NSString *_copyImageUrlsLabel;
-  NSArray<NSString *> *_copyImageUrlPluralTemplates;
+  ENRMSelectionMenuLabels _selectionMenuLabels;
 
   ENRMSpoilerOverlay _spoilerOverlay;
 
@@ -403,14 +397,14 @@ static char kENRMSegmentFadeAnimatorKey;
   for (RCTUIView *segment in _segmentViews) {
     if ([segment isKindOfClass:[TableContainerView class]]) {
       TableContainerView *tableView = (TableContainerView *)segment;
-      tableView.copyLabel = _copyLabel;
-      tableView.copyAsMarkdownLabel = _copyAsMarkdownLabel;
+      tableView.copyLabel = _selectionMenuLabels.copyLabel;
+      tableView.copyAsMarkdownLabel = _selectionMenuLabels.copyAsMarkdownLabel;
     }
 #if ENRICHED_MARKDOWN_MATH
     else if ([segment isKindOfClass:[ENRMMathContainerView class]]) {
       ENRMMathContainerView *mathView = (ENRMMathContainerView *)segment;
-      mathView.copyLabel = _copyLabel;
-      mathView.copyAsMarkdownLabel = _copyAsMarkdownLabel;
+      mathView.copyLabel = _selectionMenuLabels.copyLabel;
+      mathView.copyAsMarkdownLabel = _selectionMenuLabels.copyAsMarkdownLabel;
     }
 #endif
   }
@@ -627,8 +621,8 @@ static char kENRMSegmentFadeAnimatorKey;
   tableView.enableLinkPreview = _enableLinkPreview;
   tableView.writingDirectionMode = _writingDirectionMode;
   tableView.resolvedLayoutDirection = _resolvedLayoutDirection;
-  tableView.copyLabel = _copyLabel;
-  tableView.copyAsMarkdownLabel = _copyAsMarkdownLabel;
+  tableView.copyLabel = _selectionMenuLabels.copyLabel;
+  tableView.copyAsMarkdownLabel = _selectionMenuLabels.copyAsMarkdownLabel;
 
   __weak EnrichedMarkdown *weakSelf = self;
 
@@ -665,8 +659,8 @@ static char kENRMSegmentFadeAnimatorKey;
 - (ENRMMathContainerView *)createMathViewForSegment:(ENRMMathSegment *)mathSegment
 {
   ENRMMathContainerView *mathView = [[ENRMMathContainerView alloc] initWithConfig:_config];
-  mathView.copyLabel = _copyLabel;
-  mathView.copyAsMarkdownLabel = _copyAsMarkdownLabel;
+  mathView.copyLabel = _selectionMenuLabels.copyLabel;
+  mathView.copyAsMarkdownLabel = _selectionMenuLabels.copyAsMarkdownLabel;
   [mathView applyLatex:mathSegment.latex];
   return mathView;
 }
@@ -819,26 +813,10 @@ static char kENRMSegmentFadeAnimatorKey;
     _contextMenuItemIcons = ENRMContextMenuIconsFromItems(newViewProps.contextMenuItems);
   }
 
-  _copyLabel = [[NSString alloc] initWithUTF8String:newViewProps.selectionMenuConfig.copyLabel.c_str()];
-  _copyAsMarkdownLabel =
-      [[NSString alloc] initWithUTF8String:newViewProps.selectionMenuConfig.copyAsMarkdownLabel.c_str()];
-  _copyImageUrlLabel = [[NSString alloc] initWithUTF8String:newViewProps.selectionMenuConfig.copyImageUrlLabel.c_str()];
-  _copyImageUrlsLabel =
-      [[NSString alloc] initWithUTF8String:newViewProps.selectionMenuConfig.copyImageUrlsLabel.c_str()];
-  NSMutableArray<NSString *> *pluralTemplates = [NSMutableArray array];
-  for (const auto &templateStr : newViewProps.selectionMenuConfig.copyImageUrlPluralTemplates) {
-    [pluralTemplates addObject:[[NSString alloc] initWithUTF8String:templateStr.c_str()]];
-  }
-  _copyImageUrlPluralTemplates = pluralTemplates;
-  _selectionMenuConfig = (ENRMSelectionMenuConfig){
-      .copyAsMarkdown = newViewProps.selectionMenuConfig.copyAsMarkdown,
-      .copyImageURL = newViewProps.selectionMenuConfig.copyImageUrl,
-      .copyLabel = _copyLabel,
-      .copyAsMarkdownLabel = _copyAsMarkdownLabel,
-      .copyImageUrlLabel = _copyImageUrlLabel,
-      .copyImageUrlsLabel = _copyImageUrlsLabel,
-      .copyImageUrlPluralTemplates = _copyImageUrlPluralTemplates,
-  };
+  _selectionMenuLabels = ENRMParseSelectionMenuLabels(newViewProps.selectionMenuConfig);
+  _selectionMenuConfig =
+      ENRMBuildSelectionMenuConfig(_selectionMenuLabels, newViewProps.selectionMenuConfig.copyAsMarkdown,
+                                   newViewProps.selectionMenuConfig.copyImageUrl);
   [self pushSelectionMenuLabelsToSegments];
 
   if (newViewProps.spoilerOverlay != oldViewProps.spoilerOverlay) {

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -98,13 +98,7 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   NSArray<NSString *> *_contextMenuItemTexts;
   NSArray<NSString *> *_contextMenuItemIcons;
   ENRMSelectionMenuConfig _selectionMenuConfig;
-  // Strong owners for the selection menu labels referenced (unretained) by
-  // _selectionMenuConfig. Kept alive for the view's lifetime.
-  NSString *_copyLabel;
-  NSString *_copyAsMarkdownLabel;
-  NSString *_copyImageUrlLabel;
-  NSString *_copyImageUrlsLabel;
-  NSArray<NSString *> *_copyImageUrlPluralTemplates;
+  ENRMSelectionMenuLabels _selectionMenuLabels;
 
   ENRMSpoilerOverlayManager *_spoilerManager;
 
@@ -540,26 +534,10 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
     _contextMenuItemIcons = ENRMContextMenuIconsFromItems(newViewProps.contextMenuItems);
   }
 
-  _copyLabel = [[NSString alloc] initWithUTF8String:newViewProps.selectionMenuConfig.copyLabel.c_str()];
-  _copyAsMarkdownLabel =
-      [[NSString alloc] initWithUTF8String:newViewProps.selectionMenuConfig.copyAsMarkdownLabel.c_str()];
-  _copyImageUrlLabel = [[NSString alloc] initWithUTF8String:newViewProps.selectionMenuConfig.copyImageUrlLabel.c_str()];
-  _copyImageUrlsLabel =
-      [[NSString alloc] initWithUTF8String:newViewProps.selectionMenuConfig.copyImageUrlsLabel.c_str()];
-  NSMutableArray<NSString *> *pluralTemplates = [NSMutableArray array];
-  for (const auto &templateStr : newViewProps.selectionMenuConfig.copyImageUrlPluralTemplates) {
-    [pluralTemplates addObject:[[NSString alloc] initWithUTF8String:templateStr.c_str()]];
-  }
-  _copyImageUrlPluralTemplates = pluralTemplates;
-  _selectionMenuConfig = (ENRMSelectionMenuConfig){
-      .copyAsMarkdown = newViewProps.selectionMenuConfig.copyAsMarkdown,
-      .copyImageURL = newViewProps.selectionMenuConfig.copyImageUrl,
-      .copyLabel = _copyLabel,
-      .copyAsMarkdownLabel = _copyAsMarkdownLabel,
-      .copyImageUrlLabel = _copyImageUrlLabel,
-      .copyImageUrlsLabel = _copyImageUrlsLabel,
-      .copyImageUrlPluralTemplates = _copyImageUrlPluralTemplates,
-  };
+  _selectionMenuLabels = ENRMParseSelectionMenuLabels(newViewProps.selectionMenuConfig);
+  _selectionMenuConfig =
+      ENRMBuildSelectionMenuConfig(_selectionMenuLabels, newViewProps.selectionMenuConfig.copyAsMarkdown,
+                                   newViewProps.selectionMenuConfig.copyImageUrl);
 
   if (newViewProps.streamingAnimation != oldViewProps.streamingAnimation) {
     _streamingAnimation = newViewProps.streamingAnimation;

--- a/packages/react-native-enriched-markdown/ios/utils/EditMenuUtils.h
+++ b/packages/react-native-enriched-markdown/ios/utils/EditMenuUtils.h
@@ -37,6 +37,47 @@ static inline NSString *ENRMResolveImageURLsTitle(ENRMSelectionMenuConfig config
 }
 
 #ifdef __cplusplus
+
+/// Strong owners for the label strings in ENRMSelectionMenuConfig.
+struct ENRMSelectionMenuLabels {
+  NSString *copyLabel = nil;
+  NSString *copyAsMarkdownLabel = nil;
+  NSString *copyImageUrlLabel = nil;
+  NSString *copyImageUrlsLabel = nil;
+  NSArray<NSString *> *copyImageUrlPluralTemplates = nil;
+};
+
+/// Converts a codegen SelectionMenuConfig struct into strong NSString labels.
+template <typename T> static inline ENRMSelectionMenuLabels ENRMParseSelectionMenuLabels(const T &src)
+{
+  NSMutableArray<NSString *> *templates = [NSMutableArray array];
+  for (const auto &s : src.copyImageUrlPluralTemplates) {
+    [templates addObject:[[NSString alloc] initWithUTF8String:s.c_str()]];
+  }
+  return {
+      [[NSString alloc] initWithUTF8String:src.copyLabel.c_str()],
+      [[NSString alloc] initWithUTF8String:src.copyAsMarkdownLabel.c_str()],
+      [[NSString alloc] initWithUTF8String:src.copyImageUrlLabel.c_str()],
+      [[NSString alloc] initWithUTF8String:src.copyImageUrlsLabel.c_str()],
+      templates,
+  };
+}
+
+/// Builds an ENRMSelectionMenuConfig from pre-parsed labels and boolean flags.
+static inline ENRMSelectionMenuConfig ENRMBuildSelectionMenuConfig(const ENRMSelectionMenuLabels &labels,
+                                                                   bool copyAsMarkdown, bool copyImageUrl)
+{
+  return (ENRMSelectionMenuConfig){
+      .copyAsMarkdown = copyAsMarkdown,
+      .copyImageURL = copyImageUrl,
+      .copyLabel = labels.copyLabel,
+      .copyAsMarkdownLabel = labels.copyAsMarkdownLabel,
+      .copyImageUrlLabel = labels.copyImageUrlLabel,
+      .copyImageUrlsLabel = labels.copyImageUrlsLabel,
+      .copyImageUrlPluralTemplates = labels.copyImageUrlPluralTemplates,
+  };
+}
+
 extern "C" {
 #endif
 


### PR DESCRIPTION
### What/Why?
Deduplicate the identical 20-line prop-parsing block in EnrichedMarkdown.mm and EnrichedMarkdownText.mm into a reusable C++ template in EditMenuUtils.h.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

