### PR TITLE
fix(ios): stop bold/italic handlers from overwriting link variant colors

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
@@ -136,8 +136,6 @@
     return;
   }
 
-  NSMutableArray<ENRMFormattingRange *> *deferredLinkRanges = [NSMutableArray array];
-
   for (ENRMFormattingRange *formattingRange in ranges) {
     if (formattingRange.range.length == 0 || NSMaxRange(formattingRange.range) > textLength) {
       continue;
@@ -157,25 +155,10 @@
       }
     }
 
-    // Defer link styling to a second pass so its variant color wins over a font style's base text
-    // color: a bold/italic mention must keep its chip color instead of turning black.
-    if (formattingRange.type == ENRMInputStyleTypeLink) {
-      [deferredLinkRanges addObject:formattingRange];
-      continue;
-    }
-
     [handler applyNonFontAttributesToTextStorage:textStorage
                                            range:formattingRange.range
                                  formattingRange:formattingRange
                                            style:style];
-  }
-
-  for (ENRMFormattingRange *linkRange in deferredLinkRanges) {
-    id<ENRMStyleHandler> linkHandler = _styleHandlers[@(linkRange.type)];
-    [linkHandler applyNonFontAttributesToTextStorage:textStorage
-                                               range:linkRange.range
-                                     formattingRange:linkRange
-                                               style:style];
   }
 
   NSUInteger runStart = 0;

--- a/packages/react-native-enriched-markdown/ios/input/styles/ENRMBoldStyleHandler.mm
+++ b/packages/react-native-enriched-markdown/ios/input/styles/ENRMBoldStyleHandler.mm
@@ -22,8 +22,9 @@
                             formattingRange:(ENRMFormattingRange *)formattingRange
                                       style:(ENRMInputFormatterStyle *)style
 {
-  RCTUIColor *color = style.boldColor ?: style.baseTextColor;
-  [storage addAttribute:NSForegroundColorAttributeName value:color range:range];
+  if (style.boldColor) {
+    [storage addAttribute:NSForegroundColorAttributeName value:style.boldColor range:range];
+  }
 }
 
 @end

--- a/packages/react-native-enriched-markdown/ios/input/styles/ENRMItalicStyleHandler.mm
+++ b/packages/react-native-enriched-markdown/ios/input/styles/ENRMItalicStyleHandler.mm
@@ -22,8 +22,9 @@
                             formattingRange:(ENRMFormattingRange *)formattingRange
                                       style:(ENRMInputFormatterStyle *)style
 {
-  RCTUIColor *color = style.italicColor ?: style.baseTextColor;
-  [storage addAttribute:NSForegroundColorAttributeName value:color range:range];
+  if (style.italicColor) {
+    [storage addAttribute:NSForegroundColorAttributeName value:style.italicColor range:range];
+  }
 }
 
 @end


### PR DESCRIPTION
### What/Why?

On iOS, bold/italic handlers unconditionally set `NSForegroundColorAttributeName` with `boldColor ?: baseTextColor`. When no explicit `boldColor`/`italicColor` is configured, this redundantly writes `baseTextColor` over any link variant color — so toggling bold on a mention makes it turn black until re-parse.

This removes the root cause: bold/italic now only write foreground color when explicitly configured. The reset phase already applies `baseTextColor` everywhere, so the fallback was always a no-op that happened to be destructive on link overlaps. Also removes the two-pass workaround from #446 since the conflict can no longer occur.

Aligns iOS with Android, which already skips the color write when `boldColor`/`italicColor` is unset.
### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

