### PR TITLE
feat(android): add Compose markdown style DSL

### DIFF
--- a/packages/android-enriched-markdown/compose/build.gradle
+++ b/packages/android-enriched-markdown/compose/build.gradle
@@ -31,11 +31,10 @@ android {
 
 dependencies {
   implementation(project(":ui"))
+  implementation("androidx.core:core-ktx:1.15.0")
 
   def composeBom = platform("androidx.compose:compose-bom:2026.06.00")
   implementation(composeBom)
-  androidTestImplementation(composeBom)
 
   implementation("androidx.compose.ui:ui")
-  implementation("androidx.compose.material3:material3")
 }

--- a/packages/android-enriched-markdown/compose/build.gradle
+++ b/packages/android-enriched-markdown/compose/build.gradle
@@ -37,4 +37,5 @@ dependencies {
   implementation(composeBom)
 
   implementation("androidx.compose.ui:ui")
+  implementation("androidx.compose.material3:material3")
 }

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/ComposeModule.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/ComposeModule.kt
@@ -1,3 +1,0 @@
-package com.swmansion.enriched.markdown.compose
-
-object ComposeModule

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownStyle.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownStyle.kt
@@ -1,0 +1,50 @@
+package com.swmansion.enriched.markdown.compose
+
+import androidx.compose.runtime.Immutable
+import com.swmansion.enriched.markdown.compose.style.StyleResolveContext
+import com.swmansion.enriched.markdown.styles.StyleConfig
+
+/**
+ * An immutable, layered markdown style that resolves to a [StyleConfig] at composition time.
+ *
+ * Create styles with [markdownStyle] or derive overrides with [copy]. Provide defaults app-wide
+ * via [MarkdownTheme], and override per subtree by nesting another [MarkdownTheme].
+ *
+ * ```
+ * val base = markdownStyle { paragraph { fontSize = 16.sp } }
+ *
+ * val lightStyle = base.copy { paragraph { color = Color(0xFF1A1A1A) } }
+ * val darkStyle = base.copy { paragraph { color = Color(0xFFE0E0E0) } }
+ * ```
+ */
+@Immutable
+class MarkdownStyle internal constructor(
+  private val layers: List<MarkdownStyleLayer>,
+) {
+  /**
+   * Returns a new style that applies [block] on top of this style's layers.
+   *
+   * Useful for light/dark overrides or scoped tweaks without rebuilding the entire style.
+   */
+  fun copy(block: MarkdownStyleBuilder.() -> Unit): MarkdownStyle {
+    val layer = MarkdownStyleBuilder().apply(block).captureLayer()
+    return MarkdownStyle(layers + layer)
+  }
+
+  internal fun resolve(resolveContext: StyleResolveContext): StyleConfig =
+    layers.fold(StyleConfig.default(resolveContext.context)) { config, layer ->
+      layer.apply(resolveContext, config)
+    }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is MarkdownStyle) return false
+    return layers == other.layers
+  }
+
+  override fun hashCode(): Int = layers.hashCode()
+
+  companion object {
+    val Default = MarkdownStyle(emptyList())
+  }
+}

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownStyleBuilder.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownStyleBuilder.kt
@@ -1,0 +1,117 @@
+package com.swmansion.enriched.markdown.compose
+
+@MarkdownStyleDsl
+class MarkdownStyleBuilder internal constructor() {
+  private var paragraph: TextStylePatch? = null
+  private val headingPatches = mutableMapOf<Int, TextStylePatch>()
+  private var link: LinkStylePatch? = null
+  private var strong: StrongStylePatch? = null
+  private var emphasis: EmphasisStylePatch? = null
+  private var code: CodeStylePatch? = null
+  private var codeBlock: CodeBlockStylePatch? = null
+  private var blockquote: BlockquoteStylePatch? = null
+  private var list: ListStylePatch? = null
+  private var image: ImageStylePatch? = null
+  private var inlineImage: InlineImageStylePatch? = null
+  private var thematicBreak: ThematicBreakStylePatch? = null
+
+  fun paragraph(block: ParagraphStyleScope.() -> Unit) {
+    paragraph = TextStyleScope.merge(paragraph, block)
+  }
+
+  fun h1(block: HeadingStyleScope.() -> Unit) = heading(1, block)
+
+  fun h2(block: HeadingStyleScope.() -> Unit) = heading(2, block)
+
+  fun h3(block: HeadingStyleScope.() -> Unit) = heading(3, block)
+
+  fun h4(block: HeadingStyleScope.() -> Unit) = heading(4, block)
+
+  fun h5(block: HeadingStyleScope.() -> Unit) = heading(5, block)
+
+  fun h6(block: HeadingStyleScope.() -> Unit) = heading(6, block)
+
+  fun link(block: LinkStyleScope.() -> Unit) {
+    link = LinkStyleScope.merge(link, block)
+  }
+
+  fun strong(block: StrongStyleScope.() -> Unit) {
+    strong = StrongStyleScope.merge(strong, block)
+  }
+
+  fun emphasis(block: EmphasisStyleScope.() -> Unit) {
+    emphasis = EmphasisStyleScope.merge(emphasis, block)
+  }
+
+  fun code(block: CodeStyleScope.() -> Unit) {
+    code = CodeStyleScope.merge(code, block)
+  }
+
+  fun codeBlock(block: CodeBlockStyleScope.() -> Unit) {
+    codeBlock = CodeBlockStyleScope.merge(codeBlock, block)
+  }
+
+  fun blockquote(block: BlockquoteStyleScope.() -> Unit) {
+    blockquote = BlockquoteStyleScope.merge(blockquote, block)
+  }
+
+  fun list(block: ListStyleScope.() -> Unit) {
+    list = ListStyleScope.merge(list, block)
+  }
+
+  fun image(block: ImageStyleScope.() -> Unit) {
+    image = ImageStyleScope.merge(image, block)
+  }
+
+  fun inlineImage(block: InlineImageStyleScope.() -> Unit) {
+    inlineImage = InlineImageStyleScope.merge(inlineImage, block)
+  }
+
+  fun thematicBreak(block: ThematicBreakStyleScope.() -> Unit) {
+    thematicBreak = ThematicBreakStyleScope.merge(thematicBreak, block)
+  }
+
+  internal fun captureLayer(): MarkdownStyleLayer =
+    MarkdownStyleLayer(
+      paragraph = paragraph,
+      headingPatches = headingPatches.toMap(),
+      link = link,
+      strong = strong,
+      emphasis = emphasis,
+      code = code,
+      codeBlock = codeBlock,
+      blockquote = blockquote,
+      list = list,
+      image = image,
+      inlineImage = inlineImage,
+      thematicBreak = thematicBreak,
+    )
+
+  private fun heading(
+    level: Int,
+    block: HeadingStyleScope.() -> Unit,
+  ) {
+    headingPatches[level] = TextStyleScope.merge(headingPatches[level], block)
+  }
+}
+
+/**
+ * Creates a [MarkdownStyle] using Compose types (`Color`, `Dp`, `sp`, [androidx.compose.ui.text.font.FontFamily]).
+ *
+ * Call from a `@Composable` to read [androidx.compose.material3.MaterialTheme] tokens:
+ *
+ * ```
+ * MaterialTheme {
+ *   MarkdownTheme(style = markdownStyle {
+ *     paragraph { color = MaterialTheme.colorScheme.onSurface }
+ *     link { color = MaterialTheme.colorScheme.primary }
+ *   }) {
+ *     NavHost(...)
+ *   }
+ * }
+ * ```
+ *
+ * For styles that track Material color-scheme changes automatically, prefer [rememberMarkdownStyle].
+ */
+fun markdownStyle(block: MarkdownStyleBuilder.() -> Unit): MarkdownStyle =
+  MarkdownStyle(listOf(MarkdownStyleBuilder().apply(block).captureLayer()))

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownStyleDsl.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownStyleDsl.kt
@@ -1,0 +1,4 @@
+package com.swmansion.enriched.markdown.compose
+
+@DslMarker
+annotation class MarkdownStyleDsl

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownStyleLayer.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownStyleLayer.kt
@@ -1,0 +1,57 @@
+package com.swmansion.enriched.markdown.compose
+
+import androidx.compose.runtime.Immutable
+import com.swmansion.enriched.markdown.compose.style.StyleResolveContext
+import com.swmansion.enriched.markdown.compose.style.StyleConfigMerger
+import com.swmansion.enriched.markdown.compose.style.StylePatch
+import com.swmansion.enriched.markdown.compose.style.StyleUnits
+import com.swmansion.enriched.markdown.styles.StyleConfig
+
+@Immutable
+internal data class MarkdownStyleLayer(
+  val paragraph: TextStylePatch? = null,
+  val headingPatches: Map<Int, TextStylePatch> = emptyMap(),
+  val link: LinkStylePatch? = null,
+  val strong: StrongStylePatch? = null,
+  val emphasis: EmphasisStylePatch? = null,
+  val code: CodeStylePatch? = null,
+  val codeBlock: CodeBlockStylePatch? = null,
+  val blockquote: BlockquoteStylePatch? = null,
+  val list: ListStylePatch? = null,
+  val image: ImageStylePatch? = null,
+  val inlineImage: InlineImageStylePatch? = null,
+  val thematicBreak: ThematicBreakStylePatch? = null,
+) {
+  fun apply(
+    resolveContext: StyleResolveContext,
+    base: StyleConfig,
+  ): StyleConfig {
+    val units = StyleUnits(resolveContext.density)
+    val headingStyles =
+      headingPatches
+        .mapNotNull { (level, patch) ->
+          base.headingStyles.getOrNull(level)?.let { level to patch.apply(it, resolveContext, units) }
+        }.toMap()
+        .takeIf { it.isNotEmpty() }
+
+    return StyleConfigMerger.merge(
+      resolveContext = resolveContext,
+      base = base,
+      patch =
+        StylePatch(
+          paragraphStyle = paragraph?.apply(base.paragraphStyle, resolveContext, units),
+          headingStyles = headingStyles,
+          linkStyle = link?.apply(base.linkStyle, resolveContext, units),
+          strongStyle = strong?.apply(base.strongStyle, resolveContext, units),
+          emphasisStyle = emphasis?.apply(base.emphasisStyle, resolveContext, units),
+          codeStyle = code?.apply(base.codeStyle, resolveContext, units),
+          codeBlockStyle = codeBlock?.apply(base.codeBlockStyle, resolveContext, units),
+          blockquoteStyle = blockquote?.apply(base.blockquoteStyle, resolveContext, units),
+          listStyle = list?.apply(base.listStyle, resolveContext, units),
+          imageStyle = image?.apply(base.imageStyle, units),
+          inlineImageStyle = inlineImage?.apply(base.inlineImageStyle, units),
+          thematicBreakStyle = thematicBreak?.apply(base.thematicBreakStyle, units),
+        ),
+    )
+  }
+}

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownStylePatches.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownStylePatches.kt
@@ -1,0 +1,770 @@
+package com.swmansion.enriched.markdown.compose
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import com.swmansion.enriched.markdown.compose.style.FontFamilyResolver
+import com.swmansion.enriched.markdown.compose.style.StyleResolveContext
+import com.swmansion.enriched.markdown.compose.style.StyleUnits
+import com.swmansion.enriched.markdown.compose.style.toEmphasisStyleString
+import com.swmansion.enriched.markdown.compose.style.toStyleWeight
+import com.swmansion.enriched.markdown.styles.BlockquoteStyle
+import com.swmansion.enriched.markdown.styles.CodeBlockStyle
+import com.swmansion.enriched.markdown.styles.CodeStyle
+import com.swmansion.enriched.markdown.styles.EmphasisStyle
+import com.swmansion.enriched.markdown.styles.HeadingStyle
+import com.swmansion.enriched.markdown.styles.ImageStyle
+import com.swmansion.enriched.markdown.styles.InlineImageStyle
+import com.swmansion.enriched.markdown.styles.LinkStyle
+import com.swmansion.enriched.markdown.styles.ListStyle
+import com.swmansion.enriched.markdown.styles.ParagraphStyle
+import com.swmansion.enriched.markdown.styles.StrongStyle
+import com.swmansion.enriched.markdown.styles.TextAlignment
+import com.swmansion.enriched.markdown.styles.ThematicBreakStyle
+
+@Immutable
+internal data class TextStylePatch(
+  val fontSize: TextUnit? = null,
+  val fontFamily: FontFamily? = null,
+  val fontWeight: FontWeight? = null,
+  val color: Color? = null,
+  val lineHeight: TextUnit? = null,
+  val marginTop: Dp? = null,
+  val marginBottom: Dp? = null,
+  val textAlign: TextAlignment? = null,
+) {
+  fun apply(
+    base: ParagraphStyle,
+    resolveContext: StyleResolveContext,
+    units: StyleUnits,
+  ): ParagraphStyle =
+    base.copy(
+      fontSize = fontSize?.let(units::sp) ?: base.fontSize,
+      fontFamily = fontFamily?.let { FontFamilyResolver.resolve(it, resolveContext) } ?: base.fontFamily,
+      fontWeight = fontWeight?.toStyleWeight() ?: base.fontWeight,
+      color = color?.let(units::color) ?: base.color,
+      lineHeight = lineHeight?.let(units::sp) ?: base.lineHeight,
+      marginTop = marginTop?.let(units::dp) ?: base.marginTop,
+      marginBottom = marginBottom?.let(units::dp) ?: base.marginBottom,
+      textAlign = textAlign ?: base.textAlign,
+    )
+
+  fun apply(
+    base: HeadingStyle,
+    resolveContext: StyleResolveContext,
+    units: StyleUnits,
+  ): HeadingStyle =
+    base.copy(
+      fontSize = fontSize?.let(units::sp) ?: base.fontSize,
+      fontFamily = fontFamily?.let { FontFamilyResolver.resolve(it, resolveContext) } ?: base.fontFamily,
+      fontWeight = fontWeight?.toStyleWeight() ?: base.fontWeight,
+      color = color?.let(units::color) ?: base.color,
+      lineHeight = lineHeight?.let(units::sp) ?: base.lineHeight,
+      marginTop = marginTop?.let(units::dp) ?: base.marginTop,
+      marginBottom = marginBottom?.let(units::dp) ?: base.marginBottom,
+      textAlign = textAlign ?: base.textAlign,
+    )
+}
+
+@MarkdownStyleDsl
+class TextStyleScope {
+  var fontSize: TextUnit? = null
+  var fontFamily: FontFamily? = null
+  var fontWeight: FontWeight? = null
+  var color: Color? = null
+  var lineHeight: TextUnit? = null
+  var marginTop: Dp? = null
+  var marginBottom: Dp? = null
+  var textAlign: TextAlignment? = null
+
+  internal fun toPatch(): TextStylePatch =
+    TextStylePatch(
+      fontSize = fontSize,
+      fontFamily = fontFamily,
+      fontWeight = fontWeight,
+      color = color,
+      lineHeight = lineHeight,
+      marginTop = marginTop,
+      marginBottom = marginBottom,
+      textAlign = textAlign,
+    )
+
+  internal companion object {
+    fun merge(
+      existing: TextStylePatch?,
+      block: TextStyleScope.() -> Unit,
+    ): TextStylePatch {
+      val scope =
+        TextStyleScope().apply {
+          if (existing != null) {
+            fontSize = existing.fontSize
+            fontFamily = existing.fontFamily
+            fontWeight = existing.fontWeight
+            color = existing.color
+            lineHeight = existing.lineHeight
+            marginTop = existing.marginTop
+            marginBottom = existing.marginBottom
+            textAlign = existing.textAlign
+          }
+        }
+      scope.apply(block)
+      return scope.toPatch()
+    }
+  }
+}
+
+typealias ParagraphStyleScope = TextStyleScope
+typealias HeadingStyleScope = TextStyleScope
+
+@Immutable
+internal data class LinkStylePatch(
+  val fontFamily: FontFamily? = null,
+  val color: Color? = null,
+  val underline: Boolean? = null,
+  val backgroundColor: Color? = null,
+) {
+  fun apply(
+    base: LinkStyle,
+    resolveContext: StyleResolveContext,
+    units: StyleUnits,
+  ): LinkStyle =
+    base.copy(
+      fontFamily = fontFamily?.let { FontFamilyResolver.resolve(it, resolveContext) } ?: base.fontFamily,
+      color = color?.let(units::color) ?: base.color,
+      underline = underline ?: base.underline,
+      backgroundColor = backgroundColor?.let(units::color) ?: base.backgroundColor,
+    )
+}
+
+@MarkdownStyleDsl
+class LinkStyleScope {
+  var fontFamily: FontFamily? = null
+  var color: Color? = null
+  var underline: Boolean? = null
+  var backgroundColor: Color? = null
+
+  internal fun toPatch(): LinkStylePatch =
+    LinkStylePatch(
+      fontFamily = fontFamily,
+      color = color,
+      underline = underline,
+      backgroundColor = backgroundColor,
+    )
+
+  internal companion object {
+    fun merge(
+      existing: LinkStylePatch?,
+      block: LinkStyleScope.() -> Unit,
+    ): LinkStylePatch {
+      val scope =
+        LinkStyleScope().apply {
+          if (existing != null) {
+            fontFamily = existing.fontFamily
+            color = existing.color
+            underline = existing.underline
+            backgroundColor = existing.backgroundColor
+          }
+        }
+      scope.apply(block)
+      return scope.toPatch()
+    }
+  }
+}
+
+@Immutable
+internal data class StrongStylePatch(
+  val fontFamily: FontFamily? = null,
+  val fontWeight: FontWeight? = null,
+  val color: Color? = null,
+) {
+  fun apply(
+    base: StrongStyle,
+    resolveContext: StyleResolveContext,
+    units: StyleUnits,
+  ): StrongStyle =
+    base.copy(
+      fontFamily = fontFamily?.let { FontFamilyResolver.resolve(it, resolveContext) } ?: base.fontFamily,
+      fontWeight = fontWeight?.toStyleWeight() ?: base.fontWeight,
+      color = color?.let(units::color) ?: base.color,
+    )
+}
+
+@MarkdownStyleDsl
+class StrongStyleScope {
+  var fontFamily: FontFamily? = null
+  var fontWeight: FontWeight? = null
+  var color: Color? = null
+
+  internal fun toPatch(): StrongStylePatch =
+    StrongStylePatch(
+      fontFamily = fontFamily,
+      fontWeight = fontWeight,
+      color = color,
+    )
+
+  internal companion object {
+    fun merge(
+      existing: StrongStylePatch?,
+      block: StrongStyleScope.() -> Unit,
+    ): StrongStylePatch {
+      val scope =
+        StrongStyleScope().apply {
+          if (existing != null) {
+            fontFamily = existing.fontFamily
+            fontWeight = existing.fontWeight
+            color = existing.color
+          }
+        }
+      scope.apply(block)
+      return scope.toPatch()
+    }
+  }
+}
+
+@Immutable
+internal data class EmphasisStylePatch(
+  val fontFamily: FontFamily? = null,
+  val fontStyle: FontStyle? = null,
+  val color: Color? = null,
+) {
+  fun apply(
+    base: EmphasisStyle,
+    resolveContext: StyleResolveContext,
+    units: StyleUnits,
+  ): EmphasisStyle =
+    base.copy(
+      fontFamily = fontFamily?.let { FontFamilyResolver.resolve(it, resolveContext) } ?: base.fontFamily,
+      fontStyle = fontStyle?.toEmphasisStyleString() ?: base.fontStyle,
+      color = color?.let(units::color) ?: base.color,
+    )
+}
+
+@MarkdownStyleDsl
+class EmphasisStyleScope {
+  var fontFamily: FontFamily? = null
+  var fontStyle: FontStyle? = null
+  var color: Color? = null
+
+  internal fun toPatch(): EmphasisStylePatch =
+    EmphasisStylePatch(
+      fontFamily = fontFamily,
+      fontStyle = fontStyle,
+      color = color,
+    )
+
+  internal companion object {
+    fun merge(
+      existing: EmphasisStylePatch?,
+      block: EmphasisStyleScope.() -> Unit,
+    ): EmphasisStylePatch {
+      val scope =
+        EmphasisStyleScope().apply {
+          if (existing != null) {
+            fontFamily = existing.fontFamily
+            fontStyle = existing.fontStyle
+            color = existing.color
+          }
+        }
+      scope.apply(block)
+      return scope.toPatch()
+    }
+  }
+}
+
+@Immutable
+internal data class CodeStylePatch(
+  val fontFamily: FontFamily? = null,
+  val fontSize: TextUnit? = null,
+  val color: Color? = null,
+  val backgroundColor: Color? = null,
+  val borderColor: Color? = null,
+) {
+  fun apply(
+    base: CodeStyle,
+    resolveContext: StyleResolveContext,
+    units: StyleUnits,
+  ): CodeStyle =
+    base.copy(
+      fontFamily = fontFamily?.let { FontFamilyResolver.resolve(it, resolveContext) } ?: base.fontFamily,
+      fontSize = fontSize?.let(units::sp) ?: base.fontSize,
+      color = color?.let(units::color) ?: base.color,
+      backgroundColor = backgroundColor?.let(units::color) ?: base.backgroundColor,
+      borderColor = borderColor?.let(units::color) ?: base.borderColor,
+    )
+}
+
+@MarkdownStyleDsl
+class CodeStyleScope {
+  var fontFamily: FontFamily? = null
+  var fontSize: TextUnit? = null
+  var color: Color? = null
+  var backgroundColor: Color? = null
+  var borderColor: Color? = null
+
+  internal fun toPatch(): CodeStylePatch =
+    CodeStylePatch(
+      fontFamily = fontFamily,
+      fontSize = fontSize,
+      color = color,
+      backgroundColor = backgroundColor,
+      borderColor = borderColor,
+    )
+
+  internal companion object {
+    fun merge(
+      existing: CodeStylePatch?,
+      block: CodeStyleScope.() -> Unit,
+    ): CodeStylePatch {
+      val scope =
+        CodeStyleScope().apply {
+          if (existing != null) {
+            fontFamily = existing.fontFamily
+            fontSize = existing.fontSize
+            color = existing.color
+            backgroundColor = existing.backgroundColor
+            borderColor = existing.borderColor
+          }
+        }
+      scope.apply(block)
+      return scope.toPatch()
+    }
+  }
+}
+
+@Immutable
+internal data class CodeBlockStylePatch(
+  val fontSize: TextUnit? = null,
+  val fontFamily: FontFamily? = null,
+  val fontWeight: FontWeight? = null,
+  val color: Color? = null,
+  val lineHeight: TextUnit? = null,
+  val marginTop: Dp? = null,
+  val marginBottom: Dp? = null,
+  val backgroundColor: Color? = null,
+  val borderColor: Color? = null,
+  val cornerRadius: Dp? = null,
+  val borderWidth: Dp? = null,
+  val padding: Dp? = null,
+) {
+  fun apply(
+    base: CodeBlockStyle,
+    resolveContext: StyleResolveContext,
+    units: StyleUnits,
+  ): CodeBlockStyle =
+    base.copy(
+      fontSize = fontSize?.let(units::sp) ?: base.fontSize,
+      fontFamily = fontFamily?.let { FontFamilyResolver.resolve(it, resolveContext) } ?: base.fontFamily,
+      fontWeight = fontWeight?.toStyleWeight() ?: base.fontWeight,
+      color = color?.let(units::color) ?: base.color,
+      lineHeight = lineHeight?.let(units::sp) ?: base.lineHeight,
+      marginTop = marginTop?.let(units::dp) ?: base.marginTop,
+      marginBottom = marginBottom?.let(units::dp) ?: base.marginBottom,
+      backgroundColor = backgroundColor?.let(units::color) ?: base.backgroundColor,
+      borderColor = borderColor?.let(units::color) ?: base.borderColor,
+      borderRadius = cornerRadius?.let(units::dp) ?: base.borderRadius,
+      borderWidth = borderWidth?.let(units::dp) ?: base.borderWidth,
+      padding = padding?.let(units::dp) ?: base.padding,
+    )
+}
+
+@MarkdownStyleDsl
+class CodeBlockStyleScope {
+  var fontSize: TextUnit? = null
+  var fontFamily: FontFamily? = null
+  var fontWeight: FontWeight? = null
+  var color: Color? = null
+  var lineHeight: TextUnit? = null
+  var marginTop: Dp? = null
+  var marginBottom: Dp? = null
+  var backgroundColor: Color? = null
+  var borderColor: Color? = null
+  var cornerRadius: Dp? = null
+  var borderWidth: Dp? = null
+  var padding: Dp? = null
+
+  internal fun toPatch(): CodeBlockStylePatch =
+    CodeBlockStylePatch(
+      fontSize = fontSize,
+      fontFamily = fontFamily,
+      fontWeight = fontWeight,
+      color = color,
+      lineHeight = lineHeight,
+      marginTop = marginTop,
+      marginBottom = marginBottom,
+      backgroundColor = backgroundColor,
+      borderColor = borderColor,
+      cornerRadius = cornerRadius,
+      borderWidth = borderWidth,
+      padding = padding,
+    )
+
+  internal companion object {
+    fun merge(
+      existing: CodeBlockStylePatch?,
+      block: CodeBlockStyleScope.() -> Unit,
+    ): CodeBlockStylePatch {
+      val scope =
+        CodeBlockStyleScope().apply {
+          if (existing != null) {
+            fontSize = existing.fontSize
+            fontFamily = existing.fontFamily
+            fontWeight = existing.fontWeight
+            color = existing.color
+            lineHeight = existing.lineHeight
+            marginTop = existing.marginTop
+            marginBottom = existing.marginBottom
+            backgroundColor = existing.backgroundColor
+            borderColor = existing.borderColor
+            cornerRadius = existing.cornerRadius
+            borderWidth = existing.borderWidth
+            padding = existing.padding
+          }
+        }
+      scope.apply(block)
+      return scope.toPatch()
+    }
+  }
+}
+
+@Immutable
+internal data class BlockquoteStylePatch(
+  val fontSize: TextUnit? = null,
+  val fontFamily: FontFamily? = null,
+  val fontWeight: FontWeight? = null,
+  val color: Color? = null,
+  val lineHeight: TextUnit? = null,
+  val marginTop: Dp? = null,
+  val marginBottom: Dp? = null,
+  val borderColor: Color? = null,
+  val borderWidth: Dp? = null,
+  val gapWidth: Dp? = null,
+  val backgroundColor: Color? = null,
+) {
+  fun apply(
+    base: BlockquoteStyle,
+    resolveContext: StyleResolveContext,
+    units: StyleUnits,
+  ): BlockquoteStyle =
+    base.copy(
+      fontSize = fontSize?.let(units::sp) ?: base.fontSize,
+      fontFamily = fontFamily?.let { FontFamilyResolver.resolve(it, resolveContext) } ?: base.fontFamily,
+      fontWeight = fontWeight?.toStyleWeight() ?: base.fontWeight,
+      color = color?.let(units::color) ?: base.color,
+      lineHeight = lineHeight?.let(units::sp) ?: base.lineHeight,
+      marginTop = marginTop?.let(units::dp) ?: base.marginTop,
+      marginBottom = marginBottom?.let(units::dp) ?: base.marginBottom,
+      borderColor = borderColor?.let(units::color) ?: base.borderColor,
+      borderWidth = borderWidth?.let(units::dp) ?: base.borderWidth,
+      gapWidth = gapWidth?.let(units::dp) ?: base.gapWidth,
+      backgroundColor = backgroundColor?.let(units::color) ?: base.backgroundColor,
+    )
+}
+
+@MarkdownStyleDsl
+class BlockquoteStyleScope {
+  var fontSize: TextUnit? = null
+  var fontFamily: FontFamily? = null
+  var fontWeight: FontWeight? = null
+  var color: Color? = null
+  var lineHeight: TextUnit? = null
+  var marginTop: Dp? = null
+  var marginBottom: Dp? = null
+  var borderColor: Color? = null
+  var borderWidth: Dp? = null
+  var gapWidth: Dp? = null
+  var backgroundColor: Color? = null
+
+  internal fun toPatch(): BlockquoteStylePatch =
+    BlockquoteStylePatch(
+      fontSize = fontSize,
+      fontFamily = fontFamily,
+      fontWeight = fontWeight,
+      color = color,
+      lineHeight = lineHeight,
+      marginTop = marginTop,
+      marginBottom = marginBottom,
+      borderColor = borderColor,
+      borderWidth = borderWidth,
+      gapWidth = gapWidth,
+      backgroundColor = backgroundColor,
+    )
+
+  internal companion object {
+    fun merge(
+      existing: BlockquoteStylePatch?,
+      block: BlockquoteStyleScope.() -> Unit,
+    ): BlockquoteStylePatch {
+      val scope =
+        BlockquoteStyleScope().apply {
+          if (existing != null) {
+            fontSize = existing.fontSize
+            fontFamily = existing.fontFamily
+            fontWeight = existing.fontWeight
+            color = existing.color
+            lineHeight = existing.lineHeight
+            marginTop = existing.marginTop
+            marginBottom = existing.marginBottom
+            borderColor = existing.borderColor
+            borderWidth = existing.borderWidth
+            gapWidth = existing.gapWidth
+            backgroundColor = existing.backgroundColor
+          }
+        }
+      scope.apply(block)
+      return scope.toPatch()
+    }
+  }
+}
+
+@Immutable
+internal data class ListStylePatch(
+  val fontSize: TextUnit? = null,
+  val fontFamily: FontFamily? = null,
+  val fontWeight: FontWeight? = null,
+  val color: Color? = null,
+  val lineHeight: TextUnit? = null,
+  val marginTop: Dp? = null,
+  val marginBottom: Dp? = null,
+  val bulletColor: Color? = null,
+  val bulletSize: Dp? = null,
+  val markerMinWidth: Dp? = null,
+  val markerColor: Color? = null,
+  val markerFontWeight: FontWeight? = null,
+  val gapWidth: Dp? = null,
+  val marginLeft: Dp? = null,
+) {
+  fun apply(
+    base: ListStyle,
+    resolveContext: StyleResolveContext,
+    units: StyleUnits,
+  ): ListStyle =
+    base.copy(
+      fontSize = fontSize?.let(units::sp) ?: base.fontSize,
+      fontFamily = fontFamily?.let { FontFamilyResolver.resolve(it, resolveContext) } ?: base.fontFamily,
+      fontWeight = fontWeight?.toStyleWeight() ?: base.fontWeight,
+      color = color?.let(units::color) ?: base.color,
+      lineHeight = lineHeight?.let(units::sp) ?: base.lineHeight,
+      marginTop = marginTop?.let(units::dp) ?: base.marginTop,
+      marginBottom = marginBottom?.let(units::dp) ?: base.marginBottom,
+      bulletColor = bulletColor?.let(units::color) ?: base.bulletColor,
+      bulletSize = bulletSize?.let(units::dp) ?: base.bulletSize,
+      markerMinWidth = markerMinWidth?.let(units::dp) ?: base.markerMinWidth,
+      markerColor = markerColor?.let(units::color) ?: base.markerColor,
+      markerFontWeight = markerFontWeight?.toStyleWeight() ?: base.markerFontWeight,
+      gapWidth = gapWidth?.let(units::dp) ?: base.gapWidth,
+      marginLeft = marginLeft?.let(units::dp) ?: base.marginLeft,
+    )
+}
+
+@MarkdownStyleDsl
+class ListStyleScope {
+  var fontSize: TextUnit? = null
+  var fontFamily: FontFamily? = null
+  var fontWeight: FontWeight? = null
+  var color: Color? = null
+  var lineHeight: TextUnit? = null
+  var marginTop: Dp? = null
+  var marginBottom: Dp? = null
+  var bulletColor: Color? = null
+  var bulletSize: Dp? = null
+  var markerMinWidth: Dp? = null
+  var markerColor: Color? = null
+  var markerFontWeight: FontWeight? = null
+  var gapWidth: Dp? = null
+  var marginLeft: Dp? = null
+
+  internal fun toPatch(): ListStylePatch =
+    ListStylePatch(
+      fontSize = fontSize,
+      fontFamily = fontFamily,
+      fontWeight = fontWeight,
+      color = color,
+      lineHeight = lineHeight,
+      marginTop = marginTop,
+      marginBottom = marginBottom,
+      bulletColor = bulletColor,
+      bulletSize = bulletSize,
+      markerMinWidth = markerMinWidth,
+      markerColor = markerColor,
+      markerFontWeight = markerFontWeight,
+      gapWidth = gapWidth,
+      marginLeft = marginLeft,
+    )
+
+  internal companion object {
+    fun merge(
+      existing: ListStylePatch?,
+      block: ListStyleScope.() -> Unit,
+    ): ListStylePatch {
+      val scope =
+        ListStyleScope().apply {
+          if (existing != null) {
+            fontSize = existing.fontSize
+            fontFamily = existing.fontFamily
+            fontWeight = existing.fontWeight
+            color = existing.color
+            lineHeight = existing.lineHeight
+            marginTop = existing.marginTop
+            marginBottom = existing.marginBottom
+            bulletColor = existing.bulletColor
+            bulletSize = existing.bulletSize
+            markerMinWidth = existing.markerMinWidth
+            markerColor = existing.markerColor
+            markerFontWeight = existing.markerFontWeight
+            gapWidth = existing.gapWidth
+            marginLeft = existing.marginLeft
+          }
+        }
+      scope.apply(block)
+      return scope.toPatch()
+    }
+  }
+}
+
+@Immutable
+internal data class ImageStylePatch(
+  val height: Dp? = null,
+  val borderRadius: Dp? = null,
+  val marginTop: Dp? = null,
+  val marginBottom: Dp? = null,
+) {
+  fun apply(
+    base: ImageStyle,
+    units: StyleUnits,
+  ): ImageStyle =
+    base.copy(
+      height = height?.let(units::dp) ?: base.height,
+      borderRadius = borderRadius?.let(units::dp) ?: base.borderRadius,
+      marginTop = marginTop?.let(units::dp) ?: base.marginTop,
+      marginBottom = marginBottom?.let(units::dp) ?: base.marginBottom,
+    )
+}
+
+@MarkdownStyleDsl
+class ImageStyleScope {
+  var height: Dp? = null
+  var borderRadius: Dp? = null
+  var marginTop: Dp? = null
+  var marginBottom: Dp? = null
+
+  internal fun toPatch(): ImageStylePatch =
+    ImageStylePatch(
+      height = height,
+      borderRadius = borderRadius,
+      marginTop = marginTop,
+      marginBottom = marginBottom,
+    )
+
+  internal companion object {
+    fun merge(
+      existing: ImageStylePatch?,
+      block: ImageStyleScope.() -> Unit,
+    ): ImageStylePatch {
+      val scope =
+        ImageStyleScope().apply {
+          if (existing != null) {
+            height = existing.height
+            borderRadius = existing.borderRadius
+            marginTop = existing.marginTop
+            marginBottom = existing.marginBottom
+          }
+        }
+      scope.apply(block)
+      return scope.toPatch()
+    }
+  }
+}
+
+@Immutable
+internal data class InlineImageStylePatch(
+  val size: Dp? = null,
+) {
+  fun apply(
+    base: InlineImageStyle,
+    units: StyleUnits,
+  ): InlineImageStyle =
+    base.copy(
+      size = size?.let(units::dp) ?: base.size,
+    )
+}
+
+@MarkdownStyleDsl
+class InlineImageStyleScope {
+  var size: Dp? = null
+
+  internal fun toPatch(): InlineImageStylePatch = InlineImageStylePatch(size = size)
+
+  internal companion object {
+    fun merge(
+      existing: InlineImageStylePatch?,
+      block: InlineImageStyleScope.() -> Unit,
+    ): InlineImageStylePatch {
+      val scope =
+        InlineImageStyleScope().apply {
+          if (existing != null) {
+            size = existing.size
+          }
+        }
+      scope.apply(block)
+      return scope.toPatch()
+    }
+  }
+}
+
+@Immutable
+internal data class ThematicBreakStylePatch(
+  val color: Color? = null,
+  val height: Dp? = null,
+  val marginTop: Dp? = null,
+  val marginBottom: Dp? = null,
+) {
+  fun apply(
+    base: ThematicBreakStyle,
+    units: StyleUnits,
+  ): ThematicBreakStyle =
+    base.copy(
+      color = color?.let(units::color) ?: base.color,
+      height = height?.let(units::dp) ?: base.height,
+      marginTop = marginTop?.let(units::dp) ?: base.marginTop,
+      marginBottom = marginBottom?.let(units::dp) ?: base.marginBottom,
+    )
+}
+
+@MarkdownStyleDsl
+class ThematicBreakStyleScope {
+  var color: Color? = null
+  var height: Dp? = null
+  var marginTop: Dp? = null
+  var marginBottom: Dp? = null
+
+  internal fun toPatch(): ThematicBreakStylePatch =
+    ThematicBreakStylePatch(
+      color = color,
+      height = height,
+      marginTop = marginTop,
+      marginBottom = marginBottom,
+    )
+
+  internal companion object {
+    fun merge(
+      existing: ThematicBreakStylePatch?,
+      block: ThematicBreakStyleScope.() -> Unit,
+    ): ThematicBreakStylePatch {
+      val scope =
+        ThematicBreakStyleScope().apply {
+          if (existing != null) {
+            color = existing.color
+            height = existing.height
+            marginTop = existing.marginTop
+            marginBottom = existing.marginBottom
+          }
+        }
+      scope.apply(block)
+      return scope.toPatch()
+    }
+  }
+}

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownTheme.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/MarkdownTheme.kt
@@ -1,0 +1,73 @@
+package com.swmansion.enriched.markdown.compose
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalMarkdownStyle =
+  staticCompositionLocalOf { MarkdownStyle.Default }
+
+/**
+ * Access the [MarkdownStyle] provided by the nearest enclosing [MarkdownTheme].
+ */
+object MarkdownTheme {
+  val style: MarkdownStyle
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalMarkdownStyle.current
+}
+
+/**
+ * Provides a default [MarkdownStyle] for the [content] subtree via [LocalMarkdownStyle].
+ *
+ * Nest [MarkdownTheme] to override styles for part of the UI; inner themes win.
+ *
+ * ```
+ * MarkdownTheme(style = appStyle) {
+ *   HomeScreen()
+ *   MarkdownTheme(style = compactStyle) {
+ *     ChatBubble(markdown = message) // uses compactStyle
+ *   }
+ * }
+ * ```
+ */
+@Composable
+fun MarkdownTheme(
+  style: MarkdownStyle = LocalMarkdownStyle.current,
+  content: @Composable () -> Unit,
+) {
+  CompositionLocalProvider(LocalMarkdownStyle provides style) {
+    content()
+  }
+}
+
+/**
+ * Creates and remembers a [MarkdownStyle] that tracks [MaterialTheme.colorScheme] changes.
+ *
+ * Use inside `MaterialTheme { ... }` when style values reference Material tokens:
+ *
+ * ```
+ * MaterialTheme {
+ *   MarkdownTheme(style = rememberMarkdownStyle {
+ *     paragraph { color = MaterialTheme.colorScheme.onSurface }
+ *     link { color = MaterialTheme.colorScheme.primary }
+ *   }) {
+ *     NavHost(...)
+ *   }
+ * }
+ * ```
+ *
+ * For static light/dark styles with literal colors, hoist `markdownStyle` / [MarkdownStyle.copy]
+ * at file scope instead.
+ */
+@Composable
+fun rememberMarkdownStyle(
+  vararg keys: Any?,
+  block: MarkdownStyleBuilder.() -> Unit,
+): MarkdownStyle {
+  val colorScheme = MaterialTheme.colorScheme
+  return remember(colorScheme, *keys) { markdownStyle(block) }
+}

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/ComposeFontRegistry.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/ComposeFontRegistry.kt
@@ -1,0 +1,21 @@
+package com.swmansion.enriched.markdown.compose.style
+
+import android.graphics.Typeface
+import com.swmansion.enriched.markdown.utils.text.TypefaceUtils
+import java.util.WeakHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+internal object ComposeFontRegistry {
+  private val idGenerator = AtomicInteger()
+  private val typefaceToKey = WeakHashMap<Typeface, String>()
+  private val lock = Any()
+
+  fun register(typeface: Typeface): String =
+    synchronized(lock) {
+      typefaceToKey.getOrPut(typeface) {
+        val key = "compose-font:${idGenerator.incrementAndGet()}"
+        TypefaceUtils.registerComposeFont(key, typeface)
+        key
+      }
+    }
+}

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/FontFamilyResolver.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/FontFamilyResolver.kt
@@ -1,0 +1,65 @@
+package com.swmansion.enriched.markdown.compose.style
+
+import android.graphics.Typeface
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontListFontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.ResourceFont
+import androidx.core.content.res.ResourcesCompat
+
+internal object FontFamilyResolver {
+  fun resolve(
+    fontFamily: FontFamily?,
+    resolveContext: StyleResolveContext,
+  ): String? {
+    if (fontFamily == null) {
+      return null
+    }
+
+    systemFontFamilyKey(fontFamily)?.let { return it }
+
+    val resourceTypeface = resolveResourceFont(fontFamily, resolveContext)
+    if (resourceTypeface != null) {
+      return ComposeFontRegistry.register(resourceTypeface)
+    }
+
+    val resolvedTypeface =
+      resolveContext.fontFamilyResolver
+        .resolve(
+          fontFamily = fontFamily,
+          fontWeight = FontWeight.Normal,
+          fontStyle = FontStyle.Normal,
+        ).value as? Typeface ?: return null
+
+    return ComposeFontRegistry.register(resolvedTypeface)
+  }
+
+  private fun systemFontFamilyKey(fontFamily: FontFamily): String? =
+    when (fontFamily) {
+      FontFamily.Default, FontFamily.SansSerif -> "sans-serif"
+      FontFamily.Serif -> "serif"
+      FontFamily.Monospace -> "monospace"
+      FontFamily.Cursive -> "cursive"
+      else -> null
+    }
+
+  private fun resolveResourceFont(
+    fontFamily: FontFamily,
+    resolveContext: StyleResolveContext,
+  ): Typeface? {
+    if (fontFamily !is FontListFontFamily) {
+      return null
+    }
+
+    for (font in fontFamily.fonts) {
+      if (font !is ResourceFont) {
+        continue
+      }
+
+      ResourcesCompat.getFont(resolveContext.context, font.resId)?.let { return it }
+    }
+
+    return null
+  }
+}

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/StyleConfigMerger.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/StyleConfigMerger.kt
@@ -1,0 +1,83 @@
+package com.swmansion.enriched.markdown.compose.style
+
+import com.swmansion.enriched.markdown.styles.BlockquoteStyle
+import com.swmansion.enriched.markdown.styles.CodeBlockStyle
+import com.swmansion.enriched.markdown.styles.CodeStyle
+import com.swmansion.enriched.markdown.styles.EmphasisStyle
+import com.swmansion.enriched.markdown.styles.HeadingStyle
+import com.swmansion.enriched.markdown.styles.ImageStyle
+import com.swmansion.enriched.markdown.styles.InlineImageStyle
+import com.swmansion.enriched.markdown.styles.LinkStyle
+import com.swmansion.enriched.markdown.styles.ListStyle
+import com.swmansion.enriched.markdown.styles.ParagraphStyle
+import com.swmansion.enriched.markdown.styles.StrongStyle
+import com.swmansion.enriched.markdown.styles.StyleConfig
+import com.swmansion.enriched.markdown.styles.ThematicBreakStyle
+import com.swmansion.enriched.markdown.utils.text.TypefaceUtils
+
+internal data class StylePatch(
+  val paragraphStyle: ParagraphStyle? = null,
+  val headingStyles: Map<Int, HeadingStyle>? = null,
+  val linkStyle: LinkStyle? = null,
+  val strongStyle: StrongStyle? = null,
+  val emphasisStyle: EmphasisStyle? = null,
+  val codeStyle: CodeStyle? = null,
+  val codeBlockStyle: CodeBlockStyle? = null,
+  val blockquoteStyle: BlockquoteStyle? = null,
+  val listStyle: ListStyle? = null,
+  val imageStyle: ImageStyle? = null,
+  val inlineImageStyle: InlineImageStyle? = null,
+  val thematicBreakStyle: ThematicBreakStyle? = null,
+)
+
+internal object StyleConfigMerger {
+  fun merge(
+    resolveContext: StyleResolveContext,
+    base: StyleConfig,
+    patch: StylePatch,
+  ): StyleConfig {
+    val headingStyles =
+      patch.headingStyles?.let { overrides ->
+        base.headingStyles.copyOf().also { styles ->
+          overrides.forEach { (level, style) -> styles[level] = style }
+        }
+      } ?: base.headingStyles
+
+    val headingTypefaces =
+      if (patch.headingStyles != null) {
+        buildHeadingTypefaces(resolveContext, headingStyles)
+      } else {
+        base.headingTypefaces
+      }
+
+    return StyleConfig(
+      paragraphStyleDefault = patch.paragraphStyle ?: base.paragraphStyle,
+      headingStyles = headingStyles,
+      headingTypefaces = headingTypefaces,
+      linkStyle = patch.linkStyle ?: base.linkStyle,
+      strongStyle = patch.strongStyle ?: base.strongStyle,
+      emphasisStyle = patch.emphasisStyle ?: base.emphasisStyle,
+      codeStyle = patch.codeStyle ?: base.codeStyle,
+      imageStyle = patch.imageStyle ?: base.imageStyle,
+      inlineImageStyle = patch.inlineImageStyle ?: base.inlineImageStyle,
+      blockquoteStyle = patch.blockquoteStyle ?: base.blockquoteStyle,
+      listStyle = patch.listStyle ?: base.listStyle,
+      codeBlockStyle = patch.codeBlockStyle ?: base.codeBlockStyle,
+      thematicBreakStyle = patch.thematicBreakStyle ?: base.thematicBreakStyle,
+    )
+  }
+
+  private fun buildHeadingTypefaces(
+    resolveContext: StyleResolveContext,
+    headingStyles: Array<HeadingStyle?>,
+  ) =
+    Array(headingStyles.size) { level ->
+      if (level == 0) {
+        null
+      } else {
+        headingStyles[level]?.let { style ->
+          TypefaceUtils.applyStyles(resolveContext.context, style.fontFamily, style.fontWeight)
+        }
+      }
+    }
+}

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/StyleResolveContext.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/StyleResolveContext.kt
@@ -1,0 +1,11 @@
+package com.swmansion.enriched.markdown.compose.style
+
+import android.content.Context
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Density
+
+internal class StyleResolveContext(
+  val context: Context,
+  val density: Density,
+  val fontFamilyResolver: FontFamily.Resolver,
+)

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/StyleUnits.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/style/StyleUnits.kt
@@ -1,0 +1,41 @@
+package com.swmansion.enriched.markdown.compose.style
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+internal class StyleUnits(
+  private val density: Density,
+) {
+  fun sp(value: TextUnit): Float {
+    require(value.type == TextUnitType.Sp) {
+      "fontSize and lineHeight must use sp, got ${value.type}"
+    }
+    return with(density) { value.toPx() }
+  }
+
+  fun dp(value: Dp): Float = with(density) { value.toPx() }
+
+  fun color(value: Color): Int = value.toArgb()
+}
+
+internal fun FontWeight.toStyleWeight(): String =
+  when {
+    this >= FontWeight.Bold -> "bold"
+    this >= FontWeight.SemiBold -> "600"
+    this >= FontWeight.Medium -> "500"
+    else -> "normal"
+  }
+
+internal fun FontStyle.toEmphasisStyleString(): String =
+  when (this) {
+    FontStyle.Italic -> "italic"
+    else -> "normal"
+  }

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/TypefaceUtils.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/TypefaceUtils.kt
@@ -65,6 +65,13 @@ object TypefaceUtils {
     }
   }
 
+  fun registerComposeFont(
+    key: String,
+    typeface: Typeface,
+  ) {
+    typefaceCache["family:$key"] = typeface
+  }
+
   fun loadFontFamily(
     context: Context,
     family: String,


### PR DESCRIPTION
### What/Why?
Adds a nice way for the user to specify styles passed to markdown. See it in the example app



### Testing
example app



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

