### PR TITLE
feat(android): add "Copy as markdown" functionality

### DIFF
--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -15,6 +15,7 @@ import com.swmansion.enriched.markdown.parser.Parser
 import com.swmansion.enriched.markdown.renderer.Renderer
 import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.text.view.LinkLongPressMovementMethod
+import com.swmansion.enriched.markdown.utils.text.view.SelectionMenuConfig
 import com.swmansion.enriched.markdown.utils.text.view.applySelectableState
 import com.swmansion.enriched.markdown.utils.text.view.applySelectionColors
 import com.swmansion.enriched.markdown.utils.text.view.createSelectionActionModeCallback
@@ -48,10 +49,15 @@ class EnrichedMarkdownText
     private var selectionColor: Int? = null
     private var selectionHandleColor: Int? = null
     private var isSelectable = true
+    private var selectionMenuConfig = SelectionMenuConfig()
 
     init {
       setupAsMarkdownTextView()
-      customSelectionActionModeCallback = createSelectionActionModeCallback(this)
+      customSelectionActionModeCallback =
+        createSelectionActionModeCallback(
+          this,
+          getSelectionMenuConfig = { selectionMenuConfig },
+        )
     }
 
     fun setMarkdownContent(markdown: String) {
@@ -123,6 +129,11 @@ class EnrichedMarkdownText
       if (selectionHandleColor == color) return
       selectionHandleColor = color
       applySelectionColors(selectionColor, selectionHandleColor)
+    }
+
+    fun setSelectionMenuConfig(config: SelectionMenuConfig) {
+      if (selectionMenuConfig == config) return
+      selectionMenuConfig = config
     }
 
     fun emitOnLinkPress(url: String) {

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/conversion/MarkdownExtractor.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/conversion/MarkdownExtractor.kt
@@ -1,0 +1,375 @@
+package com.swmansion.enriched.markdown.utils.text.conversion
+
+import android.text.Spannable
+import android.text.style.UnderlineSpan
+import android.widget.TextView
+import com.swmansion.enriched.markdown.EnrichedMarkdownText
+import com.swmansion.enriched.markdown.spans.BaselineShiftSpan
+import com.swmansion.enriched.markdown.spans.BlockquoteSpan
+import com.swmansion.enriched.markdown.spans.CodeBlockSpan
+import com.swmansion.enriched.markdown.spans.CodeSpan
+import com.swmansion.enriched.markdown.spans.EmphasisSpan
+import com.swmansion.enriched.markdown.spans.HeadingSpan
+import com.swmansion.enriched.markdown.spans.ImageSpan
+import com.swmansion.enriched.markdown.spans.LinkSpan
+import com.swmansion.enriched.markdown.spans.OrderedListSpan
+import com.swmansion.enriched.markdown.spans.StrongSpan
+import com.swmansion.enriched.markdown.spans.ThematicBreakSpan
+import com.swmansion.enriched.markdown.spans.UnorderedListSpan
+
+/** Extracts markdown from styled text (Spannable). */
+object MarkdownExtractor {
+  /**
+   * Gets markdown for the current text selection.
+   * Full selection returns original markdown, partial reconstructs from spans.
+   */
+  fun getMarkdownForSelection(textView: TextView): String? {
+    val start = textView.selectionStart
+    val end = textView.selectionEnd
+    if (start < 0 || end < 0 || start >= end) return null
+
+    val spannable = textView.text as? Spannable ?: return null
+
+    val isFullSelection = start == 0 && end >= textView.text.length - 1
+    if (isFullSelection && textView is EnrichedMarkdownText) {
+      val original = textView.currentMarkdown
+      if (original.isNotEmpty()) return original
+    }
+
+    return extractFromSpannable(spannable, start, end)
+  }
+
+  /** Extracts markdown from a Spannable within a given range. */
+  fun extractFromSpannable(
+    spannable: Spannable,
+    start: Int,
+    end: Int,
+  ): String {
+    val result = StringBuilder()
+    val state = ExtractionState()
+    val headingAccumulator = HeadingAccumulator()
+
+    var i = start
+    while (i < end) {
+      val nextTransition = spannable.nextSpanTransition(i, end, Any::class.java)
+      val segmentText = spannable.subSequence(i, nextTransition).toString()
+
+      val handled =
+        processSegment(
+          spannable = spannable,
+          segmentText = segmentText,
+          segmentStart = i,
+          segmentEnd = nextTransition,
+          result = result,
+          state = state,
+          headingAccumulator = headingAccumulator,
+        )
+
+      if (!handled) {
+        appendFormattedSegment(spannable, segmentText, i, nextTransition, result, state)
+      }
+
+      i = nextTransition
+    }
+
+    headingAccumulator.flush(result, state)
+    return result.toString()
+  }
+
+  private fun processSegment(
+    spannable: Spannable,
+    segmentText: String,
+    segmentStart: Int,
+    segmentEnd: Int,
+    result: StringBuilder,
+    state: ExtractionState,
+    headingAccumulator: HeadingAccumulator,
+  ): Boolean {
+    val thematicBreakSpans = spannable.getSpans(segmentStart, segmentEnd, ThematicBreakSpan::class.java)
+    if (thematicBreakSpans.isNotEmpty()) {
+      appendThematicBreak(result, state)
+      return true
+    }
+
+    if (segmentText == "\uFFFC" || segmentText == "\u200B") {
+      val imageSpans = spannable.getSpans(segmentStart, segmentEnd, ImageSpan::class.java)
+      if (imageSpans.isNotEmpty()) {
+        appendImage(imageSpans[0], result, state)
+        return true
+      }
+    }
+
+    if (segmentText.isEmpty()) return true
+
+    if (segmentText == "\n" || segmentText == "\n\n") {
+      handleNewline(spannable, segmentStart, segmentEnd, result, state)
+      return true
+    }
+
+    val headingSpans = spannable.getSpans(segmentStart, segmentEnd, HeadingSpan::class.java)
+    if (headingSpans.isNotEmpty()) {
+      headingAccumulator.accumulate(headingSpans[0].level, segmentText, result, state)
+      return true
+    } else {
+      headingAccumulator.flush(result, state)
+    }
+
+    val codeBlockSpans = spannable.getSpans(segmentStart, segmentEnd, CodeBlockSpan::class.java)
+    if (codeBlockSpans.isNotEmpty()) {
+      appendCodeBlock(segmentText, result, state)
+      return true
+    }
+
+    return false
+  }
+
+  private fun appendFormattedSegment(
+    spannable: Spannable,
+    segmentText: String,
+    segmentStart: Int,
+    segmentEnd: Int,
+    result: StringBuilder,
+    state: ExtractionState,
+  ) {
+    val blockquotePrefix = detectBlockquote(spannable, segmentStart, segmentEnd, state)
+    val listPrefix = detectList(spannable, segmentStart, segmentEnd, state)
+    var segment = applyInlineFormatting(spannable, segmentText, segmentStart, segmentEnd)
+
+    if (result.isAtLineStart() && !segmentText.startsWith("\n")) {
+      segment = buildBlockPrefix(blockquotePrefix, listPrefix) + segment
+    }
+
+    if (state.needsBlankLine && result.isNotEmpty()) {
+      result.ensureBlankLine()
+      state.needsBlankLine = false
+    }
+
+    result.append(segment)
+  }
+
+  private fun appendImage(
+    img: ImageSpan,
+    result: StringBuilder,
+    state: ExtractionState,
+  ) {
+    if (img.isInline) {
+      result.append("![image](${img.imageUrl})")
+    } else {
+      result.ensureBlankLine()
+      result.append("![image](${img.imageUrl})\n")
+      state.needsBlankLine = true
+      state.blockquoteDepth = -1
+      state.listDepth = -1
+    }
+  }
+
+  private fun appendThematicBreak(
+    result: StringBuilder,
+    state: ExtractionState,
+  ) {
+    result.ensureBlankLine()
+    result.append("---\n")
+    state.needsBlankLine = true
+    state.blockquoteDepth = -1
+    state.listDepth = -1
+  }
+
+  private fun handleNewline(
+    spannable: Spannable,
+    start: Int,
+    end: Int,
+    result: StringBuilder,
+    state: ExtractionState,
+  ) {
+    val inBlockquote = spannable.getSpans(start, end, BlockquoteSpan::class.java).isNotEmpty()
+    val inList =
+      spannable.getSpans(start, end, OrderedListSpan::class.java).isNotEmpty() ||
+        spannable.getSpans(start, end, UnorderedListSpan::class.java).isNotEmpty()
+
+    when {
+      !inBlockquote && state.blockquoteDepth >= 0 -> {
+        result.ensureBlankLine()
+        state.blockquoteDepth = -1
+      }
+
+      !inList && state.listDepth >= 0 -> {
+        result.ensureBlankLine()
+        state.listDepth = -1
+      }
+
+      inBlockquote || inList -> {
+        if (!result.endsWith("\n")) result.append("\n")
+      }
+
+      else -> {
+        result.ensureBlankLine()
+      }
+    }
+  }
+
+  private fun appendCodeBlock(
+    text: String,
+    result: StringBuilder,
+    state: ExtractionState,
+  ) {
+    if (state.needsBlankLine) {
+      result.ensureBlankLine()
+      state.needsBlankLine = false
+    }
+
+    val needsFence = result.isEmpty() || result.endsWith("\n\n")
+    if (needsFence) result.append("```\n")
+
+    result.append(text)
+
+    if (text.endsWith("\n")) {
+      result.append("```\n")
+      state.needsBlankLine = true
+    }
+  }
+
+  private fun detectBlockquote(
+    spannable: Spannable,
+    start: Int,
+    end: Int,
+    state: ExtractionState,
+  ): String? {
+    val spans = spannable.getSpans(start, end, BlockquoteSpan::class.java)
+    val depth = spans.maxOfOrNull { it.depth } ?: -1
+
+    return if (depth >= 0) {
+      state.blockquoteDepth = depth
+      "> ".repeat(depth + 1)
+    } else {
+      if (state.blockquoteDepth >= 0) state.blockquoteDepth = -1
+      null
+    }
+  }
+
+  private fun detectList(
+    spannable: Spannable,
+    start: Int,
+    end: Int,
+    state: ExtractionState,
+  ): String? {
+    val orderedSpans = spannable.getSpans(start, end, OrderedListSpan::class.java)
+    val unorderedSpans = spannable.getSpans(start, end, UnorderedListSpan::class.java)
+
+    val orderedDepth = orderedSpans.maxOfOrNull { it.depth } ?: -1
+    val unorderedDepth = unorderedSpans.maxOfOrNull { it.depth } ?: -1
+    val depth = maxOf(orderedDepth, unorderedDepth)
+
+    return if (depth >= 0) {
+      state.listDepth = depth
+      val indent = "  ".repeat(depth)
+      if (orderedSpans.isNotEmpty()) {
+        "$indent${orderedSpans[0].itemNumber}. "
+      } else {
+        "$indent- "
+      }
+    } else {
+      if (state.listDepth >= 0) state.listDepth = -1
+      null
+    }
+  }
+
+  private fun applyInlineFormatting(
+    spannable: Spannable,
+    text: String,
+    start: Int,
+    end: Int,
+  ): String {
+    val hasStrong = spannable.getSpans(start, end, StrongSpan::class.java).isNotEmpty()
+    val hasEmphasis = spannable.getSpans(start, end, EmphasisSpan::class.java).isNotEmpty()
+    val hasCode = spannable.getSpans(start, end, CodeSpan::class.java).isNotEmpty()
+    val hasUnderline = spannable.getSpans(start, end, UnderlineSpan::class.java).isNotEmpty()
+    val baselineShiftSpans = spannable.getSpans(start, end, BaselineShiftSpan::class.java)
+    val hasSuperscript = baselineShiftSpans.any { it.spanType == BaselineShiftSpan.SpanType.SUPERSCRIPT }
+    val hasSubscript = baselineShiftSpans.any { it.spanType == BaselineShiftSpan.SpanType.SUBSCRIPT }
+    val linkSpans = spannable.getSpans(start, end, LinkSpan::class.java)
+
+    var result = text
+
+    if (hasCode && linkSpans.isEmpty()) {
+      result = "`$result`"
+    }
+    if (hasSubscript) {
+      result = "~$result~"
+    }
+    if (hasSuperscript) {
+      result = "^$result^"
+    }
+    if (hasUnderline && linkSpans.isEmpty()) {
+      result = "<u>$result</u>"
+    }
+    if (hasEmphasis) {
+      result = "*$result*"
+    }
+    if (hasStrong) {
+      result = "**$result**"
+    }
+    if (linkSpans.isNotEmpty()) {
+      result = "[$result](${linkSpans[0].url})"
+    }
+
+    return result
+  }
+
+  private fun buildBlockPrefix(
+    blockquotePrefix: String?,
+    listPrefix: String?,
+  ): String =
+    buildString {
+      blockquotePrefix?.let { append(it) }
+      listPrefix?.let { append(it) }
+    }
+
+  private data class ExtractionState(
+    var blockquoteDepth: Int = -1,
+    var listDepth: Int = -1,
+    var needsBlankLine: Boolean = false,
+  )
+
+  private class HeadingAccumulator {
+    private var level: Int? = null
+    private val content = StringBuilder()
+
+    fun accumulate(
+      newLevel: Int,
+      text: String,
+      result: StringBuilder,
+      state: ExtractionState,
+    ) {
+      if (level != newLevel) {
+        flush(result, state)
+        level = newLevel
+      }
+      content.append(text.trim('\n'))
+    }
+
+    fun flush(
+      result: StringBuilder,
+      state: ExtractionState,
+    ) {
+      val currentLevel = level ?: return
+      if (content.isEmpty()) return
+
+      result.ensureBlankLine()
+      result.append("#".repeat(currentLevel))
+      result.append(" ")
+      result.append(content.toString().trim())
+      result.append("\n")
+
+      level = null
+      content.clear()
+      state.needsBlankLine = true
+    }
+  }
+
+  private fun StringBuilder.ensureBlankLine() {
+    if (isEmpty() || endsWith("\n\n")) return
+    append(if (endsWith("\n")) "\n" else "\n\n")
+  }
+
+  private fun StringBuilder.isAtLineStart(): Boolean = isEmpty() || endsWith("\n")
+}

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionMode.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionMode.kt
@@ -9,11 +9,16 @@ import android.view.Menu
 import android.view.MenuItem
 import android.widget.TextView
 import com.swmansion.enriched.markdown.spans.ImageSpan
+import com.swmansion.enriched.markdown.utils.text.conversion.MarkdownExtractor
 
+private const val MENU_ITEM_COPY_MARKDOWN = 1000
 private const val MENU_ITEM_COPY_IMAGE_URL = 1001
+private const val DEFAULT_COPY_AS_MARKDOWN_LABEL = "Copy as Markdown"
 
 data class SelectionMenuConfig(
+  val copyAsMarkdown: Boolean = true,
   val copyImageUrl: Boolean = true,
+  val copyAsMarkdownLabel: String = "",
 )
 
 fun createSelectionActionModeCallback(
@@ -35,9 +40,23 @@ fun createSelectionActionModeCallback(
     ): Boolean {
       if (menu == null) return false
 
+      menu.removeItem(MENU_ITEM_COPY_MARKDOWN)
       menu.removeItem(MENU_ITEM_COPY_IMAGE_URL)
 
       val selectionMenuConfig = getSelectionMenuConfig()
+
+      if (
+        selectionMenuConfig.copyAsMarkdown &&
+        textView.selectionStart >= 0 &&
+        textView.selectionEnd > textView.selectionStart
+      ) {
+        val label =
+          selectionMenuConfig.copyAsMarkdownLabel.ifEmpty {
+            DEFAULT_COPY_AS_MARKDOWN_LABEL
+          }
+        menu.add(Menu.NONE, MENU_ITEM_COPY_MARKDOWN, Menu.NONE, label)
+      }
+
       val imageUrls =
         if (selectionMenuConfig.copyImageUrl) {
           textView.getImageUrlsInSelection()
@@ -70,6 +89,12 @@ fun createSelectionActionModeCallback(
           return true
         }
 
+        MENU_ITEM_COPY_MARKDOWN -> {
+          textView.copyMarkdownToClipboard()
+          mode?.finish()
+          return true
+        }
+
         MENU_ITEM_COPY_IMAGE_URL -> {
           textView.copyImageUrlsToClipboard()
           mode?.finish()
@@ -82,6 +107,12 @@ fun createSelectionActionModeCallback(
 
     override fun onDestroyActionMode(mode: ActionMode?) {}
   }
+
+private fun TextView.copyMarkdownToClipboard() {
+  val markdown = MarkdownExtractor.getMarkdownForSelection(this) ?: return
+  val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+  clipboard.setPrimaryClip(ClipData.newPlainText("Markdown", markdown))
+}
 
 private fun TextView.copyPlainTextToClipboard() {
   val start = selectionStart

--- a/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/MarkdownExtractorTest.kt
+++ b/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/MarkdownExtractorTest.kt
@@ -1,0 +1,464 @@
+package com.swmansion.enriched.markdown
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createEnrichedMarkdownTextWithFullSelection
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewSelectingText
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewWithFullSelection
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewWithSelection
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.extractFromFullSelection
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.extractSelectingText
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.indexOf
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.render
+import com.swmansion.enriched.markdown.test.TestAstFactory.blockquote
+import com.swmansion.enriched.markdown.test.TestAstFactory.code
+import com.swmansion.enriched.markdown.test.TestAstFactory.codeBlock
+import com.swmansion.enriched.markdown.test.TestAstFactory.document
+import com.swmansion.enriched.markdown.test.TestAstFactory.emphasis
+import com.swmansion.enriched.markdown.test.TestAstFactory.heading
+import com.swmansion.enriched.markdown.test.TestAstFactory.image
+import com.swmansion.enriched.markdown.test.TestAstFactory.link
+import com.swmansion.enriched.markdown.test.TestAstFactory.listItem
+import com.swmansion.enriched.markdown.test.TestAstFactory.orderedList
+import com.swmansion.enriched.markdown.test.TestAstFactory.paragraph
+import com.swmansion.enriched.markdown.test.TestAstFactory.strong
+import com.swmansion.enriched.markdown.test.TestAstFactory.text
+import com.swmansion.enriched.markdown.test.TestAstFactory.thematicBreak
+import com.swmansion.enriched.markdown.test.TestAstFactory.unorderedList
+import com.swmansion.enriched.markdown.utils.text.conversion.MarkdownExtractor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [28])
+class MarkdownExtractorTest {
+  @Test
+  fun returnsNullForInvalidSelection() {
+    val spannable = render(document(paragraph(text("Hello"))))
+    val textView = createTextViewWithSelection(spannable, 2, 2)
+
+    assertNull(MarkdownExtractor.getMarkdownForSelection(textView))
+  }
+
+  @Test
+  fun fullSelectionOnEnrichedMarkdownTextReturnsOriginalMarkdown() {
+    val original = "# Title\n\n with *bold**."
+    val rendered =
+      render(
+        document(
+          heading(1, text("Title")),
+          paragraph(
+            text("Paragraph with "),
+            strong(text("bold")),
+            text("."),
+          ),
+        ),
+      )
+
+    val textView = createEnrichedMarkdownTextWithFullSelection(original, rendered)
+
+    assertEquals(original, MarkdownExtractor.getMarkdownForSelection(textView))
+  }
+
+  @Test
+  fun extractsPlainParagraphText() {
+    val markdown =
+      extractSelectingText(
+        document(paragraph(text("Hello CommonMark"))),
+        "Hello CommonMark",
+      )
+
+    assertEquals("Hello CommonMark", markdown)
+  }
+
+  @Test
+  fun extractsBoldText() {
+    assertEquals(
+      "**31%**",
+      extractSelectingText(
+        document(
+          paragraph(
+            text("Forests cover "),
+            strong(text("31%")),
+            text(" of land."),
+          ),
+        ),
+        "31%",
+      ),
+    )
+  }
+
+  @Test
+  fun extractsItalicText() {
+    assertEquals(
+      "*300 million years*",
+      extractSelectingText(
+        document(
+          paragraph(
+            text("Over "),
+            emphasis(text("300 million years")),
+            text(" old."),
+          ),
+        ),
+        "300 million years",
+      ),
+    )
+  }
+
+  @Test
+  fun extractsBoldAndItalicInSameParagraph() {
+    val spannable =
+      render(
+        document(
+          paragraph(
+            text("Text with "),
+            strong(text("bold")),
+            text(" and "),
+            emphasis(text("italic")),
+            text(" styles."),
+          ),
+        ),
+      )
+    val start = indexOf(spannable, "Text with ")
+    val end = spannable.indexOf(" styles.") + " styles.".length
+    val textView = createTextViewWithSelection(spannable, start, end)
+
+    assertEquals(
+      "Text with **bold** and *italic* styles.",
+      MarkdownExtractor.getMarkdownForSelection(textView),
+    )
+  }
+
+  @Test
+  fun extractsInlineCode() {
+    assertEquals(
+      "`48 pounds`",
+      extractSelectingText(
+        document(
+          paragraph(
+            text("Use "),
+            code("48 pounds"),
+            text(" per year."),
+          ),
+        ),
+        "48 pounds",
+      ),
+    )
+  }
+
+  @Test
+  fun extractsLink() {
+    assertEquals(
+      "[Example link](https://example.com)",
+      extractSelectingText(
+        document(
+          paragraph(
+            link("https://example.com", text("Example link")),
+          ),
+        ),
+        "Example link",
+      ),
+    )
+  }
+
+  @Test
+  fun extractsHeading() {
+    assertEquals(
+      "# The Hidden World of Forest Ecosystems\n",
+      extractSelectingText(
+        document(
+          heading(1, text("The Hidden World of Forest Ecosystems")),
+        ),
+        "The Hidden World of Forest Ecosystems",
+      ),
+    )
+  }
+
+  @Test
+  fun extractsAllHeadingLevels() {
+    for (level in 1..6) {
+      val title = "Heading level $level"
+      val expected = "${"#".repeat(level)} $title\n"
+      assertEquals(
+        expected,
+        extractSelectingText(document(heading(level, text(title))), title),
+      )
+    }
+  }
+
+  @Test
+  fun extractsBlockquote() {
+    val quote = "In every walk with nature, one receives far more than he seeks."
+    assertEquals(
+      "> $quote",
+      extractSelectingText(
+        document(
+          blockquote(
+            paragraph(text(quote)),
+          ),
+        ),
+        quote,
+      ),
+    )
+  }
+
+  @Test
+  fun extractsNestedBlockquote() {
+    val innerQuote = "Inner quote"
+    val spannable =
+      render(
+        document(
+          blockquote(
+            paragraph(text("Outer quote")),
+            blockquote(
+              paragraph(text(innerQuote)),
+            ),
+          ),
+        ),
+      )
+    val start = indexOf(spannable, innerQuote)
+    val textView = createTextViewWithSelection(spannable, start, start + innerQuote.length)
+
+    assertEquals("> > $innerQuote", MarkdownExtractor.getMarkdownForSelection(textView))
+  }
+
+  @Test
+  fun extractsUnorderedListItem() {
+    assertEquals(
+      "- Climate regulation",
+      extractSelectingText(
+        document(
+          unorderedList(
+            listItem(paragraph(text("Climate regulation"))),
+            listItem(paragraph(text("Biodiversity"))),
+          ),
+        ),
+        "Climate regulation",
+      ),
+    )
+  }
+
+  @Test
+  fun extractsOrderedListItem() {
+    assertEquals(
+      "1. First item",
+      extractSelectingText(
+        document(
+          orderedList(
+            listItem(paragraph(text("First item"))),
+            listItem(paragraph(text("Second item"))),
+          ),
+        ),
+        "First item",
+      ),
+    )
+  }
+
+  @Test
+  fun extractsSecondOrderedListItem() {
+    assertEquals(
+      "2. Second item",
+      extractSelectingText(
+        document(
+          orderedList(
+            listItem(paragraph(text("First item"))),
+            listItem(paragraph(text("Second item"))),
+          ),
+        ),
+        "Second item",
+      ),
+    )
+  }
+
+  @Test
+  fun extractsNestedUnorderedListItem() {
+    val nestedItem = "Nested item"
+    val spannable =
+      render(
+        document(
+          unorderedList(
+            listItem(
+              paragraph(text("Parent item")),
+              unorderedList(
+                listItem(paragraph(text(nestedItem))),
+              ),
+            ),
+          ),
+        ),
+      )
+    val start = indexOf(spannable, nestedItem)
+    val textView = createTextViewWithSelection(spannable, start, start + nestedItem.length)
+
+    assertEquals("  - $nestedItem", MarkdownExtractor.getMarkdownForSelection(textView))
+  }
+
+  @Test
+  fun extractsMultiLineCodeBlock() {
+    val codeBlockContent =
+      """
+      fun main() {
+        println("forest")
+      }
+      """.trimIndent()
+    val spannable = render(document(codeBlock(codeBlockContent)))
+    val codeBlockSpan =
+      spannable
+        .getSpans(0, spannable.length, com.swmansion.enriched.markdown.spans.CodeBlockSpan::class.java)
+        .first()
+    val textView =
+      createTextViewWithSelection(
+        spannable,
+        spannable.getSpanStart(codeBlockSpan),
+        spannable.getSpanEnd(codeBlockSpan),
+      )
+
+    assertEquals("```\n$codeBlockContent", MarkdownExtractor.getMarkdownForSelection(textView))
+  }
+
+  @Test
+  fun extractsCodeBlockWithoutClosingFenceWhenSelectionExcludesTrailingNewline() {
+    val code = "fun main() = println(\"forest\")"
+    val spannable = render(document(codeBlock(code)))
+    val codeBlockSpan =
+      spannable
+        .getSpans(0, spannable.length, com.swmansion.enriched.markdown.spans.CodeBlockSpan::class.java)
+        .first()
+    val start = spannable.getSpanStart(codeBlockSpan)
+    val end = spannable.getSpanEnd(codeBlockSpan)
+    val textView = createTextViewWithSelection(spannable, start, end)
+
+    assertEquals("```\n$code", MarkdownExtractor.getMarkdownForSelection(textView))
+  }
+
+  @Test
+  fun extractsThematicBreak() {
+    val spannable = render(document(thematicBreak()))
+    val breakStart =
+      spannable
+        .getSpans(0, spannable.length, com.swmansion.enriched.markdown.spans.ThematicBreakSpan::class.java)
+        .first()
+        .let { spannable.getSpanStart(it) }
+    val breakEnd = breakStart + 1
+    val textView = createTextViewWithSelection(spannable, breakStart, breakEnd)
+
+    assertEquals("---\n", MarkdownExtractor.getMarkdownForSelection(textView))
+  }
+
+  @Test
+  fun extractsInlineImage() {
+    val url = "https://example.com/forest.jpg"
+    val spannable =
+      render(
+        document(
+          paragraph(
+            text("Before "),
+            image(url),
+            text(" after"),
+          ),
+        ),
+      )
+    val imageStart = spannable.indexOf('\uFFFC')
+    val textView = createTextViewWithSelection(spannable, imageStart, imageStart + 1)
+
+    assertEquals("![image]($url)", MarkdownExtractor.getMarkdownForSelection(textView))
+  }
+
+  @Test
+  fun extractsBlockImage() {
+    val url = "https://example.com/forest.jpg"
+    val spannable =
+      render(
+        document(
+          paragraph(
+            image(url),
+          ),
+        ),
+      )
+    val imageStart = spannable.indexOf('\uFFFC')
+    val textView = createTextViewWithSelection(spannable, imageStart, imageStart + 1)
+
+    assertEquals("![image]($url)\n", MarkdownExtractor.getMarkdownForSelection(textView))
+  }
+
+  @Test
+  fun extractsParagraphWithInlineImageAndText() {
+    val url = "https://example.com/forest.jpg"
+    val spannable =
+      render(
+        document(
+          paragraph(
+            text("See "),
+            image(url),
+            text(" for details."),
+          ),
+        ),
+      )
+    val textView = createTextViewWithFullSelection(spannable)
+
+    assertEquals(
+      "See ![image]($url) for details.",
+      MarkdownExtractor.getMarkdownForSelection(textView),
+    )
+  }
+
+  @Test
+  fun extractsMultipleListItemsFromFullSelection() {
+    val markdown =
+      extractFromFullSelection(
+        document(
+          unorderedList(
+            listItem(paragraph(text("Alpha"))),
+            listItem(paragraph(text("Beta"))),
+          ),
+        ),
+      )
+
+    assertEquals("- Alpha\n- Beta", markdown)
+  }
+
+  @Test
+  fun extractsBlockquoteWithFormattedText() {
+    val spannable =
+      render(
+        document(
+          blockquote(
+            paragraph(
+              text("Quote with "),
+              strong(text("bold")),
+              text(" text."),
+            ),
+          ),
+        ),
+      )
+    val start = indexOf(spannable, "Quote with ")
+    val end = spannable.indexOf(" text.") + " text.".length
+    val textView = createTextViewWithSelection(spannable, start, end)
+
+    assertEquals("> Quote with **bold** text.", MarkdownExtractor.getMarkdownForSelection(textView))
+  }
+
+  @Test
+  fun extractsPartialSelectionWithinParagraph() {
+    val spannable = render(document(paragraph(text("Hello world"))))
+    val textView = createTextViewWithSelection(spannable, 0, 5)
+
+    assertEquals("Hello", MarkdownExtractor.getMarkdownForSelection(textView))
+  }
+
+  @Test
+  fun extractsLinkWithinBoldContext() {
+    assertEquals(
+      "[link text](https://example.com)",
+      extractSelectingText(
+        document(
+          paragraph(
+            link("https://example.com", text("link text")),
+          ),
+        ),
+        "link text",
+      ),
+    )
+  }
+}

--- a/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/test/MarkdownExtractorTestSupport.kt
+++ b/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/test/MarkdownExtractorTestSupport.kt
@@ -1,0 +1,101 @@
+package com.swmansion.enriched.markdown.test
+
+import android.text.Selection
+import android.text.Spannable
+import android.text.SpannableString
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import com.swmansion.enriched.markdown.EnrichedMarkdownText
+import com.swmansion.enriched.markdown.parser.MarkdownASTNode
+import com.swmansion.enriched.markdown.utils.text.conversion.MarkdownExtractor
+
+object MarkdownExtractorTestSupport {
+  fun render(document: MarkdownASTNode): SpannableString = MarkdownRenderTestSupport.render(document)
+
+  fun createTextViewWithSelection(
+    spannable: SpannableString,
+    selectionStart: Int,
+    selectionEnd: Int,
+  ): TextView {
+    val textView = TextView(ApplicationProvider.getApplicationContext())
+    textView.setTextIsSelectable(true)
+    textView.setText(spannable, TextView.BufferType.SPANNABLE)
+    val selectableText = textView.text as Spannable
+    Selection.setSelection(selectableText, selectionStart, selectionEnd)
+    return textView
+  }
+
+  fun createTextViewWithSelection(
+    document: MarkdownASTNode,
+    selectionStart: Int,
+    selectionEnd: Int,
+  ): TextView = createTextViewWithSelection(render(document), selectionStart, selectionEnd)
+
+  fun createTextViewWithFullSelection(spannable: SpannableString): TextView =
+    createTextViewWithSelection(spannable, 0, spannable.length)
+
+  fun createTextViewWithFullSelection(document: MarkdownASTNode): TextView {
+    val spannable = render(document)
+    return createTextViewWithFullSelection(spannable)
+  }
+
+  fun createTextViewSelectingText(
+    document: MarkdownASTNode,
+    selectedText: String,
+  ): TextView {
+    val spannable = render(document)
+    val start = spannable.indexOf(selectedText)
+    require(start >= 0) { "Rendered text does not contain \"$selectedText\": \"$spannable\"" }
+    return createTextViewWithSelection(spannable, start, start + selectedText.length)
+  }
+
+  fun extractFromSelection(
+    document: MarkdownASTNode,
+    selectionStart: Int,
+    selectionEnd: Int,
+  ): String? {
+    val textView = createTextViewWithSelection(document, selectionStart, selectionEnd)
+    return MarkdownExtractor.getMarkdownForSelection(textView)
+  }
+
+  fun extractFromFullSelection(document: MarkdownASTNode): String? {
+    val textView = createTextViewWithFullSelection(document)
+    return MarkdownExtractor.getMarkdownForSelection(textView)
+  }
+
+  fun extractSelectingText(
+    document: MarkdownASTNode,
+    selectedText: String,
+  ): String? {
+    val textView = createTextViewSelectingText(document, selectedText)
+    return MarkdownExtractor.getMarkdownForSelection(textView)
+  }
+
+  fun createEnrichedMarkdownTextWithFullSelection(
+    originalMarkdown: String,
+    rendered: SpannableString,
+  ): EnrichedMarkdownText {
+    val textView = EnrichedMarkdownText(ApplicationProvider.getApplicationContext())
+    textView.setTextIsSelectable(true)
+    textView.text = rendered
+    setCurrentMarkdown(textView, originalMarkdown)
+    val selectableText = textView.text as Spannable
+    Selection.setSelection(selectableText, 0, selectableText.length)
+    return textView
+  }
+
+  private fun setCurrentMarkdown(
+    textView: EnrichedMarkdownText,
+    markdown: String,
+  ) {
+    val field = EnrichedMarkdownText::class.java.getDeclaredField("currentMarkdown")
+    field.isAccessible = true
+    field.set(textView, markdown)
+  }
+
+  fun indexOf(spannable: Spannable, text: String): Int {
+    val index = spannable.indexOf(text)
+    require(index >= 0) { "Rendered text does not contain \"$text\": \"$spannable\"" }
+    return index
+  }
+}

--- a/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionModeTest.kt
+++ b/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionModeTest.kt
@@ -1,0 +1,226 @@
+package com.swmansion.enriched.markdown.utils.text.view
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.view.ActionMode
+import android.view.Menu
+import android.widget.TextView
+import androidx.appcompat.view.menu.MenuBuilder
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewSelectingText
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewWithFullSelection
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewWithSelection
+import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.render
+import com.swmansion.enriched.markdown.test.TestAstFactory.document
+import com.swmansion.enriched.markdown.test.TestAstFactory.image
+import com.swmansion.enriched.markdown.test.TestAstFactory.paragraph
+import com.swmansion.enriched.markdown.test.TestAstFactory.strong
+import com.swmansion.enriched.markdown.test.TestAstFactory.text
+import com.swmansion.enriched.markdown.utils.text.conversion.MarkdownExtractor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [28])
+class SelectionActionModeTest {
+  private val context = ApplicationProvider.getApplicationContext<Context>()
+
+  @Test
+  fun copyAsMarkdownMenuItemAppearsWhenSelectionExists() {
+    val textView =
+      createTextViewSelectingText(
+        document(paragraph(text("Copy me"))),
+        "Copy me",
+      )
+    val menu = prepareMenu(textView)
+
+    assertNotNull(findMenuItem(menu, "Copy as Markdown"))
+  }
+
+  @Test
+  fun copyAsMarkdownMenuItemHiddenWhenDisabled() {
+    val textView =
+      createTextViewSelectingText(
+        document(paragraph(text("Copy me"))),
+        "Copy me",
+      )
+    val menu =
+      prepareMenu(
+        textView,
+        SelectionMenuConfig(copyAsMarkdown = false),
+      )
+
+    assertNull(findMenuItem(menu, "Copy as Markdown"))
+  }
+
+  @Test
+  fun copyAsMarkdownUsesCustomLabel() {
+    val textView =
+      createTextViewSelectingText(
+        document(paragraph(text("Copy me"))),
+        "Copy me",
+      )
+    val menu =
+      prepareMenu(
+        textView,
+        SelectionMenuConfig(copyAsMarkdownLabel = "Export Markdown"),
+      )
+
+    assertNotNull(findMenuItem(menu, "Export Markdown"))
+    assertNull(findMenuItem(menu, "Copy as Markdown"))
+  }
+
+  @Test
+  fun clickingCopyAsMarkdownCopiesMarkdownToClipboard() {
+    val textView =
+      createTextViewSelectingText(
+        document(
+          paragraph(
+            text("Value: "),
+            strong(text("42")),
+          ),
+        ),
+        "42",
+      )
+    val callback = createSelectionActionModeCallback(textView)
+    val menu = prepareMenu(textView, callback = callback)
+    val copyItem = findMenuItem(menu, "Copy as Markdown")
+
+    assertTrue(callback.onActionItemClicked(null, copyItem))
+
+    assertEquals("**42**", getClipboardText())
+  }
+
+  @Test
+  fun clickingPlainCopyCopiesPlainTextToClipboard() {
+    val textView =
+      createTextViewSelectingText(
+        document(
+          paragraph(
+            text("Value: "),
+            strong(text("42")),
+          ),
+        ),
+        "42",
+      )
+    val callback = createSelectionActionModeCallback(textView)
+    val menu = MenuBuilder(context)
+    menu.add(0, android.R.id.copy, 0, "Copy")
+
+    assertTrue(callback.onActionItemClicked(null, menu.findItem(android.R.id.copy)))
+
+    assertEquals("42", getClipboardText())
+  }
+
+  @Test
+  fun copyImageUrlMenuItemAppearsForHttpImageSelection() {
+    val url = "https://example.com/image.png"
+    val spannable = render(document(paragraph(image(url))))
+    val imageStart = spannable.indexOf('\uFFFC')
+    val textView = createTextViewWithSelection(spannable, imageStart, imageStart + 1)
+    val menu = prepareMenu(textView)
+
+    assertNotNull(findMenuItem(menu, "Copy Image URL"))
+  }
+
+  @Test
+  fun copyImageUrlMenuItemHiddenWhenDisabled() {
+    val url = "https://example.com/image.png"
+    val spannable = render(document(paragraph(image(url))))
+    val imageStart = spannable.indexOf('\uFFFC')
+    val textView = createTextViewWithSelection(spannable, imageStart, imageStart + 1)
+    val menu =
+      prepareMenu(
+        textView,
+        SelectionMenuConfig(copyImageUrl = false),
+      )
+
+    assertNull(findMenuItem(menu, "Copy Image URL"))
+  }
+
+  @Test
+  fun clickingCopyImageUrlCopiesUrlToClipboard() {
+    val url = "https://example.com/image.png"
+    val spannable = render(document(paragraph(image(url))))
+    val imageStart = spannable.indexOf('\uFFFC')
+    val textView = createTextViewWithSelection(spannable, imageStart, imageStart + 1)
+    val callback = createSelectionActionModeCallback(textView)
+    val menu = prepareMenu(textView, callback = callback)
+    val copyUrlItem = findMenuItem(menu, "Copy Image URL")
+
+    assertTrue(callback.onActionItemClicked(null, copyUrlItem))
+
+    assertEquals(url, getClipboardText())
+  }
+
+  @Test
+  fun copyImageUrlMenuShowsCountForMultipleImages() {
+    val firstUrl = "https://example.com/first.png"
+    val secondUrl = "https://example.com/second.png"
+    val spannable =
+      render(
+        document(
+          paragraph(
+            image(firstUrl),
+            text(" and "),
+            image(secondUrl),
+          ),
+        ),
+      )
+    val textView = createTextViewWithFullSelection(spannable)
+    val menu = prepareMenu(textView)
+
+    assertNotNull(findMenuItem(menu, "Copy 2 Image URLs"))
+  }
+
+  @Test
+  fun copyAsMarkdownDoesNothingForEmptySelection() {
+    val spannable = render(document(paragraph(text("Hello"))))
+    val textView = createTextViewWithSelection(spannable, 2, 2)
+    val callback = createSelectionActionModeCallback(textView)
+    val menu = prepareMenu(textView, callback = callback)
+
+    assertNull(findMenuItem(menu, "Copy as Markdown"))
+    assertFalse(copyMarkdownDirectly(textView))
+    assertNull(getClipboardText())
+  }
+
+  private fun prepareMenu(
+    textView: TextView,
+    config: SelectionMenuConfig = SelectionMenuConfig(),
+    callback: ActionMode.Callback =
+      createSelectionActionModeCallback(
+        textView,
+        getSelectionMenuConfig = { config },
+      ),
+  ): Menu {
+    val menu = MenuBuilder(context)
+    callback.onPrepareActionMode(null, menu)
+    return menu
+  }
+
+  private fun findMenuItem(
+    menu: Menu,
+    title: String,
+  ) = (0 until menu.size()).map { menu.getItem(it) }.find { it.title.toString() == title }
+
+  private fun getClipboardText(): String? {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    return clipboard.primaryClip?.getItemAt(0)?.text?.toString()
+  }
+
+  private fun copyMarkdownDirectly(textView: TextView): Boolean {
+    val markdown = MarkdownExtractor.getMarkdownForSelection(textView) ?: return false
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText("Markdown", markdown))
+    return true
+  }
+}


### PR DESCRIPTION
### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
- Open example app, go to Text example.
- Copy some text and image as markdown
- Paste somewhere
- Verify that the pasted text has correct markdown

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

