### PR TITLE
fix(ios): keep link variant color when a font style is toggled on a mention

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
@@ -136,6 +136,8 @@
     return;
   }
 
+  NSMutableArray<ENRMFormattingRange *> *deferredLinkRanges = [NSMutableArray array];
+
   for (ENRMFormattingRange *formattingRange in ranges) {
     if (formattingRange.range.length == 0 || NSMaxRange(formattingRange.range) > textLength) {
       continue;
@@ -155,10 +157,25 @@
       }
     }
 
+    // Defer link styling to a second pass so its variant color wins over a font style's base text
+    // color: a bold/italic mention must keep its chip color instead of turning black.
+    if (formattingRange.type == ENRMInputStyleTypeLink) {
+      [deferredLinkRanges addObject:formattingRange];
+      continue;
+    }
+
     [handler applyNonFontAttributesToTextStorage:textStorage
                                            range:formattingRange.range
                                  formattingRange:formattingRange
                                            style:style];
+  }
+
+  for (ENRMFormattingRange *linkRange in deferredLinkRanges) {
+    id<ENRMStyleHandler> linkHandler = _styleHandlers[@(linkRange.type)];
+    [linkHandler applyNonFontAttributesToTextStorage:textStorage
+                                               range:linkRange.range
+                                     formattingRange:linkRange
+                                               style:style];
   }
 
   NSUInteger runStart = 0;


### PR DESCRIPTION
## Summary

On iOS, toggling an inline font style (Bold/Italic) on a range that overlaps a link/mention makes the link lose its `linkVariants` color: it falls back to the base text color (e.g. turns black) while the style is active. A full re-parse (reload) restores the color, so the stored data is fine — it is a live-rendering bug. Android is not affected.

## Problem

A mention's `linkVariants` color is dropped the moment a font style is toggled over it, and only comes back after the document is re-parsed.

Steps to reproduce:

1. Render `EnrichedMarkdownTextInput` with a variant, e.g. `markdownStyle={{ linkVariants: { "^custom://": { color: "red" } } }}`.
2. Insert a link `[label](custom://x)` — it renders red.
3. Select it and toggle **Bold** from the Format context menu.
4. The text turns black (loses the red variant color) while bold.
5. Reopen / re-parse the document → red again.

### Root cause

In `ENRMInputFormatter applyFormattingRanges:toTextView:style:` the ranges are applied in iteration order. `ENRMBoldStyleHandler` (and the other font handlers) always set the foreground color:

```objc
RCTUIColor *color = style.boldColor ?: style.baseTextColor;
[storage addAttribute:NSForegroundColorAttributeName value:color range:range];
```

When the `Strong` range is applied **after** the `Link` range, this base color overwrites the variant color set by `ENRMLinkStyleHandler`. On parse the ordering happens to apply the link last, so it looks fine; a live toggle appends the `Strong` range after the link, which exposes the bug.

## Fix

Apply link (structural) styling in a second pass, after the font-style handlers, so a link's variant color always wins over a font style's base color.

## Before / after

|  | Before | After |
| :--: | :--: | :--: |
| **iOS** | <video src="https://github.com/user-attachments/assets/c28e2b60-39fe-4729-9803-57604075944c"></video> | <video src="https://github.com/user-attachments/assets/a0c366dc-f2e6-4465-b7cb-11e53e5f3efe"></video> |

## Test plan

- iOS: bold/italic a mention that has a `linkVariants` color → the chip keeps its color live (no black), and still after a re-parse.
- Plain bold/italic text, and styles that configure `boldColor`/`italicColor`, are unaffected.

## Notes

- **Android is not affected:** its bold handler adds a color span only when `boldColor` is set in the style (`style.boldColor?.let { ... }`), so the link variant color stays intact. iOS instead always sets `boldColor ?: baseTextColor`, overwriting it.
- Single-file change in `ios/input/ENRMInputFormatter.mm`. Tested on iOS, on top of `main`.
