### PR TITLE
feat(input): add H1-H3 heading block support

### DIFF
--- a/.maestro/enrichedMarkdownInput/flows/basic/block_elements/heading_test.yaml
+++ b/.maestro/enrichedMarkdownInput/flows/basic/block_elements/heading_test.yaml
@@ -1,0 +1,24 @@
+appId: swmansion.enriched.markdown.example
+tags:
+  - input
+  - smoke
+  - heading
+  - block
+---
+- launchApp
+
+- runFlow:
+    file: '../../../../subflows/move_to_playground.yaml'
+
+- tapOn:
+    id: toolbar-h1
+
+- runFlow:
+    file: '../../../subflows/set_enriched_input_value.yaml'
+    env:
+      VALUE: "Heading one"
+
+- runFlow:
+    file: '../../../subflows/capture_or_assert_screenshot.yaml'
+    env:
+      SCREENSHOT_NAME: 'heading_input'

--- a/apps/react-native-example/src/components/FormattingToolbar.tsx
+++ b/apps/react-native-example/src/components/FormattingToolbar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import {
   Text,
-  View,
+  ScrollView,
   TouchableOpacity,
   StyleSheet,
   type StyleProp,
@@ -30,6 +30,12 @@ interface FormattingToolbarProps {
 
 const ICON_COLOR = '#001A72';
 const ICON_SIZE = 18;
+
+const HEADING_TEXT_STYLE = {
+  color: ICON_COLOR,
+  fontWeight: '700' as const,
+  fontSize: 13,
+};
 
 const ITEMS = [
   {
@@ -68,6 +74,21 @@ const ITEMS = [
     icon: (
       <SpoilerIcon width={ICON_SIZE} height={ICON_SIZE} color={ICON_COLOR} />
     ),
+  },
+  {
+    styleKey: 'h1',
+    action: 'toggleH1',
+    icon: <Text style={HEADING_TEXT_STYLE}>H1</Text>,
+  },
+  {
+    styleKey: 'h2',
+    action: 'toggleH2',
+    icon: <Text style={HEADING_TEXT_STYLE}>H2</Text>,
+  },
+  {
+    styleKey: 'h3',
+    action: 'toggleH3',
+    icon: <Text style={HEADING_TEXT_STYLE}>H3</Text>,
   },
 ] as const;
 
@@ -110,7 +131,14 @@ export function FormattingToolbar({
 
   return (
     <>
-      <View style={[styles.toolbar, style]} testID={testID}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+        style={[styles.toolbar, style]}
+        contentContainerStyle={styles.toolbarContent}
+        testID={testID}
+      >
         {ITEMS.map(({ styleKey, action, icon }) => (
           <TouchableOpacity
             key={styleKey}
@@ -144,7 +172,7 @@ export function FormattingToolbar({
             <Text style={styles.mentionButtonText}>{indicator}</Text>
           </TouchableOpacity>
         ))}
-      </View>
+      </ScrollView>
       <LinkModal
         visible={linkModalVisible}
         initialText=""
@@ -158,13 +186,17 @@ export function FormattingToolbar({
 
 const styles = StyleSheet.create({
   toolbar: {
-    flexDirection: 'row',
-    gap: 4,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
+    flexGrow: 0,
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: '#E5E7EB',
     backgroundColor: '#F9FAFB',
+  },
+  toolbarContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
   },
   toolbarButton: {
     minWidth: 34,

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -66,6 +66,25 @@ Each call toggles the style within the current text selection. They are being to
 
 Styles are also available through the built-in native format bar that appears on text selection, and through the system context menu.
 
+## Block Styles
+
+Supported block styles:
+
+- heading 1 (`toggleH1()`)
+- heading 2 (`toggleH2()`)
+- heading 3 (`toggleH3()`)
+
+Unlike inline styles, block styles apply to the whole line (or every line the
+selection touches) and are mutually exclusive — toggling one heading level off
+returns the line to a normal paragraph, and toggling a different level replaces
+the current one. Calling a heading `toggle` again with the same level removes it.
+
+Headings render in-editor at their configured size and serialize to Markdown as
+ATX headings (`# `, `## `, `### `); the markers only exist in the serialized
+output, never in the editor text. The active heading level for the cursor's line
+is reported through `onChangeState` as `h1`, `h2`, and `h3` (each with an
+`isActive` property), the same shape as inline styles.
+
 ## Links
 
 Links are a piece of text with a URL attributed to it. They can be managed by calling methods on the input ref:

--- a/docs/block-input-editing.md
+++ b/docs/block-input-editing.md
@@ -1,0 +1,61 @@
+# Block-level editing in the Markdown input (issue #359)
+
+Adds in-editor rendering + toggling of paragraph-level blocks (headings first,
+then lists) to `EnrichedMarkdownTextInput`, while keeping Markdown as the
+serialization format. Closes the gap behind issue #359: the readonly renderer
+(`EnrichedMarkdownText`) already renders headings/lists, but the editable input
+only supported inline marks.
+
+## Architecture recap
+
+The editor keeps **plain text** in the platform text storage plus a list of
+**inline** `ENRMFormattingRange` (type + range) in `ENRMFormattingStore`. Inline
+marks are thin strategies keyed by `ENRMInputStyleType`. The serializer inserts
+paired delimiters (`**`, `*`, …); the parser uses md4c to map Markdown → plain
+text + inline ranges.
+
+Blocks are fundamentally different from inline marks:
+
+- They apply to **whole paragraphs/lines**, are **mutually exclusive** per
+  paragraph, and serialize as **line prefixes** (`# `, `- `, `1. `, `- [ ] `),
+  not paired delimiters.
+- The serializer already noted this: block elements "are prefix-based and will
+  need a separate serialization path."
+- md4c already parses block structure; the input parser's `enter_block`/
+  `leave_block` were no-ops with explicit TODOs anticipating block support.
+
+## Model
+
+Block kind is stored as a **custom attributed-string attribute**
+(`ENRMBlockTypeAttributeName` → `ENRMInputBlockType`) on the paragraph's text.
+TextKit/Android spans migrate attributes across edits, so the block kind
+survives typing, deletion, and paste with no manual range bookkeeping — the same
+reason inline marks aren't re-derived per keystroke. A transient
+`_pendingBlockType` carries the kind for an empty line (no character holds the
+attribute yet) into the next keystroke.
+
+## Pipeline (iOS; Android mirrors)
+
+| Concern | File | Change |
+|---|---|---|
+| Type + attribute | `ENRMInputBlockType.{h,m}` | enum, attribute name, `ENRMBlockRange` |
+| Render | `ENRMInputFormatter` | per-paragraph base font (heading size+bold) via heading map; font runs keyed by (traits, heading level) |
+| Toggle | `EnrichedMarkdownTextInput` | `toggleH1/2/3` set/clear the block attribute per line in the selected paragraph(s) |
+| Typing | `syncTypingAttributesWithPendingStyles` | typing attributes carry heading font + block attribute |
+| Enter | `handleTextChanged` | a newline ends a heading (Markdown headings are single-line) |
+| State | `emitOnChangeState` | `h1/h2/h3` active flags from the cursor paragraph |
+| Serialize | `ENRMMarkdownSerializer` | line-based prefix pass after inline serialization (preserves line structure) |
+| Parse | `ENRMInputParser` | line-based post-pass strips `#{1,3} ` prefixes, remaps inline ranges via old→new index map, returns block ranges |
+| API | codegen spec + JS wrapper | `toggleH1/2/3` commands; `h1/h2/h3` in `OnChangeStateEvent` + context-menu styleState |
+
+## Lists (follow-up)
+
+Lists reuse the same model with added bookkeeping: ordered-list numbering,
+checkbox checked state, Enter continues/exits the list, Backspace outdents. The
+readonly renderer's `ListMarkerDrawer` provides marker drawing to reuse.
+
+## Line-height parity (#359 part 1)
+
+Heading typography is derived from the base font. Aligning the editor's
+paragraph line-height/spacing with the readonly renderer's `StyleConfig` closes
+the "line-height collapses on edit" half of the issue.

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
@@ -414,6 +414,18 @@ class EnrichedMarkdownTextInputManager :
     view?.toggleInlineStyle(StyleType.SPOILER)
   }
 
+  override fun toggleH1(view: EnrichedMarkdownTextInputView?) {
+    view?.toggleHeading(1)
+  }
+
+  override fun toggleH2(view: EnrichedMarkdownTextInputView?) {
+    view?.toggleHeading(2)
+  }
+
+  override fun toggleH3(view: EnrichedMarkdownTextInputView?) {
+    view?.toggleHeading(3)
+  }
+
   override fun setLink(
     view: EnrichedMarkdownTextInputView?,
     url: String?,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -7,6 +7,7 @@ import android.graphics.Color
 import android.os.Build
 import android.text.Editable
 import android.text.InputType
+import android.text.Spanned
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.KeyEvent
@@ -33,10 +34,13 @@ import com.swmansion.enriched.markdown.input.formatting.InputFormatter
 import com.swmansion.enriched.markdown.input.formatting.InputParser
 import com.swmansion.enriched.markdown.input.layout.InputEventEmitter
 import com.swmansion.enriched.markdown.input.layout.InputLayoutManager
+import com.swmansion.enriched.markdown.input.model.BlockRange
+import com.swmansion.enriched.markdown.input.model.BlockType
 import com.swmansion.enriched.markdown.input.model.FormattingRange
 import com.swmansion.enriched.markdown.input.model.InputFormatterStyle
 import com.swmansion.enriched.markdown.input.model.StyleType
 import com.swmansion.enriched.markdown.input.toolbar.InputContextMenu
+import com.swmansion.enriched.markdown.spans.InputHeadingSpan
 import com.swmansion.enriched.markdown.utils.input.AutoCapitalizeUtils
 import kotlin.math.ceil
 
@@ -51,6 +55,10 @@ class EnrichedMarkdownTextInputView(
   val formatter = InputFormatter()
   val pendingStyles = mutableSetOf<StyleType>()
   val pendingStyleRemovals = mutableSetOf<StyleType>()
+
+  // Heading kind the next typed character should adopt when the cursor sits on an
+  // empty line (no character holds the heading span yet).
+  private var pendingBlockType: BlockType = BlockType.PARAGRAPH
 
   var isDuringTransaction = false
     private set
@@ -249,6 +257,16 @@ class EnrichedMarkdownTextInputView(
     try {
       formattingStore.adjustForEdit(editStart, deletedLength, insertedLength)
       applyPendingStyles(editStart, insertedLength)
+
+      val insertedHasGlyph =
+        insertedLength > 0 &&
+          run {
+            val t = text
+            val end = editStart + insertedLength
+            t != null && end <= t.length && (editStart until end).any { !t[it].isLineBreak() }
+          }
+      normalizeHeadingSpans(insertedHasGlyph)
+
       applyFormatting()
 
       val editable = text
@@ -282,6 +300,9 @@ class EnrichedMarkdownTextInputView(
       } else {
         pendingStyles.clear()
         pendingStyleRemovals.clear()
+        // Heading carries via the span on non-empty lines; clear the pending kind
+        // so it never leaks onto a different (empty) line.
+        pendingBlockType = BlockType.PARAGRAPH
       }
     }
 
@@ -404,6 +425,126 @@ class EnrichedMarkdownTextInputView(
       applyFormattingAndEmit()
     }
   }
+
+  // region Block styles
+
+  /** Start/end (exclusive) offsets of the line's content containing [offset], excluding newlines. */
+  private fun lineBounds(offset: Int): Pair<Int, Int> {
+    val s = text ?: return 0 to 0
+    val len = s.length
+    val pos = offset.coerceIn(0, len)
+    var start = pos
+    while (start > 0 && s[start - 1] != '\n') start--
+    var end = pos
+    while (end < len && s[end] != '\n') end++
+    return start to end
+  }
+
+  private fun removeHeadingSpans(
+    editable: Editable,
+    start: Int,
+    end: Int,
+  ) {
+    for (span in editable.getSpans(start, end, InputHeadingSpan::class.java)) {
+      editable.removeSpan(span)
+    }
+  }
+
+  /** Block kind of the cursor's line, falling back to the pending kind for empty lines. */
+  fun blockTypeAtCursor(): BlockType {
+    val editable = text ?: return pendingBlockType
+    if (editable.isEmpty()) return pendingBlockType
+    val (ls, le) = lineBounds(selectionStart)
+    if (le <= ls) return pendingBlockType
+    return editable
+      .getSpans(ls, le, InputHeadingSpan::class.java)
+      .firstOrNull()
+      ?.blockType ?: BlockType.PARAGRAPH
+  }
+
+  /** Heading ranges currently stored as spans, in text coordinates. */
+  fun currentBlockRanges(): List<BlockRange> {
+    val editable = text ?: return emptyList()
+    return editable
+      .getSpans(0, editable.length, InputHeadingSpan::class.java)
+      .mapNotNull { span ->
+        val start = editable.getSpanStart(span)
+        val end = editable.getSpanEnd(span)
+        if (end > start) BlockRange(span.blockType, start, end) else null
+      }
+  }
+
+  fun toggleHeading(level: Int) {
+    val editable = text ?: return
+    val target = BlockType.forHeadingLevel(level)
+    val turningOff = blockTypeAtCursor() == target
+    val newType = if (turningOff) BlockType.PARAGRAPH else target
+
+    // Apply per line so a multi-line selection toggles each line, never the
+    // separating newline (headings are single-line in Markdown).
+    val selEnd = selectionEnd
+    var cursor = lineBounds(selectionStart).first
+    while (cursor <= editable.length) {
+      val (ls, le) = lineBounds(cursor)
+      removeHeadingSpans(editable, ls, le)
+      if (newType != BlockType.PARAGRAPH && le > ls) {
+        editable.setSpan(InputHeadingSpan(newType), ls, le, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+      }
+      if (le >= selEnd) break
+      cursor = le + 1
+    }
+
+    // Carry the kind for the cursor's (possibly empty) line into the next keystroke.
+    pendingBlockType = newType
+
+    applyFormatting()
+    forceScrollToSelection()
+    if (emitMarkdown) eventEmitter.emitChangeMarkdown()
+    eventEmitter.emitState()
+  }
+
+  /**
+   * Keeps heading spans well-formed after an edit: seeds a span for the first
+   * character typed on a freshly-toggled empty line, re-clamps every heading
+   * span to its line's content (so typing extends it and it never crosses a
+   * newline), and ends a heading when a newline is inserted.
+   */
+  private fun normalizeHeadingSpans(insertedHasGlyph: Boolean) {
+    val editable = text ?: return
+
+    if (insertedHasGlyph && pendingBlockType != BlockType.PARAGRAPH) {
+      val (ls, le) = lineBounds(selectionStart)
+      if (le > ls && editable.getSpans(ls, le, InputHeadingSpan::class.java).isEmpty()) {
+        editable.setSpan(InputHeadingSpan(pendingBlockType), ls, le, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+      }
+    }
+
+    for (span in editable.getSpans(0, editable.length, InputHeadingSpan::class.java)) {
+      val (ls, le) = lineBounds(editable.getSpanStart(span))
+      editable.removeSpan(span)
+      if (le > ls) {
+        editable.setSpan(InputHeadingSpan(span.blockType), ls, le, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+      }
+    }
+
+    if (!insertedHasGlyph) pendingBlockType = BlockType.PARAGRAPH
+  }
+
+  /** Writes parsed heading ranges into the text as spans. */
+  private fun applyBlockRanges(blockRanges: List<BlockRange>) {
+    val editable = text ?: return
+    removeHeadingSpans(editable, 0, editable.length)
+    for (range in blockRanges) {
+      if (range.type == BlockType.PARAGRAPH) continue
+      val start = range.start.coerceIn(0, editable.length)
+      val end = range.end.coerceIn(start, editable.length)
+      if (end > start) {
+        editable.setSpan(InputHeadingSpan(range.type), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+      }
+    }
+  }
+
+  // endregion
 
   fun setLinkForSelection(url: String) {
     val selStart = selectionStart
@@ -569,6 +710,7 @@ class EnrichedMarkdownTextInputView(
         formattingStore.clearAll()
         formattingStore.setRanges(parsed.formattingRanges)
         setText(parsed.plainText)
+        applyBlockRanges(parsed.blockRanges)
         setSelection(text?.length ?: 0)
       }
       applyFormatting()

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnChangeStateEvent.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnChangeStateEvent.kt
@@ -13,6 +13,9 @@ class OnChangeStateEvent(
   private val isStrikethrough: Boolean,
   private val isSpoiler: Boolean,
   private val isLink: Boolean,
+  private val isH1: Boolean,
+  private val isH2: Boolean,
+  private val isH3: Boolean,
 ) : Event<OnChangeStateEvent>(surfaceId, viewId) {
   override fun getEventName(): String = EVENT_NAME
 
@@ -41,6 +44,18 @@ class OnChangeStateEvent(
       putMap(
         "link",
         Arguments.createMap().apply { putBoolean("isActive", isLink) },
+      )
+      putMap(
+        "h1",
+        Arguments.createMap().apply { putBoolean("isActive", isH1) },
+      )
+      putMap(
+        "h2",
+        Arguments.createMap().apply { putBoolean("isActive", isH2) },
+      )
+      putMap(
+        "h3",
+        Arguments.createMap().apply { putBoolean("isActive", isH3) },
       )
     }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnContextMenuItemPressEvent.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnContextMenuItemPressEvent.kt
@@ -17,6 +17,9 @@ class OnContextMenuItemPressEvent(
   private val isStrikethrough: Boolean,
   private val isSpoiler: Boolean,
   private val isLink: Boolean,
+  private val isH1: Boolean,
+  private val isH2: Boolean,
+  private val isH3: Boolean,
 ) : Event<OnContextMenuItemPressEvent>(surfaceId, viewId) {
   override fun getEventName(): String = EVENT_NAME
 
@@ -37,6 +40,9 @@ class OnContextMenuItemPressEvent(
           putMap("strikethrough", styleEntry(isStrikethrough))
           putMap("spoiler", styleEntry(isSpoiler))
           putMap("link", styleEntry(isLink))
+          putMap("h1", styleEntry(isH1))
+          putMap("h2", styleEntry(isH2))
+          putMap("h3", styleEntry(isH3))
         },
       )
     }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputParser.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputParser.kt
@@ -1,5 +1,7 @@
 package com.swmansion.enriched.markdown.input.formatting
 
+import com.swmansion.enriched.markdown.input.model.BlockRange
+import com.swmansion.enriched.markdown.input.model.BlockType
 import com.swmansion.enriched.markdown.input.model.FormattingRange
 import com.swmansion.enriched.markdown.input.model.StyleType
 import com.swmansion.enriched.markdown.parser.MarkdownASTNode
@@ -11,6 +13,7 @@ import com.swmansion.enriched.markdown.parser.isTopLevelBlock
 data class ParseResult(
   val plainText: String,
   val formattingRanges: List<FormattingRange>,
+  val blockRanges: List<BlockRange> = emptyList(),
 )
 
 object InputParser {
@@ -28,6 +31,7 @@ object InputParser {
 
     val plainText = StringBuilder()
     val ranges = mutableListOf<FormattingRange>()
+    val blockRanges = mutableListOf<BlockRange>()
 
     // md4c collapses any blank-line run into a single break, unlike iOS which keeps them.
     // Re-read the real runs so each break replays its original number of newlines.
@@ -39,15 +43,16 @@ object InputParser {
           .toList(),
       )
 
-    walkNode(ast, plainText, ranges, ArrayDeque(), blankRuns)
+    walkNode(ast, plainText, ranges, blockRanges, ArrayDeque(), blankRuns)
 
-    return ParseResult(plainText.toString(), ranges)
+    return ParseResult(plainText.toString(), ranges, blockRanges)
   }
 
   private fun walkNode(
     node: MarkdownASTNode,
     plainText: StringBuilder,
     ranges: MutableList<FormattingRange>,
+    blockRanges: MutableList<BlockRange>,
     activeStyles: ArrayDeque<ActiveStyle>,
     blankRuns: ArrayDeque<Int>,
   ) {
@@ -57,6 +62,10 @@ object InputParser {
       val url = if (styleType == StyleType.LINK) node.getAttribute("url") else null
       activeStyles.addLast(ActiveStyle(styleType, plainText.length, url))
     }
+
+    // Headings are emitted by md4c without their `#` markers, so the content
+    // captured here already excludes them — record the rendered range only.
+    val headingStart = if (node.type == NodeType.Heading) plainText.length else -1
 
     if (node.type == NodeType.Text) {
       plainText.append(node.content)
@@ -69,7 +78,14 @@ object InputParser {
       if (index > 0 && child.type.isTopLevelBlock() && plainText.isNotEmpty()) {
         plainText.append("\n".repeat(blankRuns.removeFirstOrNull() ?: 2))
       }
-      walkNode(child, plainText, ranges, activeStyles, blankRuns)
+      walkNode(child, plainText, ranges, blockRanges, activeStyles, blankRuns)
+    }
+
+    if (headingStart >= 0) {
+      val level = node.getAttribute("level")?.toIntOrNull() ?: 1
+      if (level in 1..3 && plainText.length > headingStart) {
+        blockRanges.add(BlockRange(BlockType.forHeadingLevel(level), headingStart, plainText.length))
+      }
     }
 
     if (styleType != null) {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/MarkdownSerializer.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/MarkdownSerializer.kt
@@ -1,9 +1,52 @@
 package com.swmansion.enriched.markdown.input.formatting
 
+import com.swmansion.enriched.markdown.input.model.BlockRange
 import com.swmansion.enriched.markdown.input.model.FormattingRange
 import com.swmansion.enriched.markdown.input.model.StyleType
 
 object MarkdownSerializer {
+  /**
+   * Serializes inline marks and then prefixes each line with its block marker
+   * (`# `/`## `/`### ` for headings). Block markers are line-based, so this runs
+   * after inline serialization, which preserves the text's line structure.
+   */
+  fun serialize(
+    text: String,
+    ranges: List<FormattingRange>,
+    blockRanges: List<BlockRange>,
+  ): String {
+    val inline = serialize(text, ranges)
+    if (blockRanges.isEmpty()) return inline
+
+    val plainLines = text.split("\n")
+    val markdownLines = inline.split("\n").toMutableList()
+    // Inline serialization never adds or removes newlines, so line counts align;
+    // bail out safely if that invariant is ever broken.
+    if (plainLines.size != markdownLines.size) return inline
+
+    var lineStart = 0
+    for (i in plainLines.indices) {
+      val lineLength = plainLines[i].length
+      val lineEnd = lineStart + lineLength
+      val level =
+        blockRanges
+          .firstOrNull { br ->
+            br.type.headingLevel > 0 &&
+              (
+                maxOf(lineStart, br.start) < minOf(lineEnd, br.end) ||
+                  (lineLength == 0 && lineStart >= br.start && lineStart < br.end)
+              )
+          }?.type
+          ?.headingLevel ?: 0
+      if (level > 0) {
+        markdownLines[i] = "#".repeat(level) + " " + markdownLines[i]
+      }
+      lineStart = lineEnd + 1
+    }
+
+    return markdownLines.joinToString("\n")
+  }
+
   fun serialize(
     text: String,
     ranges: List<FormattingRange>,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
@@ -19,6 +19,7 @@ import com.swmansion.enriched.markdown.input.events.OnRequestCaretRectResultEven
 import com.swmansion.enriched.markdown.input.events.OnRequestMarkdownResultEvent
 import com.swmansion.enriched.markdown.input.events.OnStartMentionEvent
 import com.swmansion.enriched.markdown.input.formatting.MarkdownSerializer
+import com.swmansion.enriched.markdown.input.model.BlockType
 import com.swmansion.enriched.markdown.input.model.CaretRect
 import com.swmansion.enriched.markdown.input.model.StyleType
 
@@ -26,6 +27,7 @@ class InputEventEmitter(
   private val view: EnrichedMarkdownTextInputView,
 ) {
   private var prevState: Map<StyleType, Boolean> = emptyMap()
+  private var prevBlockType: BlockType? = null
   private var prevCaretRect: CaretRect? = null
 
   fun emitChangeText() {
@@ -50,9 +52,11 @@ class InputEventEmitter(
       StyleType.entries.associateWith { style ->
         isStyleEffectivelyActive(style, pos)
       }
+    val blockType = view.blockTypeAtCursor()
 
-    if (current == prevState) return
+    if (current == prevState && blockType == prevBlockType) return
     prevState = current
+    prevBlockType = blockType
 
     dispatch(
       OnChangeStateEvent(
@@ -64,6 +68,9 @@ class InputEventEmitter(
         current[StyleType.STRIKETHROUGH] ?: false,
         current[StyleType.SPOILER] ?: false,
         current[StyleType.LINK] ?: false,
+        blockType == BlockType.HEADING_1,
+        blockType == BlockType.HEADING_2,
+        blockType == BlockType.HEADING_3,
       ),
     )
   }
@@ -169,6 +176,9 @@ class InputEventEmitter(
         isStrikethrough = isActive(StyleType.STRIKETHROUGH),
         isSpoiler = isActive(StyleType.SPOILER),
         isLink = isActive(StyleType.LINK),
+        isH1 = view.blockTypeAtCursor() == BlockType.HEADING_1,
+        isH2 = view.blockTypeAtCursor() == BlockType.HEADING_2,
+        isH3 = view.blockTypeAtCursor() == BlockType.HEADING_3,
       ),
     )
   }
@@ -185,7 +195,11 @@ class InputEventEmitter(
 
   private fun serializeToMarkdown(): String {
     val plainText = view.text?.toString() ?: ""
-    return MarkdownSerializer.serialize(plainText, view.allFormattingRangesForSerialization())
+    return MarkdownSerializer.serialize(
+      plainText,
+      view.allFormattingRangesForSerialization(),
+      view.currentBlockRanges(),
+    )
   }
 
   private fun surfaceId(): Int {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/model/BlockType.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/model/BlockType.kt
@@ -1,0 +1,41 @@
+package com.swmansion.enriched.markdown.input.model
+
+/**
+ * Paragraph-level block kinds supported by the editor. Unlike inline styles
+ * (bold, italic) which apply to character ranges, block styles apply to whole
+ * lines and are mutually exclusive per line.
+ */
+enum class BlockType {
+  PARAGRAPH,
+  HEADING_1,
+  HEADING_2,
+  HEADING_3,
+  ;
+
+  /** Heading level (1-3) for a heading block, or 0 for non-headings. */
+  val headingLevel: Int
+    get() =
+      when (this) {
+        HEADING_1 -> 1
+        HEADING_2 -> 2
+        HEADING_3 -> 3
+        else -> 0
+      }
+
+  companion object {
+    fun forHeadingLevel(level: Int): BlockType =
+      when (level) {
+        1 -> HEADING_1
+        2 -> HEADING_2
+        3 -> HEADING_3
+        else -> PARAGRAPH
+      }
+  }
+}
+
+/** A line range tagged with its block type, used to hand block structure to the serializer. */
+data class BlockRange(
+  val type: BlockType,
+  val start: Int,
+  val end: Int,
+)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/InputHeadingSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/InputHeadingSpan.kt
@@ -1,0 +1,42 @@
+package com.swmansion.enriched.markdown.spans
+
+import android.graphics.Typeface
+import android.text.TextPaint
+import android.text.style.MetricAffectingSpan
+import com.swmansion.enriched.markdown.input.model.BlockType
+
+/**
+ * Marker so the inline formatter (which reconciles only [MarkdownSpan]s) leaves
+ * block spans untouched, letting them persist across edits the way the iOS block
+ * attribute does.
+ */
+interface BlockSpan {
+  val blockType: BlockType
+}
+
+/**
+ * Editor heading span: scales the base text size and applies bold, derived from
+ * whatever base font is in effect so it tracks the configured size. Acts as the
+ * source of truth for a line's heading level in the input.
+ */
+class InputHeadingSpan(
+  override val blockType: BlockType,
+) : MetricAffectingSpan(),
+  BlockSpan {
+  private val scale: Float =
+    when (blockType) {
+      BlockType.HEADING_1 -> 1.6f
+      BlockType.HEADING_2 -> 1.4f
+      BlockType.HEADING_3 -> 1.2f
+      else -> 1.0f
+    }
+
+  override fun updateDrawState(tp: TextPaint) = applyHeadingStyle(tp)
+
+  override fun updateMeasureState(tp: TextPaint) = applyHeadingStyle(tp)
+
+  private fun applyHeadingStyle(tp: TextPaint) {
+    tp.textSize *= scale
+    tp.typeface = Typeface.create(tp.typeface ?: Typeface.DEFAULT, Typeface.BOLD)
+  }
+}

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputBlockType.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputBlockType.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Paragraph-level block kinds supported by the editor. Unlike inline styles
+/// (bold, italic) which apply to character ranges, block styles apply to whole
+/// paragraphs and are mutually exclusive per paragraph.
+typedef NS_ENUM(NSInteger, ENRMInputBlockType) {
+  ENRMInputBlockTypeParagraph = 0,
+  ENRMInputBlockTypeHeading1,
+  ENRMInputBlockTypeHeading2,
+  ENRMInputBlockTypeHeading3,
+};
+
+/// Custom attributed-string attribute storing the paragraph's ENRMInputBlockType
+/// (boxed NSNumber). TextKit migrates attributes across edits, so the block kind
+/// survives typing, deletion, and paste without manual range bookkeeping — the
+/// same reason inline marks aren't re-derived on every keystroke.
+extern NSAttributedStringKey const ENRMBlockTypeAttributeName;
+
+/// Heading level (1-3) for a heading block type, or 0 for non-headings.
+static inline NSInteger ENRMHeadingLevelForBlockType(ENRMInputBlockType type)
+{
+  switch (type) {
+    case ENRMInputBlockTypeHeading1:
+      return 1;
+    case ENRMInputBlockTypeHeading2:
+      return 2;
+    case ENRMInputBlockTypeHeading3:
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+static inline ENRMInputBlockType ENRMBlockTypeForHeadingLevel(NSInteger level)
+{
+  switch (level) {
+    case 1:
+      return ENRMInputBlockTypeHeading1;
+    case 2:
+      return ENRMInputBlockTypeHeading2;
+    case 3:
+      return ENRMInputBlockTypeHeading3;
+    default:
+      return ENRMInputBlockTypeParagraph;
+  }
+}
+
+/// A paragraph range tagged with its block type. Used to hand block structure to
+/// the serializer, which is otherwise stateless (plain text + inline ranges).
+@interface ENRMBlockRange : NSObject
+
+@property (nonatomic, assign) NSRange range;
+@property (nonatomic, assign) ENRMInputBlockType type;
+
++ (instancetype)rangeWithType:(ENRMInputBlockType)type range:(NSRange)range;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputBlockType.m
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputBlockType.m
@@ -1,0 +1,15 @@
+#import "ENRMInputBlockType.h"
+
+NSAttributedStringKey const ENRMBlockTypeAttributeName = @"ENRMBlockType";
+
+@implementation ENRMBlockRange
+
++ (instancetype)rangeWithType:(ENRMInputBlockType)type range:(NSRange)range
+{
+  ENRMBlockRange *blockRange = [[ENRMBlockRange alloc] init];
+  blockRange.type = type;
+  blockRange.range = range;
+  return blockRange;
+}
+
+@end

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.h
@@ -40,6 +40,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) RCTUIColor *spoilerBackgroundColor;
 
 - (UIFont *)fontForTraits:(UIFontDescriptorSymbolicTraits)traits;
+
+/// Bold, size-scaled font for a heading level (1-3). Level 0 returns the base
+/// font unchanged. Heading typography is derived from the base font so it tracks
+/// the configured font family and size automatically.
+- (UIFont *)baseFontForHeadingLevel:(NSInteger)level;
+
+/// Font combining a heading's base typography (size + bold) with inline traits,
+/// so a bold/italic mark inside a heading composes correctly.
+- (UIFont *)fontForTraits:(UIFontDescriptorSymbolicTraits)traits headingLevel:(NSInteger)level;
+
 - (void)invalidateFontCache;
 
 @end

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
@@ -1,5 +1,6 @@
 #import "ENRMInputFormatter.h"
 #import "ENRMBoldStyleHandler.h"
+#import "ENRMInputBlockType.h"
 #import "ENRMItalicStyleHandler.h"
 #import "ENRMLinkStyleHandler.h"
 #import "ENRMSpoilerStyleHandler.h"
@@ -77,6 +78,48 @@
   return derived;
 }
 
+/// Size multipliers applied to the base font for each heading level. Tuned to
+/// read as a clear hierarchy in-editor; the readonly renderer's StyleConfig can
+/// override these once heading style props are plumbed through.
+static CGFloat headingScaleForLevel(NSInteger level)
+{
+  switch (level) {
+    case 1:
+      return 1.6;
+    case 2:
+      return 1.4;
+    case 3:
+      return 1.2;
+    default:
+      return 1.0;
+  }
+}
+
+- (UIFont *)baseFontForHeadingLevel:(NSInteger)level
+{
+  if (level <= 0) {
+    return _baseFont;
+  }
+  CGFloat size = _baseFont.pointSize * headingScaleForLevel(level);
+  UIFontDescriptorSymbolicTraits traits = _baseFont.fontDescriptor.symbolicTraits | UIFontDescriptorTraitBold;
+  UIFontDescriptor *descriptor = [_baseFont.fontDescriptor fontDescriptorWithSymbolicTraits:traits];
+  return descriptor ? [UIFont fontWithDescriptor:descriptor size:size] : [_baseFont fontWithSize:size];
+}
+
+- (UIFont *)fontForTraits:(UIFontDescriptorSymbolicTraits)traits headingLevel:(NSInteger)level
+{
+  if (level <= 0) {
+    return [self fontForTraits:traits];
+  }
+  UIFont *base = [self baseFontForHeadingLevel:level];
+  UIFontDescriptorSymbolicTraits effective = base.fontDescriptor.symbolicTraits | traits;
+  if (effective == base.fontDescriptor.symbolicTraits) {
+    return base;
+  }
+  UIFontDescriptor *descriptor = [base.fontDescriptor fontDescriptorWithSymbolicTraits:effective];
+  return descriptor ? [UIFont fontWithDescriptor:descriptor size:base.pointSize] : base;
+}
+
 @end
 
 @implementation ENRMInputFormatter {
@@ -123,7 +166,6 @@
 
   [textStorage beginEditing];
 
-  [textStorage addAttribute:NSFontAttributeName value:style.baseFont range:fullTextRange];
   [textStorage addAttribute:NSForegroundColorAttributeName value:style.baseTextColor range:fullTextRange];
   [textStorage removeAttribute:NSUnderlineStyleAttributeName range:fullTextRange];
   [textStorage removeAttribute:NSStrikethroughStyleAttributeName range:fullTextRange];
@@ -131,10 +173,31 @@
 
   UIFontDescriptorSymbolicTraits *traitMap =
       (UIFontDescriptorSymbolicTraits *)calloc(textLength, sizeof(UIFontDescriptorSymbolicTraits));
-  if (!traitMap) {
+  // Per-character heading level, read from the block attribute TextKit migrates
+  // across edits. Drives both the base font size and the run boundaries below.
+  NSInteger *headingMap = (NSInteger *)calloc(textLength, sizeof(NSInteger));
+  if (!traitMap || !headingMap) {
+    free(traitMap);
+    free(headingMap);
     [textStorage endEditing];
     return;
   }
+
+  [textStorage enumerateAttribute:ENRMBlockTypeAttributeName
+                          inRange:fullTextRange
+                          options:0
+                       usingBlock:^(id value, NSRange attrRange, BOOL *stop) {
+                         if (!value) {
+                           return;
+                         }
+                         NSInteger level = ENRMHeadingLevelForBlockType((ENRMInputBlockType)[value integerValue]);
+                         if (level <= 0) {
+                           return;
+                         }
+                         for (NSUInteger i = attrRange.location; i < NSMaxRange(attrRange); i++) {
+                           headingMap[i] = level;
+                         }
+                       }];
 
   for (ENRMFormattingRange *formattingRange in ranges) {
     if (formattingRange.range.length == 0 || NSMaxRange(formattingRange.range) > textLength) {
@@ -161,22 +224,24 @@
                                            style:style];
   }
 
+  // Emit font runs keyed by (traits, heading level). Unlike the inline-only
+  // path, a heading run with no inline traits still needs its own (larger) font,
+  // so plain runs are no longer skipped.
   NSUInteger runStart = 0;
-  UIFontDescriptorSymbolicTraits currentTraits = traitMap[0];
-
   for (NSUInteger i = 1; i <= textLength; i++) {
-    UIFontDescriptorSymbolicTraits nextTraits = (i < textLength) ? traitMap[i] : ~currentTraits;
-    if (nextTraits != currentTraits) {
-      if (currentTraits != 0) {
-        UIFont *font = [style fontForTraits:currentTraits];
-        [textStorage addAttribute:NSFontAttributeName value:font range:NSMakeRange(runStart, i - runStart)];
-      }
-      runStart = i;
-      currentTraits = (i < textLength) ? traitMap[i] : 0;
+    BOOL boundary = (i == textLength) || traitMap[i] != traitMap[i - 1] || headingMap[i] != headingMap[i - 1];
+    if (!boundary) {
+      continue;
     }
+    UIFontDescriptorSymbolicTraits traits = traitMap[runStart];
+    NSInteger level = headingMap[runStart];
+    UIFont *font = (traits == 0 && level == 0) ? style.baseFont : [style fontForTraits:traits headingLevel:level];
+    [textStorage addAttribute:NSFontAttributeName value:font range:NSMakeRange(runStart, i - runStart)];
+    runStart = i;
   }
 
   free(traitMap);
+  free(headingMap);
 
   [textStorage endEditing];
 

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #import "ENRMFormattingRange.h"
+#import "ENRMInputBlockType.h"
 #import "ENRMInputStyledRange.h"
 #import <Foundation/Foundation.h>
 
@@ -9,6 +10,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ENRMParseResult : NSObject
 @property (nonatomic, strong, readonly) NSString *plainText;
 @property (nonatomic, strong, readonly) NSArray<ENRMFormattingRange *> *formattingRanges;
+/// Paragraph block ranges (headings) in `plainText` coordinates.
+@property (nonatomic, strong, readonly) NSArray<ENRMBlockRange *> *blockRanges;
 @end
 
 @interface ENRMInputParser : NSObject

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
@@ -1,5 +1,6 @@
 #import "ENRMInputParser.h"
 #import "ENRMFormattingRange.h"
+#import "ENRMInputBlockType.h"
 #import "ENRMInputRemend.h"
 #include "md4c.h"
 #include <string>
@@ -8,6 +9,7 @@
 @interface ENRMParseResult ()
 @property (nonatomic, strong, readwrite) NSString *plainText;
 @property (nonatomic, strong, readwrite) NSArray<ENRMFormattingRange *> *formattingRanges;
+@property (nonatomic, strong, readwrite) NSArray<ENRMBlockRange *> *blockRanges;
 @end
 
 @implementation ENRMParseResult
@@ -235,6 +237,84 @@ static bool runMd4cParse(NSString *markdown, ParseContext &context)
   return md_parse(completedUTF8, (MD_SIZE)completedLength, &parser, &context) == 0;
 }
 
+/// Strips ATX heading prefixes (`# `, `## `, `### `) from the start of each line
+/// and returns the heading block ranges. md4c leaves block markers as literal
+/// text (its block callbacks are no-ops), so headings are extracted here as a
+/// line-based post-pass. Inline formatting ranges are remapped through an
+/// old->new index map so they stay anchored to the same characters after the
+/// prefixes are removed.
+static void extractHeadingBlocks(NSString *plainText, NSArray<ENRMFormattingRange *> *inlineRanges, NSString **outText,
+                                 NSArray<ENRMFormattingRange *> **outInlineRanges,
+                                 NSArray<ENRMBlockRange *> **outBlockRanges)
+{
+  NSUInteger length = plainText.length;
+  NSMutableString *result = [NSMutableString stringWithCapacity:length];
+  std::vector<NSUInteger> map(length + 1, 0);
+  NSMutableArray<ENRMBlockRange *> *blocks = [NSMutableArray array];
+
+  NSUInteger newPos = 0;
+  NSUInteger lineStart = 0;
+  while (lineStart <= length) {
+    NSUInteger lineEnd = lineStart;
+    while (lineEnd < length && [plainText characterAtIndex:lineEnd] != '\n') {
+      lineEnd++;
+    }
+
+    NSUInteger marker = lineStart;
+    NSUInteger hashes = 0;
+    while (marker < lineEnd && [plainText characterAtIndex:marker] == '#') {
+      hashes++;
+      marker++;
+    }
+    BOOL isHeading = hashes >= 1 && hashes <= 3 && marker < lineEnd && [plainText characterAtIndex:marker] == ' ';
+    NSUInteger contentStart = isHeading ? marker + 1 : lineStart;
+
+    // Stripped prefix characters collapse onto the next kept position.
+    for (NSUInteger i = lineStart; i < contentStart; i++) {
+      map[i] = newPos;
+    }
+
+    NSUInteger blockStartNew = newPos;
+    if (lineEnd > contentStart) {
+      [result appendString:[plainText substringWithRange:NSMakeRange(contentStart, lineEnd - contentStart)]];
+      for (NSUInteger i = contentStart; i < lineEnd; i++) {
+        map[i] = newPos++;
+      }
+    }
+
+    if (isHeading) {
+      [blocks addObject:[ENRMBlockRange rangeWithType:ENRMBlockTypeForHeadingLevel((NSInteger)hashes)
+                                                range:NSMakeRange(blockStartNew, newPos - blockStartNew)]];
+    }
+
+    if (lineEnd < length) {
+      map[lineEnd] = newPos++;
+      [result appendString:@"\n"];
+      lineStart = lineEnd + 1;
+    } else {
+      break;
+    }
+  }
+  map[length] = newPos;
+
+  NSMutableArray<ENRMFormattingRange *> *remapped = [NSMutableArray arrayWithCapacity:inlineRanges.count];
+  for (ENRMFormattingRange *range in inlineRanges) {
+    NSUInteger start = MIN(range.range.location, length);
+    NSUInteger end = MIN(NSMaxRange(range.range), length);
+    NSUInteger newStart = map[start];
+    NSUInteger newEnd = map[end];
+    if (newEnd > newStart) {
+      [remapped addObject:[ENRMFormattingRange rangeWithType:range.type
+                                                       range:NSMakeRange(newStart, newEnd - newStart)
+                                                         url:range.url]];
+    }
+  }
+
+  *outText = result;
+  *outInlineRanges = remapped;
+  *outBlockRanges = blocks;
+}
+
 } // namespace
 
 @implementation ENRMInputParser
@@ -306,6 +386,7 @@ static bool runMd4cParse(NSString *markdown, ParseContext &context)
   if (markdown.length == 0) {
     parseResult.plainText = @"";
     parseResult.formattingRanges = @[];
+    parseResult.blockRanges = @[];
     return parseResult;
   }
 
@@ -394,8 +475,14 @@ static bool runMd4cParse(NSString *markdown, ParseContext &context)
     [formattingRanges addObject:formattingRange];
   }
 
-  parseResult.plainText = plainText;
-  parseResult.formattingRanges = formattingRanges;
+  NSString *blockText = nil;
+  NSArray<ENRMFormattingRange *> *blockAdjustedRanges = nil;
+  NSArray<ENRMBlockRange *> *blockRanges = nil;
+  extractHeadingBlocks(plainText, formattingRanges, &blockText, &blockAdjustedRanges, &blockRanges);
+
+  parseResult.plainText = blockText;
+  parseResult.formattingRanges = blockAdjustedRanges;
+  parseResult.blockRanges = blockRanges;
   return parseResult;
 }
 

--- a/packages/react-native-enriched-markdown/ios/input/ENRMMarkdownSerializer.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMMarkdownSerializer.h
@@ -1,12 +1,21 @@
 #pragma once
 
 #import "ENRMFormattingRange.h"
+#import "ENRMInputBlockType.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ENRMMarkdownSerializer : NSObject
 
 + (NSString *)serializePlainText:(NSString *)text ranges:(NSArray<ENRMFormattingRange *> *)ranges;
+
+/// Serializes inline marks (via the method above) and then prefixes each line
+/// with its block marker (`# `/`## `/`### ` for headings). Block markers are
+/// line-based, so this runs after inline serialization, which preserves the
+/// text's line structure.
++ (NSString *)serializePlainText:(NSString *)text
+                          ranges:(NSArray<ENRMFormattingRange *> *)ranges
+                     blockRanges:(NSArray<ENRMBlockRange *> *)blockRanges;
 
 @end
 

--- a/packages/react-native-enriched-markdown/ios/input/ENRMMarkdownSerializer.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMMarkdownSerializer.mm
@@ -219,4 +219,71 @@ static NSArray<ENRMFormattingRange *> *splitRangesAtParagraphBreaks(NSArray<ENRM
   return markdown;
 }
 
+static NSString *headingPrefixForLevel(NSInteger level)
+{
+  switch (level) {
+    case 1:
+      return @"# ";
+    case 2:
+      return @"## ";
+    case 3:
+      return @"### ";
+    default:
+      return @"";
+  }
+}
+
++ (NSString *)serializePlainText:(NSString *)text
+                          ranges:(NSArray<ENRMFormattingRange *> *)ranges
+                     blockRanges:(NSArray<ENRMBlockRange *> *)blockRanges
+{
+  NSString *inlineMarkdown = [self serializePlainText:text ranges:ranges];
+
+  if (blockRanges.count == 0) {
+    return inlineMarkdown;
+  }
+
+  // Inline serialization never adds or removes newlines, so line N of the
+  // inline markdown maps to paragraph N of the plain text. Walk plain-text
+  // lines to find each one's char range, look up its heading level, and prefix
+  // the matching markdown line.
+  NSArray<NSString *> *plainLines = [text componentsSeparatedByString:@"\n"];
+  NSMutableArray<NSString *> *markdownLines = [[inlineMarkdown componentsSeparatedByString:@"\n"] mutableCopy];
+
+  // Line counts must align for the index mapping to be valid; bail out safely if
+  // an inline edge case ever breaks the invariant.
+  if (plainLines.count != markdownLines.count) {
+    return inlineMarkdown;
+  }
+
+  NSUInteger lineStart = 0;
+  for (NSUInteger lineIndex = 0; lineIndex < plainLines.count; lineIndex++) {
+    NSUInteger lineLength = plainLines[lineIndex].length;
+    NSRange lineRange = NSMakeRange(lineStart, lineLength);
+
+    NSInteger level = 0;
+    for (ENRMBlockRange *blockRange in blockRanges) {
+      NSInteger blockLevel = ENRMHeadingLevelForBlockType(blockRange.type);
+      if (blockLevel <= 0) {
+        continue;
+      }
+      // A heading covers its paragraph; intersection (or an empty line whose
+      // start sits inside the block range) marks the line as that heading.
+      if (NSIntersectionRange(lineRange, blockRange.range).length > 0 ||
+          (lineLength == 0 && NSLocationInRange(lineStart, blockRange.range))) {
+        level = blockLevel;
+        break;
+      }
+    }
+
+    if (level > 0) {
+      markdownLines[lineIndex] = [headingPrefixForLevel(level) stringByAppendingString:markdownLines[lineIndex]];
+    }
+
+    lineStart += lineLength + 1; // +1 for the '\n' separator
+  }
+
+  return [markdownLines componentsJoinedByString:@"\n"];
+}
+
 @end

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -4,6 +4,7 @@
 #import "ENRMDetectorPipeline.h"
 #import "ENRMFormattingRange.h"
 #import "ENRMFormattingStore.h"
+#import "ENRMInputBlockType.h"
 #import "ENRMInputFormatter.h"
 #import "ENRMInputLayoutManager.h"
 #import "ENRMInputLinkPrompt.h"
@@ -59,6 +60,9 @@ using namespace facebook::react;
   ENRMFormattingStore *_formattingStore;
   NSMutableSet<NSNumber *> *_pendingStyles;
   NSMutableSet<NSNumber *> *_pendingStyleRemovals;
+  // Heading kind the next typed character should adopt when the cursor sits on an
+  // empty line (which has no character to carry the block attribute yet).
+  ENRMInputBlockType _pendingBlockType;
   BOOL _isApplyingFormatting;
   BOOL _isTextChanging;
   BOOL _emitMarkdown;
@@ -71,7 +75,9 @@ using namespace facebook::react;
   NSRange _preEditSelectedRange;
 
   struct {
-    BOOL bold, italic, underline, strikethrough, spoiler, link, initialized;
+    BOOL bold, italic, underline, strikethrough, spoiler, link;
+    BOOL h1, h2, h3;
+    BOOL initialized;
   } _prevState;
 
   std::optional<CGRect> _prevCaretRect;
@@ -540,6 +546,7 @@ using namespace facebook::react;
 
   _isApplyingFormatting = YES;
   ENRMSetPlainText(_textView, parsed.plainText);
+  [self applyBlockRanges:parsed.blockRanges];
   _isApplyingFormatting = NO;
 
   [_formattingStore setRanges:parsed.formattingRanges];
@@ -765,6 +772,104 @@ using namespace facebook::react;
   [self emitFormattingChanged];
 }
 
+#pragma mark - Block styles
+
+- (void)toggleH1
+{
+  [self toggleHeadingLevel:1];
+}
+
+- (void)toggleH2
+{
+  [self toggleHeadingLevel:2];
+}
+
+- (void)toggleH3
+{
+  [self toggleHeadingLevel:3];
+}
+
+/// Block type stored on the paragraph containing the cursor. Falls back to the
+/// pending kind for empty lines (no character holds the attribute yet).
+- (ENRMInputBlockType)blockTypeForCursorParagraph
+{
+  NSTextStorage *storage = _textView.textStorage;
+  NSString *text = storage.string;
+  if (text.length == 0) {
+    return _pendingBlockType;
+  }
+  NSRange paragraphRange = [text paragraphRangeForRange:_textView.selectedRange];
+  // Read the attribute from the paragraph's first non-newline character.
+  NSUInteger probe = paragraphRange.location;
+  if (probe >= text.length || [text characterAtIndex:probe] == '\n') {
+    return _pendingBlockType;
+  }
+  id value = [storage attribute:ENRMBlockTypeAttributeName atIndex:probe effectiveRange:NULL];
+  return value ? (ENRMInputBlockType)[value integerValue] : ENRMInputBlockTypeParagraph;
+}
+
+- (void)toggleHeadingLevel:(NSInteger)level
+{
+  ENRMInputBlockType targetType = ENRMBlockTypeForHeadingLevel(level);
+  BOOL turningOff = ([self blockTypeForCursorParagraph] == targetType);
+  ENRMInputBlockType newType = turningOff ? ENRMInputBlockTypeParagraph : targetType;
+
+  NSTextStorage *storage = _textView.textStorage;
+  NSString *text = storage.string;
+
+  if (text.length > 0) {
+    NSRange paragraphRange = [text paragraphRangeForRange:_textView.selectedRange];
+    [storage beginEditing];
+    // Apply per line so a multi-line selection toggles each paragraph, never the
+    // separating newline (headings are single-line in Markdown).
+    [text enumerateSubstringsInRange:paragraphRange
+                             options:NSStringEnumerationByLines
+                          usingBlock:^(NSString *line, NSRange lineRange, NSRange enclosingRange, BOOL *stop) {
+                            if (lineRange.length == 0) {
+                              return;
+                            }
+                            if (newType == ENRMInputBlockTypeParagraph) {
+                              [storage removeAttribute:ENRMBlockTypeAttributeName range:lineRange];
+                            } else {
+                              [storage addAttribute:ENRMBlockTypeAttributeName value:@(newType) range:lineRange];
+                            }
+                          }];
+    [storage endEditing];
+  }
+
+  // Carry the kind for the cursor's (possibly empty) line into the next keystroke.
+  _pendingBlockType = newType;
+
+  [self applyFormatting];
+  [self syncTypingAttributesWithPendingStyles];
+  [self emitFormattingChanged];
+}
+
+/// Writes parsed heading ranges into the text storage as block attributes.
+/// Caller is responsible for the surrounding `_isApplyingFormatting` guard.
+- (void)applyBlockRanges:(NSArray<ENRMBlockRange *> *)blockRanges
+{
+  NSTextStorage *storage = _textView.textStorage;
+  NSUInteger length = storage.length;
+  if (length == 0) {
+    return;
+  }
+  NSRange fullRange = NSMakeRange(0, length);
+  [storage beginEditing];
+  [storage removeAttribute:ENRMBlockTypeAttributeName range:fullRange];
+  for (ENRMBlockRange *blockRange in blockRanges) {
+    if (blockRange.type == ENRMInputBlockTypeParagraph) {
+      continue;
+    }
+    NSRange range = NSIntersectionRange(blockRange.range, fullRange);
+    if (range.length == 0) {
+      continue;
+    }
+    [storage addAttribute:ENRMBlockTypeAttributeName value:@(blockRange.type) range:range];
+  }
+  [storage endEditing];
+}
+
 - (void)setLink:(NSString *)url
 {
   NSRange selection = _textView.selectedRange;
@@ -900,7 +1005,8 @@ using namespace facebook::react;
     return;
   }
   NSString *markdown = [ENRMMarkdownSerializer serializePlainText:ENRMGetPlainText(_textView)
-                                                           ranges:[self allRangesIncludingTransient]];
+                                                           ranges:[self allRangesIncludingTransient]
+                                                      blockRanges:[self currentBlockRanges]];
   emitter->onRequestMarkdownResult({
       .requestId = static_cast<int>(requestId),
       .markdown = std::string([markdown UTF8String] ?: ""),
@@ -975,8 +1081,15 @@ using namespace facebook::react;
     traits |= UIFontDescriptorTraitItalic;
   }
 
+  NSInteger headingLevel = ENRMHeadingLevelForBlockType([self blockTypeForCursorParagraph]);
+
   NSMutableDictionary *attrs = [_textView.typingAttributes mutableCopy];
-  attrs[NSFontAttributeName] = [_formatterStyle fontForTraits:traits];
+  attrs[NSFontAttributeName] = [_formatterStyle fontForTraits:traits headingLevel:headingLevel];
+  if (headingLevel > 0) {
+    attrs[ENRMBlockTypeAttributeName] = @(ENRMBlockTypeForHeadingLevel(headingLevel));
+  } else {
+    [attrs removeObjectForKey:ENRMBlockTypeAttributeName];
+  }
   _textView.typingAttributes = attrs;
 }
 
@@ -992,6 +1105,9 @@ using namespace facebook::react;
   }
   [_pendingStyles removeAllObjects];
   [_pendingStyleRemovals removeAllObjects];
+  // Heading carries via the stored attribute on non-empty lines; clear the
+  // pending kind so it never leaks onto a different (empty) line.
+  _pendingBlockType = ENRMInputBlockTypeParagraph;
   [self rebuildPendingStylesFromContext];
   [self syncTypingAttributesWithPendingStyles];
 }
@@ -1165,8 +1281,35 @@ using namespace facebook::react;
     return;
   }
   NSString *markdown = [ENRMMarkdownSerializer serializePlainText:ENRMGetPlainText(_textView)
-                                                           ranges:[self allRangesIncludingTransient]];
+                                                           ranges:[self allRangesIncludingTransient]
+                                                      blockRanges:[self currentBlockRanges]];
   emitter->onChangeMarkdown({.value = std::string([markdown UTF8String] ?: "")});
+}
+
+/// Block (heading) ranges currently stored as text attributes, in text-storage
+/// coordinates. Source of truth for serialization and state queries.
+- (NSArray<ENRMBlockRange *> *)currentBlockRanges
+{
+  NSTextStorage *storage = _textView.textStorage;
+  NSUInteger length = storage.length;
+  if (length == 0) {
+    return @[];
+  }
+  NSMutableArray<ENRMBlockRange *> *result = [NSMutableArray array];
+  [storage enumerateAttribute:ENRMBlockTypeAttributeName
+                      inRange:NSMakeRange(0, length)
+                      options:0
+                   usingBlock:^(id value, NSRange range, BOOL *stop) {
+                     if (!value) {
+                       return;
+                     }
+                     ENRMInputBlockType type = (ENRMInputBlockType)[value integerValue];
+                     if (type == ENRMInputBlockTypeParagraph) {
+                       return;
+                     }
+                     [result addObject:[ENRMBlockRange rangeWithType:type range:range]];
+                   }];
+  return result;
 }
 
 - (void)emitOnChangeSelection
@@ -1197,9 +1340,15 @@ using namespace facebook::react;
   BOOL spoilerActive = [self isEffectiveStyleActive:ENRMInputStyleTypeSpoiler atPosition:cursor];
   BOOL linkActive = [self isEffectiveStyleActive:ENRMInputStyleTypeLink atPosition:cursor];
 
+  ENRMInputBlockType blockType = [self blockTypeForCursorParagraph];
+  BOOL h1Active = blockType == ENRMInputBlockTypeHeading1;
+  BOOL h2Active = blockType == ENRMInputBlockTypeHeading2;
+  BOOL h3Active = blockType == ENRMInputBlockTypeHeading3;
+
   if (_prevState.initialized && _prevState.bold == boldActive && _prevState.italic == italicActive &&
       _prevState.underline == underlineActive && _prevState.strikethrough == strikethroughActive &&
-      _prevState.spoiler == spoilerActive && _prevState.link == linkActive) {
+      _prevState.spoiler == spoilerActive && _prevState.link == linkActive && _prevState.h1 == h1Active &&
+      _prevState.h2 == h2Active && _prevState.h3 == h3Active) {
     return;
   }
 
@@ -1209,6 +1358,9 @@ using namespace facebook::react;
   _prevState.strikethrough = strikethroughActive;
   _prevState.spoiler = spoilerActive;
   _prevState.link = linkActive;
+  _prevState.h1 = h1Active;
+  _prevState.h2 = h2Active;
+  _prevState.h3 = h3Active;
   _prevState.initialized = YES;
 
   emitter->onChangeState({
@@ -1218,6 +1370,9 @@ using namespace facebook::react;
       .strikethrough = {.isActive = strikethroughActive},
       .spoiler = {.isActive = spoilerActive},
       .link = {.isActive = linkActive},
+      .h1 = {.isActive = h1Active},
+      .h2 = {.isActive = h2Active},
+      .h3 = {.isActive = h3Active},
   });
 }
 
@@ -1289,6 +1444,8 @@ using namespace facebook::react;
   BOOL spoilerActive = isActive(ENRMInputStyleTypeSpoiler);
   BOOL linkActive = isActive(ENRMInputStyleTypeLink);
 
+  ENRMInputBlockType blockType = [self blockTypeForCursorParagraph];
+
   eventEmitter->onContextMenuItemPress({
       .itemText = std::string(itemText.UTF8String),
       .selectedText = std::string(selectedText.UTF8String),
@@ -1302,6 +1459,9 @@ using namespace facebook::react;
               .strikethrough = {.isActive = strikethroughActive},
               .spoiler = {.isActive = spoilerActive},
               .link = {.isActive = linkActive},
+              .h1 = {.isActive = blockType == ENRMInputBlockTypeHeading1},
+              .h2 = {.isActive = blockType == ENRMInputBlockTypeHeading2},
+              .h3 = {.isActive = blockType == ENRMInputBlockTypeHeading3},
           },
   });
 }
@@ -1428,12 +1588,39 @@ using namespace facebook::react;
                                                                      range:insertedRange];
         [_formattingStore addRange:newRange];
       }
+
+      // Stamp the heading attribute onto the inserted glyphs when typing inside a
+      // heading paragraph. UIKit drops custom attributes from typingAttributes
+      // after the first insertion, so relying on it alone styles only the first
+      // character — apply directly to storage instead, matching how inline
+      // pending styles are applied above.
+      ENRMInputBlockType blockType = [self blockTypeForCursorParagraph];
+      if (blockType != ENRMInputBlockTypeParagraph) {
+        NSTextStorage *storage = _textView.textStorage;
+        NSRange clamped = NSIntersectionRange(insertedRange, NSMakeRange(0, storage.length));
+        if (clamped.length > 0) {
+          [storage addAttribute:ENRMBlockTypeAttributeName value:@(blockType) range:clamped];
+        }
+      }
     }
 
     // adjustForEditAtLocation may have expanded an existing range to cover
     // the insertion — carve out the inserted portion for removed styles.
     for (NSNumber *styleNum in _pendingStyleRemovals) {
       [_formattingStore removeType:(ENRMInputStyleType)styleNum.integerValue inRange:insertedRange];
+    }
+
+    // A newline ends a heading: Markdown headings are single-line, so the new
+    // paragraph starts plain. Strip any heading attribute the newline inherited
+    // and reset the pending kind + typing attributes so the next line is normal.
+    if (!insertedHasGlyphContent) {
+      NSTextStorage *storage = _textView.textStorage;
+      NSRange clampedInserted = NSIntersectionRange(insertedRange, NSMakeRange(0, storage.length));
+      if (clampedInserted.length > 0) {
+        [storage removeAttribute:ENRMBlockTypeAttributeName range:clampedInserted];
+      }
+      _pendingBlockType = ENRMInputBlockTypeParagraph;
+      [self syncTypingAttributesWithPendingStyles];
     }
   }
 
@@ -1446,6 +1633,12 @@ using namespace facebook::react;
 #endif
 
   [self applyFormatting];
+
+  // Keep the caret's typing font in sync with the heading paragraph so the next
+  // character keeps the heading size (UIKit otherwise resets it to the base font).
+  if ([self blockTypeForCursorParagraph] != ENRMInputBlockTypeParagraph) {
+    [self syncTypingAttributesWithPendingStyles];
+  }
 
   NSUInteger clampedEditLocation = MIN(editLocation, newLength);
   NSUInteger clampedInsertedLength = MIN(insertedLength, newLength - clampedEditLocation);

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -70,6 +70,9 @@ export interface StyleState {
   strikethrough: { isActive: boolean };
   spoiler: { isActive: boolean };
   link: { isActive: boolean };
+  h1: { isActive: boolean };
+  h2: { isActive: boolean };
+  h3: { isActive: boolean };
 }
 
 export interface ContextMenuItem {
@@ -103,6 +106,9 @@ export interface EnrichedMarkdownTextInputInstance {
   toggleUnderline: () => void;
   toggleStrikethrough: () => void;
   toggleSpoiler: () => void;
+  toggleH1: () => void;
+  toggleH2: () => void;
+  toggleH3: () => void;
   setLink: (url: string) => void;
   insertLink: (text: string, url: string) => void;
   insertMention: (displayText: string, url: string) => void;
@@ -356,8 +362,17 @@ export const EnrichedMarkdownTextInput = ({
 
   const handleChangeState = useCallback(
     (e: NativeSyntheticEvent<OnChangeStateEvent>) => {
-      const { bold, italic, underline, strikethrough, spoiler, link } =
-        e.nativeEvent;
+      const {
+        bold,
+        italic,
+        underline,
+        strikethrough,
+        spoiler,
+        link,
+        h1,
+        h2,
+        h3,
+      } = e.nativeEvent;
       onChangeState?.({
         bold,
         italic,
@@ -365,6 +380,9 @@ export const EnrichedMarkdownTextInput = ({
         strikethrough,
         spoiler,
         link,
+        h1,
+        h2,
+        h3,
       });
     },
     [onChangeState]
@@ -470,6 +488,9 @@ export const EnrichedMarkdownTextInput = ({
       toggleUnderline: () => Commands.toggleUnderline(commandRef),
       toggleStrikethrough: () => Commands.toggleStrikethrough(commandRef),
       toggleSpoiler: () => Commands.toggleSpoiler(commandRef),
+      toggleH1: () => Commands.toggleH1(commandRef),
+      toggleH2: () => Commands.toggleH2(commandRef),
+      toggleH3: () => Commands.toggleH3(commandRef),
       setLink: (url) => Commands.setLink(commandRef, url),
       insertLink: (text, url) => Commands.insertLink(commandRef, text, url),
       insertMention: (displayText, url) =>

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInputNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInputNativeComponent.ts
@@ -58,6 +58,9 @@ export interface OnChangeStateEvent {
   strikethrough: { isActive: boolean };
   spoiler: { isActive: boolean };
   link: { isActive: boolean };
+  h1: { isActive: boolean };
+  h2: { isActive: boolean };
+  h3: { isActive: boolean };
 }
 
 export interface OnRequestMarkdownResultEvent {
@@ -139,6 +142,9 @@ export interface OnContextMenuItemPressEvent {
     strikethrough: { isActive: boolean };
     spoiler: { isActive: boolean };
     link: { isActive: boolean };
+    h1: { isActive: boolean };
+    h2: { isActive: boolean };
+    h3: { isActive: boolean };
   };
 }
 
@@ -283,6 +289,9 @@ interface NativeCommands {
   toggleUnderline: (viewRef: React.ElementRef<ComponentType>) => void;
   toggleStrikethrough: (viewRef: React.ElementRef<ComponentType>) => void;
   toggleSpoiler: (viewRef: React.ElementRef<ComponentType>) => void;
+  toggleH1: (viewRef: React.ElementRef<ComponentType>) => void;
+  toggleH2: (viewRef: React.ElementRef<ComponentType>) => void;
+  toggleH3: (viewRef: React.ElementRef<ComponentType>) => void;
   setLink: (viewRef: React.ElementRef<ComponentType>, url: string) => void;
   insertLink: (
     viewRef: React.ElementRef<ComponentType>,
@@ -320,6 +329,9 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
     'toggleUnderline',
     'toggleStrikethrough',
     'toggleSpoiler',
+    'toggleH1',
+    'toggleH2',
+    'toggleH3',
     'setLink',
     'insertLink',
     'insertMention',


### PR DESCRIPTION
### What/Why?

Adds **H1–H3 heading** support to the editable `EnrichedMarkdownTextInput`, addressing the "expanded markdown support" half of #359. The readonly `EnrichedMarkdownText` already renders headings, but the input only supported inline marks (bold/italic/underline/strikethrough/spoiler/link) — there was no way to author block elements.

This is the first of a small series (headings → bullet list → numbered list); it deliberately scopes to headings so each block type lands as a reviewable unit.

**How it works**

- Heading kind is stored as a per-paragraph attribute (iOS `NSAttributedString` key / Android span) that the text system migrates across edits, so it survives typing/deletion/paste without manual range bookkeeping — mirroring how inline marks behave.
- The markers (`# `, `## `, `### `) exist **only in the serialized Markdown**, never in the editor text: they're stripped on load and re-added on save. Heading vs. `#hashtag`-mention can't collide because ATX headings require a space after the `#`, and the marker never appears in the editable text the mention detector scans.
- New imperative commands `toggleH1/H2/H3`; active level for the cursor's line is reported via `onChangeState` as `h1`/`h2`/`h3` (same `{ isActive }` shape as inline styles).
- A heading is single-line: pressing Enter ends it and starts a normal paragraph.

New public API: `toggleH1()`, `toggleH2()`, `toggleH3()`, and `h1`/`h2`/`h3` on `StyleState`. Documented in `docs/INPUT.md`.

### Testing

Built and ran the example app on **iOS** and **Android**:

- Toggle H1/H2/H3 from the toolbar, type — every typed character stays in the heading (not just the first).
- Headings render at their size in-editor; `Get Raw Markdown` round-trips to `# `/`## `/`### `.
- `Set Raw Markdown` with `# / ## / ###` content parses back to rendered headings with markers stripped.
- Enter ends a heading; the next line is a normal paragraph.
- Toggling the active level off restores a paragraph; switching levels replaces.

Added a basic Maestro flow: `enrichedMarkdownInput/flows/basic/block_elements/heading_test.yaml`. (Screenshot baselines are generated by the E2E job / `--update-screenshots`.)

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [ ] E2E tests are passing <!-- flow added; baselines need an --update-screenshots run on CI -->
- [x] Required E2E tests have been added (if applicable)
