### PR TITLE
feat(android): add Compose font registry bridge

### DIFF
--- a/packages/android-enriched-markdown/compose/build.gradle
+++ b/packages/android-enriched-markdown/compose/build.gradle
@@ -31,11 +31,10 @@ android {
 
 dependencies {
   implementation(project(":ui"))
+  implementation("androidx.core:core-ktx:1.15.0")
 
   def composeBom = platform("androidx.compose:compose-bom:2026.06.00")
   implementation(composeBom)
-  androidTestImplementation(composeBom)
 
   implementation("androidx.compose.ui:ui")
-  implementation("androidx.compose.material3:material3")
 }

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/ComposeModule.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/ComposeModule.kt
@@ -1,3 +1,0 @@
-package com.swmansion.enriched.markdown.compose
-
-object ComposeModule

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/ComposeFontRegistry.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/ComposeFontRegistry.kt
@@ -1,0 +1,21 @@
+package com.swmansion.enriched.markdown.compose.style
+
+import android.graphics.Typeface
+import com.swmansion.enriched.markdown.utils.text.TypefaceUtils
+import java.util.WeakHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+internal object ComposeFontRegistry {
+  private val idGenerator = AtomicInteger()
+  private val typefaceToKey = WeakHashMap<Typeface, String>()
+  private val lock = Any()
+
+  fun register(typeface: Typeface): String =
+    synchronized(lock) {
+      typefaceToKey.getOrPut(typeface) {
+        val key = "compose-font:${idGenerator.incrementAndGet()}"
+        TypefaceUtils.registerComposeFont(key, typeface)
+        key
+      }
+    }
+}

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/FontFamilyResolver.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/FontFamilyResolver.kt
@@ -1,0 +1,65 @@
+package com.swmansion.enriched.markdown.compose.style
+
+import android.graphics.Typeface
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontListFontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.ResourceFont
+import androidx.core.content.res.ResourcesCompat
+
+internal object FontFamilyResolver {
+  fun resolve(
+    fontFamily: FontFamily?,
+    resolveContext: StyleResolveContext,
+  ): String? {
+    if (fontFamily == null) {
+      return null
+    }
+
+    systemFontFamilyKey(fontFamily)?.let { return it }
+
+    val resourceTypeface = resolveResourceFont(fontFamily, resolveContext)
+    if (resourceTypeface != null) {
+      return ComposeFontRegistry.register(resourceTypeface)
+    }
+
+    val resolvedTypeface =
+      resolveContext.fontFamilyResolver
+        .resolve(
+          fontFamily = fontFamily,
+          fontWeight = FontWeight.Normal,
+          fontStyle = FontStyle.Normal,
+        ).value as? Typeface ?: return null
+
+    return ComposeFontRegistry.register(resolvedTypeface)
+  }
+
+  private fun systemFontFamilyKey(fontFamily: FontFamily): String? =
+    when (fontFamily) {
+      FontFamily.Default, FontFamily.SansSerif -> "sans-serif"
+      FontFamily.Serif -> "serif"
+      FontFamily.Monospace -> "monospace"
+      FontFamily.Cursive -> "cursive"
+      else -> null
+    }
+
+  private fun resolveResourceFont(
+    fontFamily: FontFamily,
+    resolveContext: StyleResolveContext,
+  ): Typeface? {
+    if (fontFamily !is FontListFontFamily) {
+      return null
+    }
+
+    for (font in fontFamily.fonts) {
+      if (font !is ResourceFont) {
+        continue
+      }
+
+      ResourcesCompat.getFont(resolveContext.context, font.resId)?.let { return it }
+    }
+
+    return null
+  }
+}

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/TypefaceUtils.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/TypefaceUtils.kt
@@ -65,6 +65,13 @@ object TypefaceUtils {
     }
   }
 
+  fun registerComposeFont(
+    key: String,
+    typeface: Typeface,
+  ) {
+    typefaceCache["family:$key"] = typeface
+  }
+
   fun loadFontFamily(
     context: Context,
     family: String,


### PR DESCRIPTION
### What/Why?
In compose we have a new way of specifying fonts family: https://developer.android.com/develop/ui/compose/text/fonts
And we need a way to "translate" compose fonts into fonts passable to normal TextView 


### Testing
example app



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

