### PR TITLE
feat(input): treat links/mentions as atomic for selection and caret

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -276,26 +276,13 @@ class EnrichedMarkdownTextInputView(
     super.onSelectionChanged(selStart, selEnd)
     if (!isComponentReady || isDuringTransaction) return
 
-    // Links (e.g. mentions) are atomic: a selection can't cover only part of a link, and the caret
-    // can't sit inside one. Snap a partial selection to the whole link, and a caret inside it to its end.
-    if (selStart != selEnd) {
-      var ns = selStart
-      var ne = selEnd
-      formattingStore.rangeOfType(StyleType.LINK, ns)?.let { ns = minOf(ns, it.start) }
-      if (ne > 0) formattingStore.rangeOfType(StyleType.LINK, ne - 1)?.let { ne = maxOf(ne, it.end) }
-      if (ns != selStart || ne != selEnd) {
-        setSelection(ns, ne)
-        return
-      }
-    } else {
-      val link = formattingStore.rangeOfType(StyleType.LINK, selStart)
-      if (link != null && selStart > link.start && selStart < link.end) {
-        setSelection(link.end)
-        return
-      }
-    }
-
     if (!isTextChanging) {
+      // Links (e.g. mentions) are atomic: snap a partial selection to the whole link, and a caret
+      // inside a link to its end. Returning lets the recursive onSelectionChanged emit for the result.
+      formattingStore.selectionAdjustedForAtomicLinks(selStart, selEnd)?.let { (newStart, newEnd) ->
+        setSelection(newStart, newEnd)
+        return
+      }
       if (didTextChangeRecently) {
         didTextChangeRecently = false
       } else {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -276,6 +276,25 @@ class EnrichedMarkdownTextInputView(
     super.onSelectionChanged(selStart, selEnd)
     if (!isComponentReady || isDuringTransaction) return
 
+    // Links (e.g. mentions) are atomic: a selection can't cover only part of a link, and the caret
+    // can't sit inside one. Snap a partial selection to the whole link, and a caret inside it to its end.
+    if (selStart != selEnd) {
+      var ns = selStart
+      var ne = selEnd
+      formattingStore.rangeOfType(StyleType.LINK, ns)?.let { ns = minOf(ns, it.start) }
+      if (ne > 0) formattingStore.rangeOfType(StyleType.LINK, ne - 1)?.let { ne = maxOf(ne, it.end) }
+      if (ns != selStart || ne != selEnd) {
+        setSelection(ns, ne)
+        return
+      }
+    } else {
+      val link = formattingStore.rangeOfType(StyleType.LINK, selStart)
+      if (link != null && selStart > link.start && selStart < link.end) {
+        setSelection(link.end)
+        return
+      }
+    }
+
     if (!isTextChanging) {
       if (didTextChangeRecently) {
         didTextChangeRecently = false

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/FormattingStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/FormattingStore.kt
@@ -34,6 +34,25 @@ class FormattingStore {
     end: Int,
   ): Boolean = ranges.any { it.type == type && it.start < end && it.end > start }
 
+  /**
+   * Snaps a selection so it never partially overlaps an atomic link: a partial selection expands to
+   * the whole link, a caret inside a link moves to its end. Returns the adjusted (start, end) or null.
+   */
+  fun selectionAdjustedForAtomicLinks(
+    start: Int,
+    end: Int,
+  ): Pair<Int, Int>? {
+    if (start != end) {
+      var newStart = start
+      var newEnd = end
+      rangeOfType(StyleType.LINK, newStart)?.let { newStart = minOf(newStart, it.start) }
+      if (newEnd > 0) rangeOfType(StyleType.LINK, newEnd - 1)?.let { newEnd = maxOf(newEnd, it.end) }
+      return if (newStart != start || newEnd != end) Pair(newStart, newEnd) else null
+    }
+    val link = rangeOfType(StyleType.LINK, start)
+    return if (link != null && start > link.start && start < link.end) Pair(link.end, link.end) else null
+  }
+
   fun addRange(newRange: FormattingRange) {
     var mergedStart = newRange.start
     var mergedEnd = newRange.end

--- a/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.h
@@ -17,6 +17,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isStyleAdjacentBefore:(ENRMInputStyleType)type position:(NSUInteger)position;
 - (NSArray<ENRMFormattingRange *> *)rangesOfType:(ENRMInputStyleType)type;
 
+/// Snaps a selection so it never partially overlaps an atomic link: a partial selection expands to
+/// the whole link, a caret inside a link moves to its end (unchanged when no adjustment is needed).
+- (NSRange)selectionAdjustedForAtomicLinks:(NSRange)selection;
+
 - (void)addRange:(ENRMFormattingRange *)range;
 - (void)removeType:(ENRMInputStyleType)type inRange:(NSRange)range;
 - (void)removeRange:(ENRMFormattingRange *)range;

--- a/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.mm
@@ -99,6 +99,30 @@ static EditOverlap classifyOverlap(NSUInteger rangeStart, NSUInteger rangeEnd, N
   return nil;
 }
 
+- (NSRange)selectionAdjustedForAtomicLinks:(NSRange)selection
+{
+  if (selection.length > 0) {
+    NSUInteger start = selection.location;
+    NSUInteger end = NSMaxRange(selection);
+    ENRMFormattingRange *startLink = [self rangeOfType:ENRMInputStyleTypeLink containingPosition:start];
+    if (startLink != nil) {
+      start = MIN(start, startLink.range.location);
+    }
+    if (end > 0) {
+      ENRMFormattingRange *endLink = [self rangeOfType:ENRMInputStyleTypeLink containingPosition:(end - 1)];
+      if (endLink != nil) {
+        end = MAX(end, NSMaxRange(endLink.range));
+      }
+    }
+    return NSMakeRange(start, end - start);
+  }
+  ENRMFormattingRange *caretLink = [self rangeOfType:ENRMInputStyleTypeLink containingPosition:selection.location];
+  if (caretLink != nil && selection.location > caretLink.range.location && selection.location < NSMaxRange(caretLink.range)) {
+    return NSMakeRange(NSMaxRange(caretLink.range), 0);
+  }
+  return selection;
+}
+
 - (BOOL)isStyleActive:(ENRMInputStyleType)type atPosition:(NSUInteger)position
 {
   return [self rangeOfType:type containingPosition:position] != nil;

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -1648,6 +1648,14 @@ using namespace facebook::react;
 - (void)textInputDidChangeSelection
 {
   NSRange newSelection = _textView.selectedRange;
+  // Atomic link snapping — same logic as textViewDidChangeSelection: (iOS).
+  if (!_isApplyingFormatting && !_isTextChanging && !ENRMHasMarkedText(_textView)) {
+    NSRange adjusted = [_formattingStore selectionAdjustedForAtomicLinks:newSelection];
+    if (!NSEqualRanges(adjusted, newSelection)) {
+      _textView.selectedRange = adjusted;
+      return;
+    }
+  }
   NSRange previousSelection = _lastSelectedRange;
   _lastSelectedRange = newSelection;
 

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -1549,32 +1549,13 @@ using namespace facebook::react;
 - (void)textViewDidChangeSelection:(UITextView *)textView
 {
   NSRange newSelection = textView.selectedRange;
-  // Links (e.g. mentions) are atomic: a selection can't cover only part of a link, and the caret
-  // can't sit inside one. Snap a partial selection to the whole link, and a caret inside it to its end.
+  // Links (e.g. mentions) are atomic: snap a partial selection to the whole link, and a caret inside
+  // a link to its end. Returning hands the adjusted selection to the recursive change (no double emit).
   if (!_isApplyingFormatting && !_isTextChanging && !ENRMHasMarkedText(_textView)) {
-    if (newSelection.length > 0) {
-      NSUInteger snapStart = newSelection.location;
-      NSUInteger snapEnd = NSMaxRange(newSelection);
-      ENRMFormattingRange *startLink = [_formattingStore rangeOfType:ENRMInputStyleTypeLink containingPosition:snapStart];
-      if (startLink != nil) {
-        snapStart = MIN(snapStart, startLink.range.location);
-      }
-      if (snapEnd > 0) {
-        ENRMFormattingRange *endLink = [_formattingStore rangeOfType:ENRMInputStyleTypeLink containingPosition:(snapEnd - 1)];
-        if (endLink != nil) {
-          snapEnd = MAX(snapEnd, NSMaxRange(endLink.range));
-        }
-      }
-      if (snapStart != newSelection.location || snapEnd != NSMaxRange(newSelection)) {
-        newSelection = NSMakeRange(snapStart, snapEnd - snapStart);
-        _textView.selectedRange = newSelection;
-      }
-    } else {
-      ENRMFormattingRange *caretLink = [_formattingStore rangeOfType:ENRMInputStyleTypeLink containingPosition:newSelection.location];
-      if (caretLink != nil && newSelection.location > caretLink.range.location && newSelection.location < NSMaxRange(caretLink.range)) {
-        newSelection = NSMakeRange(NSMaxRange(caretLink.range), 0);
-        _textView.selectedRange = newSelection;
-      }
+    NSRange adjusted = [_formattingStore selectionAdjustedForAtomicLinks:newSelection];
+    if (!NSEqualRanges(adjusted, newSelection)) {
+      _textView.selectedRange = adjusted;
+      return;
     }
   }
   NSRange previousSelection = _lastSelectedRange;

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -1549,6 +1549,34 @@ using namespace facebook::react;
 - (void)textViewDidChangeSelection:(UITextView *)textView
 {
   NSRange newSelection = textView.selectedRange;
+  // Links (e.g. mentions) are atomic: a selection can't cover only part of a link, and the caret
+  // can't sit inside one. Snap a partial selection to the whole link, and a caret inside it to its end.
+  if (!_isApplyingFormatting && !_isTextChanging && !ENRMHasMarkedText(_textView)) {
+    if (newSelection.length > 0) {
+      NSUInteger snapStart = newSelection.location;
+      NSUInteger snapEnd = NSMaxRange(newSelection);
+      ENRMFormattingRange *startLink = [_formattingStore rangeOfType:ENRMInputStyleTypeLink containingPosition:snapStart];
+      if (startLink != nil) {
+        snapStart = MIN(snapStart, startLink.range.location);
+      }
+      if (snapEnd > 0) {
+        ENRMFormattingRange *endLink = [_formattingStore rangeOfType:ENRMInputStyleTypeLink containingPosition:(snapEnd - 1)];
+        if (endLink != nil) {
+          snapEnd = MAX(snapEnd, NSMaxRange(endLink.range));
+        }
+      }
+      if (snapStart != newSelection.location || snapEnd != NSMaxRange(newSelection)) {
+        newSelection = NSMakeRange(snapStart, snapEnd - snapStart);
+        _textView.selectedRange = newSelection;
+      }
+    } else {
+      ENRMFormattingRange *caretLink = [_formattingStore rangeOfType:ENRMInputStyleTypeLink containingPosition:newSelection.location];
+      if (caretLink != nil && newSelection.location > caretLink.range.location && newSelection.location < NSMaxRange(caretLink.range)) {
+        newSelection = NSMakeRange(NSMaxRange(caretLink.range), 0);
+        _textView.selectedRange = newSelection;
+      }
+    }
+  }
   NSRange previousSelection = _lastSelectedRange;
   _lastSelectedRange = newSelection;
 


### PR DESCRIPTION
### What/Why?

On `EnrichedMarkdownTextInput`, links (e.g. mentions) render as a single styled chip, but under the hood they're just a link range over normal editable text. So today the selection can land *inside* a link: you can select only part of a mention and toggle a style on those few characters, or place the caret in the middle of it. Styling part of a link splits the chip and produces inconsistent / serialization-breaking output, and a caret sitting inside a mention is confusing for an element that's meant to be atomic.

This makes links behave as a single atomic unit for selection on both iOS and Android, in the selection-change handler (`textViewDidChangeSelection` / `onSelectionChanged`):

- **Partial selection → whole link.** If a selection's start or end falls inside a link, it's expanded to cover the entire link, so a subsequent Bold/Italic/… always applies to the complete chip.
- **Caret inside a link → its end.** Tapping inside a mention moves the caret to the end of the link (e.g. `John| Doe` → `John Doe|`) instead of leaving it in the middle. Tapping right before/after the link is unchanged, so you can still type around it.

The guards are strict (`start < pos < end`), so the snapped selection/caret lands on a link boundary and doesn't re-trigger, and selecting exactly the link or placing the caret at its edges is a no-op.

### Testing

Manually on iOS and Android:
- Drag-select part of a mention → selection expands to the whole link.
- Tap inside a mention → caret jumps to its end.
- Select from plain text into a mention → the mention is fully included.
- Tap just before/after a mention → caret stays (you can type around it).

## Before / after

|  | Before | After |
| :--: | :--: | :--: |
| **First fix** | <video src="https://github.com/user-attachments/assets/60c8d707-7f17-4729-b3bc-2b05c7ba8f4d"></video> | <video src="https://github.com/user-attachments/assets/f2cf6fd1-e542-42b1-ba2d-607af716c7d3"></video> |
| **Second fix** | <video src="https://github.com/user-attachments/assets/87d17e3d-51fe-4245-9887-2961ecf6f4a7"></video> | <video src="https://github.com/user-attachments/assets/87ad3cba-3eed-460e-a903-64d83f8abf88"></video> |
