### PR TITLE
fix(android): InputRemend mishandles combined bold+italic *** delimiter

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputRemend.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputRemend.kt
@@ -9,6 +9,7 @@ object InputRemend {
 
   private val DELIMITER_PAIRS =
     arrayOf(
+      DelimiterPair("***", "***", true),
       DelimiterPair("**", "**", true),
       DelimiterPair("*", "*", true),
       DelimiterPair("_", "_", true),


### PR DESCRIPTION

### What/Why?
InputRemend.complete() appended phantom closing asterisks when bold+italic (***) markdown was set directly as a raw value on Android.

The root cause: DELIMITER_PAIRS listed ** before * but had no entry for ***. When parsing ***bold italic***, the scanner consumed ** as one delimiter and * as another (pushing two separate stack entries). On the closing side, ** was matched first again — leaving the stack non-empty at EOF and causing extra closers to be appended (e.g. ***bold italic*** → ***bold italic*** + 6 asterisks).

Fix: Add DelimiterPair("***", "***", true) before ** in DELIMITER_PAIRS so triple-asterisk is matched atomically as a single unit.



### Testing
- Android unit tests added in InputRemendTest.kt covering balanced and unclosed *** cases
- Maestro E2E test added (bold_italic_raw_markdown_test.yaml) — sets ***Bold italic*** via the raw markdown input and asserts the screenshot renders correctly without phantom asterisks



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->
| Before | After |
| - | - |
| <img src="https://github.com/user-attachments/assets/990ec882-4019-4eaa-9fb6-8be694c87c88" width=300 /> | <img src="https://github.com/user-attachments/assets/686dd519-611b-49bf-8102-47074ec16cbf" width=300 /> |


### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

