### PR TITLE
feat(android): add copy as html feature

### DIFF
--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/common/layout/RTLUtils.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/common/layout/RTLUtils.kt
@@ -1,0 +1,6 @@
+package com.swmansion.enriched.markdown.utils.common.layout
+
+import android.content.res.Resources
+import android.view.View
+
+fun Resources.isLayoutRTL(): Boolean = configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/conversion/HTMLGenerator.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/conversion/HTMLGenerator.kt
@@ -1,0 +1,866 @@
+package com.swmansion.enriched.markdown.utils.text.conversion
+
+import android.graphics.Typeface
+import android.text.Spannable
+import android.text.style.StyleSpan
+import android.text.style.UnderlineSpan
+import com.swmansion.enriched.markdown.spans.BlockquoteSpan
+import com.swmansion.enriched.markdown.spans.CodeBlockSpan
+import com.swmansion.enriched.markdown.spans.CodeSpan
+import com.swmansion.enriched.markdown.spans.EmphasisSpan
+import com.swmansion.enriched.markdown.spans.HeadingSpan
+import com.swmansion.enriched.markdown.spans.ImageSpan
+import com.swmansion.enriched.markdown.spans.LinkSpan
+import com.swmansion.enriched.markdown.spans.OrderedListSpan
+import com.swmansion.enriched.markdown.spans.StrongSpan
+import com.swmansion.enriched.markdown.spans.UnorderedListSpan
+import com.swmansion.enriched.markdown.styles.StyleConfig
+
+/** Generates semantic HTML with inline styles from Spannable text. */
+object HTMLGenerator {
+  private const val OBJECT_REPLACEMENT_CHAR = '\uFFFC'
+
+  /** Pre-computed styles to avoid repeated StyleConfig method calls. */
+  private class CachedStyles(
+    style: StyleConfig,
+    private val fontDensity: Float,
+    private val dimDensity: Float,
+  ) {
+    // Convert device pixels back to CSS pixels
+    private fun fontPx(px: Float) = (px / fontDensity).toInt()
+
+    private fun dimPx(px: Float) = (px / dimDensity).toInt()
+
+    // Paragraph
+    val paragraphColor: String
+    val paragraphFontSize: Int
+    val paragraphMarginBottom: Int
+
+    // Code block
+    val codeBlockColor: String
+    val codeBlockBgColor: String
+    val codeBlockFontSize: Int
+    val codeBlockPadding: Int
+    val codeBlockBorderRadius: Int
+    val codeBlockMarginBottom: Int
+
+    // Inline code
+    val codeColor: String
+    val codeBgColor: String
+
+    // Blockquote
+    val blockquoteColor: String
+    val blockquoteBgColor: String
+    val blockquoteBorderColor: String
+    val blockquoteBorderWidth: Int
+    val blockquoteGapWidth: Int
+    val blockquoteMarginBottom: Int
+    val blockquoteFontSize: Int
+
+    // List
+    val listColor: String
+    val listFontSize: Int
+    val listMarginBottom: Int
+    val listMarginLeft: Int
+
+    // Link
+    val linkFontFamily: String
+    val linkColor: String
+    val linkUnderline: Boolean
+
+    // Strong/Emphasis
+    val strongColor: String?
+    val emphasisColor: String?
+
+    // Image
+    val imageMarginBottom: Int
+    val imageBorderRadius: Int
+
+    // Fixed HTML values (not from StyleConfig)
+    val blockquotePaddingVertical = "8px"
+    val blockquoteBorderRadiusCorners = "border-start-end-radius: 8px; border-end-end-radius: 8px"
+    val blockquoteNestedMargin = "8px 0 0 0"
+    val blockquoteParagraphMargin = "0 0 4px 0"
+    val inlineImageHeight = "1.2em"
+    val inlineImageVerticalAlign = "-0.2em"
+    val codePadding = "2px 4px"
+    val codeBorderRadius = "4px"
+    val codeFontSize = "1em"
+
+    // Headings (array for O(1) lookup)
+    val headingFontSizes: IntArray
+    val headingFontWeights: Array<String>
+    val headingColors: Array<String>
+    val headingMarginBottoms: IntArray
+
+    init {
+      // Paragraph
+      val pStyle = style.paragraphStyle
+      paragraphColor = colorToCSS(pStyle.color)
+      paragraphFontSize = fontPx(pStyle.fontSize)
+      paragraphMarginBottom = dimPx(pStyle.marginBottom)
+
+      // Code block
+      val cbStyle = style.codeBlockStyle
+      codeBlockColor = colorToCSS(cbStyle.color)
+      codeBlockBgColor = colorToCSS(cbStyle.backgroundColor)
+      codeBlockFontSize = fontPx(cbStyle.fontSize)
+      codeBlockPadding = dimPx(cbStyle.padding)
+      codeBlockBorderRadius = dimPx(cbStyle.borderRadius)
+      codeBlockMarginBottom = dimPx(cbStyle.marginBottom)
+
+      // Inline code
+      val cStyle = style.codeStyle
+      codeColor = colorToCSS(cStyle.color)
+      codeBgColor = colorToCSS(cStyle.backgroundColor)
+
+      // Blockquote
+      val bqStyle = style.blockquoteStyle
+      blockquoteColor = colorToCSS(bqStyle.color)
+      blockquoteBgColor = colorToCSS(bqStyle.backgroundColor ?: 0)
+      blockquoteBorderColor = colorToCSS(bqStyle.borderColor)
+      blockquoteBorderWidth = dimPx(bqStyle.borderWidth)
+      blockquoteGapWidth = dimPx(bqStyle.gapWidth)
+      blockquoteMarginBottom = dimPx(bqStyle.marginBottom)
+      blockquoteFontSize = fontPx(bqStyle.fontSize)
+
+      // List
+      val lStyle = style.listStyle
+      listColor = colorToCSS(lStyle.color)
+      listFontSize = fontPx(lStyle.fontSize)
+      listMarginBottom = dimPx(lStyle.marginBottom)
+      listMarginLeft = dimPx(lStyle.marginLeft)
+
+      // Link
+      linkFontFamily = style.linkStyle.fontFamily
+      linkColor = colorToCSS(style.linkStyle.color)
+      linkUnderline = style.linkStyle.underline
+
+      // Strong/Emphasis (nullable for inherit)
+      val sc = style.strongStyle.color
+      strongColor = if (sc != null && sc != 0) colorToCSS(sc) else null
+      val ec = style.emphasisStyle.color
+      emphasisColor = if (ec != null && ec != 0) colorToCSS(ec) else null
+
+      // Image
+      val imgStyle = style.imageStyle
+      imageMarginBottom = dimPx(imgStyle.marginBottom)
+      imageBorderRadius = dimPx(imgStyle.borderRadius)
+
+      // Headings (1-6, index 0-5)
+      headingFontSizes = IntArray(6)
+      headingFontWeights = Array(6) { "" }
+      headingColors = Array(6) { "" }
+      headingMarginBottoms = IntArray(6)
+
+      for (level in 1..6) {
+        val hStyle = style.headingStyles[level]!!
+        val idx = level - 1
+        headingFontSizes[idx] = fontPx(hStyle.fontSize)
+        headingFontWeights[idx] = fontWeightToCSS(hStyle.fontWeight)
+        headingColors[idx] = colorToCSS(hStyle.color)
+        headingMarginBottoms[idx] = dimPx(hStyle.marginBottom)
+      }
+    }
+
+    companion object {
+      private fun colorToCSS(color: Int): String {
+        if (color == 0) return "inherit"
+        val alpha = (color shr 24) and 0xFF
+        val red = (color shr 16) and 0xFF
+        val green = (color shr 8) and 0xFF
+        val blue = color and 0xFF
+
+        return if (alpha < 255) {
+          "rgba($red, $green, $blue, ${alpha / 255f})"
+        } else {
+          String.format("#%02X%02X%02X", red, green, blue)
+        }
+      }
+
+      private fun fontWeightToCSS(fontWeight: String): String =
+        when {
+          fontWeight.equals("bold", ignoreCase = true) -> "700"
+          fontWeight.equals("semibold", ignoreCase = true) -> "600"
+          fontWeight.equals("medium", ignoreCase = true) -> "500"
+          fontWeight.isEmpty() || fontWeight.equals("normal", ignoreCase = true) -> "normal"
+          else -> fontWeight
+        }
+    }
+  }
+
+  private class GeneratorState {
+    var inCodeBlock = false
+    var previousWasCodeBlock = false
+    val codeBlockLines = ArrayList<String>(16) // Pre-sized
+
+    var inBlockquote = false
+    var blockquoteDepth = -1
+    var previousWasBlockquote = false
+
+    var listDepth = -1
+    val openListTypes = ArrayList<Boolean>(4) // true = ol, false = ul
+  }
+
+  // Paragraph type constants (H1-H6 = 1-6 directly from HeadingSpan.level)
+  private const val TYPE_NORMAL = 0
+  private const val TYPE_H1 = 1
+  private const val TYPE_H6 = 6
+  private const val TYPE_CODE_BLOCK = 7
+  private const val TYPE_BLOCKQUOTE = 8
+  private const val TYPE_ORDERED_LIST = 9
+  private const val TYPE_UNORDERED_LIST = 10
+
+  private data class ParagraphInfo(
+    val start: Int,
+    val end: Int,
+    val type: Int,
+    val depth: Int = 0,
+  )
+
+  fun generateHTML(
+    text: Spannable,
+    style: StyleConfig,
+    scaledDensity: Float = 1f,
+    density: Float = 1f,
+    isRTL: Boolean = false,
+  ): String {
+    if (text.isEmpty()) return "<html></html>"
+
+    // Pre-cache all styles (single allocation)
+    val styles = CachedStyles(style, scaledDensity, density)
+    val state = GeneratorState()
+
+    // Estimate capacity (average 2x text length)
+    val html = StringBuilder(text.length * 2)
+    if (isRTL) {
+      html.append("<html dir=\"rtl\">")
+      html.append("<div dir=\"rtl\" style=\"direction: rtl; text-align: right;\">")
+    } else {
+      html.append("<html>")
+    }
+
+    // Collect paragraphs
+    val paragraphs = collectParagraphs(text)
+
+    for (para in paragraphs) {
+      processParagraph(html, text, para, styles, state)
+    }
+
+    closeRemainingContainers(html, state, styles)
+    if (isRTL) {
+      html.append("</div>")
+    }
+    html.append("</html>")
+
+    return html.toString()
+  }
+
+  private fun processParagraph(
+    html: StringBuilder,
+    text: Spannable,
+    para: ParagraphInfo,
+    styles: CachedStyles,
+    state: GeneratorState,
+  ) {
+    val paraText = text.subSequence(para.start, para.end).toString().trimEnd('\n')
+
+    // Handle empty paragraphs
+    if (paraText.isEmpty() && para.type == TYPE_NORMAL) {
+      closeAllBlockquotes(html, state)
+      state.previousWasBlockquote = false
+      return
+    }
+
+    // Get content range (trim trailing newline)
+    val contentEnd = if (para.end > para.start && text[para.end - 1] == '\n') para.end - 1 else para.end
+    val isCodeBlock = para.type == TYPE_CODE_BLOCK
+    val inlineContent = generateInlineHTML(text, para.start, contentEnd, styles, isCodeBlock)
+
+    // Handle different paragraph types
+    when (para.type) {
+      TYPE_CODE_BLOCK -> handleCodeBlock(inlineContent, state)
+      TYPE_BLOCKQUOTE -> handleBlockquote(html, inlineContent, para, styles, state)
+      TYPE_ORDERED_LIST, TYPE_UNORDERED_LIST -> handleList(html, inlineContent, para, styles, state)
+      in TYPE_H1..TYPE_H6 -> handleHeading(html, inlineContent, para.type, styles, state)
+      else -> handleNormalParagraph(html, inlineContent, styles, state)
+    }
+  }
+
+  private fun handleCodeBlock(
+    content: String,
+    state: GeneratorState,
+  ) {
+    if (!state.inCodeBlock) {
+      state.inCodeBlock = true
+      state.codeBlockLines.clear()
+    }
+
+    state.codeBlockLines.add(content.trimStart())
+    state.previousWasCodeBlock = true
+    state.previousWasBlockquote = false
+  }
+
+  private fun outputCodeBlock(
+    html: StringBuilder,
+    lines: List<String>,
+    styles: CachedStyles,
+  ) {
+    if (lines.isEmpty()) return
+
+    html
+      .append("<pre dir=\"ltr\" style=\"background-color: ")
+      .append(styles.codeBlockBgColor)
+      .append("; padding: ")
+      .append(styles.codeBlockPadding)
+      .append("px; border-radius: ")
+      .append(styles.codeBlockBorderRadius)
+      .append("px; margin: 0 0 ")
+      .append(styles.codeBlockMarginBottom)
+      .append("px 0; overflow-x: auto; text-align: left;\"><code style=\"font-family: Menlo, Monaco, Consolas, monospace; font-size: ")
+      .append(styles.codeBlockFontSize)
+      .append("px; color: ")
+      .append(styles.codeBlockColor)
+      .append(";\">")
+
+    for (i in lines.indices) {
+      if (i > 0) html.append('\n')
+      html.append(lines[i])
+    }
+
+    html.append("</code></pre>")
+  }
+
+  private fun handleBlockquote(
+    html: StringBuilder,
+    content: String,
+    para: ParagraphInfo,
+    styles: CachedStyles,
+    state: GeneratorState,
+  ) {
+    closeCodeBlockIfOpen(html, state, styles)
+
+    val depth = para.depth
+
+    // Reset if coming from non-blockquote content
+    if (!state.previousWasBlockquote && state.inBlockquote) {
+      closeAllBlockquotes(html, state)
+    }
+
+    while (state.blockquoteDepth > depth) {
+      html.append("</blockquote>")
+      state.blockquoteDepth--
+    }
+
+    while (state.blockquoteDepth < depth) {
+      state.blockquoteDepth++
+      state.inBlockquote = true
+
+      if (state.blockquoteDepth == 0) {
+        html
+          .append("<blockquote style=\"background-color: ")
+          .append(styles.blockquoteBgColor)
+          .append("; border-inline-start: ")
+          .append(styles.blockquoteBorderWidth)
+          .append("px solid ")
+          .append(styles.blockquoteBorderColor)
+          .append("; padding: ")
+          .append(styles.blockquotePaddingVertical)
+          .append(" ")
+          .append(styles.blockquoteGapWidth)
+          .append("px; margin: 0 0 ")
+          .append(styles.blockquoteMarginBottom)
+          .append("px 0; ")
+          .append(styles.blockquoteBorderRadiusCorners)
+          .append(";\">")
+      } else {
+        html
+          .append("<blockquote style=\"border-inline-start: ")
+          .append(styles.blockquoteBorderWidth)
+          .append("px solid ")
+          .append(styles.blockquoteBorderColor)
+          .append("; padding-inline-start: ")
+          .append(styles.blockquoteGapWidth)
+          .append("px; margin: ")
+          .append(styles.blockquoteNestedMargin)
+          .append(";\">")
+      }
+    }
+
+    html
+      .append("<p style=\"margin: ")
+      .append(styles.blockquoteParagraphMargin)
+      .append("; color: ")
+      .append(styles.blockquoteColor)
+      .append("; font-size: ")
+      .append(styles.blockquoteFontSize)
+      .append("px;\">")
+      .append(content)
+      .append("</p>")
+
+    state.previousWasBlockquote = true
+    state.previousWasCodeBlock = false
+  }
+
+  private fun handleList(
+    html: StringBuilder,
+    content: String,
+    para: ParagraphInfo,
+    styles: CachedStyles,
+    state: GeneratorState,
+  ) {
+    closeCodeBlockIfOpen(html, state, styles)
+    closeAllBlockquotes(html, state)
+
+    val depth = para.depth
+    val isOrdered = para.type == TYPE_ORDERED_LIST
+
+    // Close lists to shallower depth
+    while (state.listDepth > depth) {
+      html.append(if (state.openListTypes.lastOrNull() == true) "</ol>" else "</ul>")
+      if (state.openListTypes.isNotEmpty()) state.openListTypes.removeAt(state.openListTypes.lastIndex)
+      state.listDepth--
+    }
+
+    // Handle list type change at same depth (ul <-> ol)
+    if (state.listDepth == depth && state.openListTypes.isNotEmpty()) {
+      if (state.openListTypes.last() != isOrdered) {
+        html.append(if (state.openListTypes.last()) "</ol>" else "</ul>")
+        state.openListTypes.removeAt(state.openListTypes.lastIndex)
+        state.listDepth--
+      }
+    }
+
+    // Open lists to deeper depth
+    while (state.listDepth < depth) {
+      state.listDepth++
+      val marginStyle =
+        if (state.listDepth == 0) {
+          "margin: 0 0 ${styles.paragraphMarginBottom}px 0; "
+        } else {
+          "margin: 0; "
+        }
+
+      if (isOrdered) {
+        html
+          .append("<ol style=\"")
+          .append(marginStyle)
+          .append("padding-inline-start: ")
+          .append(styles.listMarginLeft)
+          .append("px;\">")
+        state.openListTypes.add(true)
+      } else {
+        html
+          .append("<ul style=\"")
+          .append(marginStyle)
+          .append("padding-inline-start: ")
+          .append(styles.listMarginLeft)
+          .append("px; list-style-type: disc;\">")
+        state.openListTypes.add(false)
+      }
+    }
+
+    html
+      .append("<li style=\"margin-bottom: ")
+      .append(styles.listMarginBottom)
+      .append("px; color: ")
+      .append(styles.listColor)
+      .append("; font-size: ")
+      .append(styles.listFontSize)
+      .append("px;\">")
+
+    html
+      .append(content)
+      .append("</li>")
+
+    state.previousWasBlockquote = false
+    state.previousWasCodeBlock = false
+  }
+
+  private fun handleHeading(
+    html: StringBuilder,
+    content: String,
+    type: Int,
+    styles: CachedStyles,
+    state: GeneratorState,
+  ) {
+    closeCodeBlockIfOpen(html, state, styles)
+    closeAllBlockquotes(html, state)
+    closeListsIfOpen(html, state)
+
+    val level = type // TYPE_H1..TYPE_H6 = 1..6
+    val idx = level - 1
+
+    html
+      .append("<h")
+      .append(level)
+      .append(" style=\"font-size: ")
+      .append(styles.headingFontSizes[idx])
+      .append("px; font-weight: ")
+      .append(styles.headingFontWeights[idx])
+      .append("; color: ")
+      .append(styles.headingColors[idx])
+      .append("; margin: 0 0 ")
+      .append(styles.headingMarginBottoms[idx])
+      .append("px 0;\">")
+      .append(content)
+      .append("</h")
+      .append(level)
+      .append('>')
+
+    state.previousWasBlockquote = false
+    state.previousWasCodeBlock = false
+  }
+
+  private fun handleNormalParagraph(
+    html: StringBuilder,
+    content: String,
+    styles: CachedStyles,
+    state: GeneratorState,
+  ) {
+    closeCodeBlockIfOpen(html, state, styles)
+    closeAllBlockquotes(html, state)
+    closeListsIfOpen(html, state)
+
+    html
+      .append("<p style=\"margin: 0 0 ")
+      .append(styles.paragraphMarginBottom)
+      .append("px 0; color: ")
+      .append(styles.paragraphColor)
+      .append("; font-size: ")
+      .append(styles.paragraphFontSize)
+      .append("px;\">")
+      .append(content)
+      .append("</p>")
+
+    state.previousWasBlockquote = false
+    state.previousWasCodeBlock = false
+  }
+
+  private fun closeCodeBlockIfOpen(
+    html: StringBuilder,
+    state: GeneratorState,
+    styles: CachedStyles,
+  ) {
+    if (state.inCodeBlock) {
+      state.inCodeBlock = false
+      outputCodeBlock(html, state.codeBlockLines, styles)
+      state.codeBlockLines.clear()
+    }
+  }
+
+  private fun closeAllBlockquotes(
+    html: StringBuilder,
+    state: GeneratorState,
+  ) {
+    while (state.blockquoteDepth >= 0) {
+      html.append("</blockquote>")
+      state.blockquoteDepth--
+    }
+    state.inBlockquote = false
+  }
+
+  private fun closeListsIfOpen(
+    html: StringBuilder,
+    state: GeneratorState,
+  ) {
+    while (state.openListTypes.isNotEmpty()) {
+      html.append(if (state.openListTypes.last()) "</ol>" else "</ul>")
+      state.openListTypes.removeAt(state.openListTypes.lastIndex)
+    }
+    state.listDepth = -1
+  }
+
+  private fun closeRemainingContainers(
+    html: StringBuilder,
+    state: GeneratorState,
+    styles: CachedStyles,
+  ) {
+    closeCodeBlockIfOpen(html, state, styles)
+    closeAllBlockquotes(html, state)
+    closeListsIfOpen(html, state)
+  }
+
+  private fun generateInlineHTML(
+    text: Spannable,
+    start: Int,
+    end: Int,
+    styles: CachedStyles,
+    isCodeBlock: Boolean,
+  ): String {
+    val html = StringBuilder(end - start + 32)
+    var i = start
+
+    while (i < end) {
+      val char = text[i]
+
+      when {
+        char == '\n' && i == end - 1 -> {
+          i++
+        }
+
+        char == OBJECT_REPLACEMENT_CHAR -> {
+          appendReplacementChar(html, text, i, styles)
+          i++
+        }
+
+        else -> {
+          val segmentEnd = minOf(text.nextSpanTransition(i, end, Any::class.java), end)
+          val segmentText = text.subSequence(i, segmentEnd).toString()
+
+          if (segmentText.isNotEmpty() && segmentText != "\n") {
+            appendStyledSegment(html, text, i, segmentEnd, segmentText, styles, isCodeBlock)
+          }
+          i = segmentEnd
+        }
+      }
+    }
+
+    return html.toString()
+  }
+
+  private fun appendReplacementChar(
+    html: StringBuilder,
+    text: Spannable,
+    pos: Int,
+    styles: CachedStyles,
+  ) {
+    val imageSpans = text.getSpans(pos, pos + 1, ImageSpan::class.java)
+    if (imageSpans.isNotEmpty()) {
+      val imgSpan = imageSpans[0]
+
+      if (imgSpan.isInline) {
+        html.append("<img src=\"")
+        escapeHTMLTo(html, imgSpan.imageUrl)
+        html
+          .append("\" style=\"height: ")
+          .append(styles.inlineImageHeight)
+          .append("; width: auto; vertical-align: ")
+          .append(styles.inlineImageVerticalAlign)
+          .append(";\">")
+      } else {
+        html
+          .append("</p><div style=\"margin-bottom: ")
+          .append(styles.imageMarginBottom)
+          .append("px;\"><img src=\"")
+        escapeHTMLTo(html, imgSpan.imageUrl)
+        html
+          .append("\" style=\"max-width: 100%; border-radius: ")
+          .append(styles.imageBorderRadius)
+          .append("px;\"></div><p>")
+      }
+      return
+    }
+
+    val mathLatex = extractMathLatex(text, pos, pos + 1)
+    if (mathLatex != null) {
+      html
+        .append("<code style=\"background-color: ")
+        .append(styles.codeBgColor)
+        .append("; color: ")
+        .append(styles.codeColor)
+        .append("; padding: ")
+        .append(styles.codePadding)
+        .append("; border-radius: ")
+        .append(styles.codeBorderRadius)
+        .append("; font-size: ")
+        .append(styles.codeFontSize)
+        .append("; font-family: Menlo, Monaco, Consolas, monospace;\">")
+      escapeHTMLTo(html, mathLatex)
+      html.append("</code>")
+    }
+  }
+
+  private fun appendStyledSegment(
+    html: StringBuilder,
+    text: Spannable,
+    start: Int,
+    end: Int,
+    content: String,
+    styles: CachedStyles,
+    isCodeBlock: Boolean,
+  ) {
+    val strongSpans = text.getSpans(start, end, StrongSpan::class.java)
+    val styleSpans = text.getSpans(start, end, StyleSpan::class.java)
+    val emphasisSpans = text.getSpans(start, end, EmphasisSpan::class.java)
+    val underlineSpans = text.getSpans(start, end, UnderlineSpan::class.java)
+    val linkSpans = text.getSpans(start, end, LinkSpan::class.java)
+    val codeSpans = text.getSpans(start, end, CodeSpan::class.java)
+
+    val isBold =
+      strongSpans.isNotEmpty() ||
+        styleSpans.any { it.style == Typeface.BOLD || it.style == Typeface.BOLD_ITALIC }
+    val isItalic =
+      emphasisSpans.isNotEmpty() ||
+        styleSpans.any { it.style == Typeface.ITALIC || it.style == Typeface.BOLD_ITALIC }
+    val isUnderline = underlineSpans.isNotEmpty()
+    val link = linkSpans.firstOrNull()
+    val isCode = codeSpans.isNotEmpty() && !isCodeBlock
+
+    link?.let {
+      html.append("<a href=\"")
+      escapeHTMLTo(html, it.url)
+      html
+        .append("\" style=\"color: ")
+        .append(styles.linkColor)
+        .append("; text-decoration: ")
+        .append(if (styles.linkUnderline) "underline" else "none")
+      if (styles.linkFontFamily.isNotEmpty()) {
+        html.append("; font-family: '").append(styles.linkFontFamily).append("'")
+      }
+      html.append(";\">")
+    }
+
+    if (isCode) {
+      html
+        .append("<code style=\"background-color: ")
+        .append(styles.codeBgColor)
+        .append("; color: ")
+        .append(styles.codeColor)
+        .append("; padding: ")
+        .append(styles.codePadding)
+        .append("; border-radius: ")
+        .append(styles.codeBorderRadius)
+        .append("; font-size: ")
+        .append(styles.codeFontSize)
+        .append("; font-family: Menlo, Monaco, Consolas, monospace;\">")
+    }
+
+    if (isBold) {
+      if (styles.strongColor != null) {
+        html.append("<strong style=\"color: ").append(styles.strongColor).append(";\">")
+      } else {
+        html.append("<strong>")
+      }
+    }
+
+    if (isItalic) {
+      if (styles.emphasisColor != null) {
+        html.append("<em style=\"color: ").append(styles.emphasisColor).append(";\">")
+      } else {
+        html.append("<em>")
+      }
+    }
+
+    if (isUnderline && link == null) {
+      html.append("<u>")
+    }
+
+    escapeHTMLTo(html, content.trimEnd('\n'))
+
+    if (isUnderline && link == null) html.append("</u>")
+    if (isItalic) html.append("</em>")
+    if (isBold) html.append("</strong>")
+    if (isCode) html.append("</code>")
+    if (link != null) html.append("</a>")
+  }
+
+  private fun collectParagraphs(text: Spannable): ArrayList<ParagraphInfo> {
+    val string = text.toString()
+    val paragraphs = ArrayList<ParagraphInfo>(string.length / 40 + 1) // Estimate
+    var currentIndex = 0
+
+    while (currentIndex < string.length) {
+      var lineEnd = string.indexOf('\n', currentIndex)
+      if (lineEnd == -1) lineEnd = string.length else lineEnd++
+
+      val type = getParagraphType(text, currentIndex)
+      val depth = getDepthForType(text, currentIndex, type)
+
+      paragraphs.add(ParagraphInfo(currentIndex, lineEnd, type, depth))
+      currentIndex = lineEnd
+    }
+
+    return paragraphs
+  }
+
+  private fun getParagraphType(
+    text: Spannable,
+    start: Int,
+  ): Int {
+    val end = minOf(start + 1, text.length)
+
+    if (text.getSpans(start, end, CodeBlockSpan::class.java).isNotEmpty()) return TYPE_CODE_BLOCK
+
+    val headingSpans = text.getSpans(start, end, HeadingSpan::class.java)
+    if (headingSpans.isNotEmpty()) return headingSpans[0].level.coerceIn(1, 6)
+
+    if (text.getSpans(start, end, BlockquoteSpan::class.java).isNotEmpty()) return TYPE_BLOCKQUOTE
+    if (text.getSpans(start, end, OrderedListSpan::class.java).isNotEmpty()) return TYPE_ORDERED_LIST
+    if (text.getSpans(start, end, UnorderedListSpan::class.java).isNotEmpty()) return TYPE_UNORDERED_LIST
+
+    return TYPE_NORMAL
+  }
+
+  private fun getDepthForType(
+    text: Spannable,
+    start: Int,
+    type: Int,
+  ): Int {
+    val end = start + 1
+    return when (type) {
+      TYPE_BLOCKQUOTE -> text.getSpans(start, end, BlockquoteSpan::class.java).maxOfOrNull { it.depth } ?: 0
+      TYPE_ORDERED_LIST -> text.getSpans(start, end, OrderedListSpan::class.java).maxOfOrNull { it.depth } ?: 0
+      TYPE_UNORDERED_LIST -> text.getSpans(start, end, UnorderedListSpan::class.java).maxOfOrNull { it.depth } ?: 0
+      else -> 0
+    }
+  }
+
+  private fun colorToCSS(color: Int): String {
+    if (color == 0) return "inherit"
+    val alpha = (color shr 24) and 0xFF
+    val red = (color shr 16) and 0xFF
+    val green = (color shr 8) and 0xFF
+    val blue = color and 0xFF
+    return if (alpha < 255) "rgba($red, $green, $blue, ${alpha / 255f})" else String.format("#%02X%02X%02X", red, green, blue)
+  }
+
+  /** Fast HTML escape using single-pass character scanning. */
+  private fun escapeHTMLTo(
+    output: StringBuilder,
+    text: String,
+  ) {
+    val len = text.length
+
+    // Fast path: skip if no escaping needed
+    var needsEscape = false
+    for (i in 0 until len) {
+      val c = text[i]
+      if (c == '&' || c == '<' || c == '>' || c == '"' || c == '\'') {
+        needsEscape = true
+        break
+      }
+    }
+    if (!needsEscape) {
+      output.append(text)
+      return
+    }
+
+    for (i in 0 until len) {
+      when (val c = text[i]) {
+        '&' -> output.append("&amp;")
+        '<' -> output.append("&lt;")
+        '>' -> output.append("&gt;")
+        '"' -> output.append("&quot;")
+        '\'' -> output.append("&#39;")
+        else -> output.append(c)
+      }
+    }
+  }
+
+  private fun extractMathLatex(
+    text: android.text.Spannable,
+    start: Int,
+    end: Int,
+  ): String? {
+    return try {
+      val mathInlineSpanClass = Class.forName("com.swmansion.enriched.markdown.spans.MathInlineSpan")
+      val spans = text.getSpans(start, end, mathInlineSpanClass)
+      if (spans.isEmpty()) return null
+      val latexField = mathInlineSpanClass.getDeclaredField("latex").apply { isAccessible = true }
+      latexField.get(spans[0]) as? String
+    } catch (_: Exception) {
+      null
+    }
+  }
+}

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionMode.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionMode.kt
@@ -8,7 +8,10 @@ import android.view.ActionMode
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.TextView
+import com.swmansion.enriched.markdown.EnrichedMarkdownText
 import com.swmansion.enriched.markdown.spans.ImageSpan
+import com.swmansion.enriched.markdown.utils.common.layout.isLayoutRTL
+import com.swmansion.enriched.markdown.utils.text.conversion.HTMLGenerator
 import com.swmansion.enriched.markdown.utils.text.conversion.MarkdownExtractor
 
 private const val MENU_ITEM_COPY_MARKDOWN = 1000
@@ -21,6 +24,10 @@ data class SelectionMenuConfig(
   val copyAsMarkdownLabel: String = "",
 )
 
+/**
+ * Creates an ActionMode.Callback that adds custom copy options and
+ * overrides the default "Copy" action to include HTML for rich text support.
+ */
 fun createSelectionActionModeCallback(
   textView: TextView,
   getCustomItemTexts: () -> List<String> = { emptyList() },
@@ -84,7 +91,7 @@ fun createSelectionActionModeCallback(
 
       when (itemId) {
         android.R.id.copy -> {
-          textView.copyPlainTextToClipboard()
+          textView.copyWithHTML()
           mode?.finish()
           return true
         }
@@ -108,20 +115,40 @@ fun createSelectionActionModeCallback(
     override fun onDestroyActionMode(mode: ActionMode?) {}
   }
 
-private fun TextView.copyMarkdownToClipboard() {
-  val markdown = MarkdownExtractor.getMarkdownForSelection(this) ?: return
-  val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-  clipboard.setPrimaryClip(ClipData.newPlainText("Markdown", markdown))
-}
-
-private fun TextView.copyPlainTextToClipboard() {
+/** Copies selection as both plain text and HTML with inline styles. */
+private fun TextView.copyWithHTML() {
   val start = selectionStart
   val end = selectionEnd
   if (start < 0 || end < 0 || start >= end) return
 
-  val plainText = text.subSequence(start, end).toString()
+  val spannable = text as? Spannable ?: return
+  val selectedText = spannable.subSequence(start, end)
+  val plainText = selectedText.toString()
+
+  val styleConfig = (this as? EnrichedMarkdownText)?.markdownStyle
   val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-  clipboard.setPrimaryClip(ClipData.newPlainText("Text", plainText))
+
+  if (styleConfig != null && selectedText is Spannable) {
+    val displayMetrics = context.resources.displayMetrics
+    val isRTL = context.resources.isLayoutRTL()
+    val html =
+      HTMLGenerator.generateHTML(
+        selectedText,
+        styleConfig,
+        displayMetrics.scaledDensity,
+        displayMetrics.density,
+        isRTL,
+      )
+    clipboard.setPrimaryClip(ClipData.newHtmlText("EnrichedMarkdown", plainText, html))
+  } else {
+    clipboard.setPrimaryClip(ClipData.newPlainText("Text", plainText))
+  }
+}
+
+private fun TextView.copyMarkdownToClipboard() {
+  val markdown = MarkdownExtractor.getMarkdownForSelection(this) ?: return
+  val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+  clipboard.setPrimaryClip(ClipData.newPlainText("Markdown", markdown))
 }
 
 private fun TextView.getImageUrlsInSelection(): List<String> {

--- a/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/HTMLGeneratorTest.kt
+++ b/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/HTMLGeneratorTest.kt
@@ -1,0 +1,382 @@
+package com.swmansion.enriched.markdown
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.swmansion.enriched.markdown.test.HTMLAssertions.assertContainsHtml
+import com.swmansion.enriched.markdown.test.HTMLAssertions.assertContainsHtmlInOrder
+import com.swmansion.enriched.markdown.test.HTMLGeneratorTestSupport.generateHTML
+import com.swmansion.enriched.markdown.test.HTMLGeneratorTestSupport.generateHTMLSelectingText
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.createTextViewWithSelection
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.indexOf
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.render
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.selectedRange
+import com.swmansion.enriched.markdown.test.TestAstFactory.blockquote
+import com.swmansion.enriched.markdown.test.TestAstFactory.code
+import com.swmansion.enriched.markdown.test.TestAstFactory.codeBlock
+import com.swmansion.enriched.markdown.test.TestAstFactory.document
+import com.swmansion.enriched.markdown.test.TestAstFactory.emphasis
+import com.swmansion.enriched.markdown.test.TestAstFactory.heading
+import com.swmansion.enriched.markdown.test.TestAstFactory.image
+import com.swmansion.enriched.markdown.test.TestAstFactory.link
+import com.swmansion.enriched.markdown.test.TestAstFactory.listItem
+import com.swmansion.enriched.markdown.test.TestAstFactory.orderedList
+import com.swmansion.enriched.markdown.test.TestAstFactory.paragraph
+import com.swmansion.enriched.markdown.test.TestAstFactory.strong
+import com.swmansion.enriched.markdown.test.TestAstFactory.text
+import com.swmansion.enriched.markdown.test.TestAstFactory.unorderedList
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [28])
+class HTMLGeneratorTest {
+  @Test
+  fun returnsEmptyHtmlDocumentForEmptySelection() {
+    assertEquals("<html></html>", generateHTML("".toSpannable()))
+  }
+
+  @Test
+  fun generatesPlainParagraph() {
+    val html = generateHTMLSelectingText(document(paragraph(text("Hello CommonMark"))), "Hello CommonMark")
+
+    html.assertContainsHtml("<html>")
+    html.assertContainsHtmlInOrder("<p", "Hello CommonMark", "</p>", "</html>")
+  }
+
+  @Test
+  fun generatesBoldText() {
+    val html =
+      generateHTMLSelectingText(
+        document(
+          paragraph(
+            text("Forests cover "),
+            strong(text("31%")),
+            text(" of land."),
+          ),
+        ),
+        "31%",
+      )
+
+    html.assertContainsHtmlInOrder("<strong", "31%", "</strong>")
+  }
+
+  @Test
+  fun generatesItalicText() {
+    val html =
+      generateHTMLSelectingText(
+        document(
+          paragraph(
+            text("Over "),
+            emphasis(text("300 million years")),
+            text(" old."),
+          ),
+        ),
+        "300 million years",
+      )
+
+    html.assertContainsHtmlInOrder("<em", "300 million years", "</em>")
+  }
+
+  @Test
+  fun generatesBoldAndItalicInSameParagraph() {
+    val spannable =
+      render(
+        document(
+          paragraph(
+            text("Text with "),
+            strong(text("bold")),
+            text(" and "),
+            emphasis(text("italic")),
+            text(" styles."),
+          ),
+        ),
+      )
+    val start = indexOf(spannable, "Text with ")
+    val end = spannable.indexOf(" styles.") + " styles.".length
+    val html = generateHTML(selectedRange(spannable, start, end))
+
+    html.assertContainsHtmlInOrder("<strong", "bold", "</strong>", "<em", "italic", "</em>")
+  }
+
+  @Test
+  fun generatesInlineCode() {
+    val html =
+      generateHTMLSelectingText(
+        document(
+          paragraph(
+            text("Use "),
+            code("48 pounds"),
+            text(" per year."),
+          ),
+        ),
+        "48 pounds",
+      )
+
+    html.assertContainsHtmlInOrder("<code", "48 pounds", "</code>")
+  }
+
+  @Test
+  fun generatesLink() {
+    val html =
+      generateHTMLSelectingText(
+        document(
+          paragraph(
+            link("https://example.com", text("Example link")),
+          ),
+        ),
+        "Example link",
+      )
+
+    html.assertContainsHtmlInOrder(
+      "<a href=\"https://example.com\"",
+      "Example link",
+      "</a>",
+    )
+  }
+
+  @Test
+  fun generatesHeading() {
+    val html =
+      generateHTMLSelectingText(
+        document(
+          heading(1, text("The Hidden World of Forest Ecosystems")),
+        ),
+        "The Hidden World of Forest Ecosystems",
+      )
+
+    html.assertContainsHtmlInOrder(
+      "<h1",
+      "The Hidden World of Forest Ecosystems",
+      "</h1>",
+    )
+  }
+
+  @Test
+  fun generatesAllHeadingLevels() {
+    for (level in 1..6) {
+      val title = "Heading level $level"
+      val html = generateHTMLSelectingText(document(heading(level, text(title))), title)
+
+      html.assertContainsHtmlInOrder("<h$level", title, "</h$level>")
+    }
+  }
+
+  @Test
+  fun generatesBlockquote() {
+    val quote = "In every walk with nature, one receives far more than he seeks."
+    val html =
+      generateHTMLSelectingText(
+        document(
+          blockquote(
+            paragraph(text(quote)),
+          ),
+        ),
+        quote,
+      )
+
+    html.assertContainsHtmlInOrder("<blockquote", quote, "</blockquote>")
+  }
+
+  @Test
+  fun generatesNestedBlockquote() {
+    val innerQuote = "Inner quote"
+    val spannable =
+      render(
+        document(
+          blockquote(
+            paragraph(text("Outer quote")),
+            blockquote(
+              paragraph(text(innerQuote)),
+            ),
+          ),
+        ),
+      )
+    val start = indexOf(spannable, innerQuote)
+    val html = generateHTML(selectedRange(spannable, start, start + innerQuote.length))
+
+    html.assertContainsHtmlInOrder("<blockquote", innerQuote, "</blockquote>")
+  }
+
+  @Test
+  fun generatesUnorderedListItem() {
+    val html =
+      generateHTMLSelectingText(
+        document(
+          unorderedList(
+            listItem(paragraph(text("Climate regulation"))),
+            listItem(paragraph(text("Biodiversity"))),
+          ),
+        ),
+        "Climate regulation",
+      )
+
+    html.assertContainsHtmlInOrder("<ul", "<li", "Climate regulation", "</li>", "</ul>")
+  }
+
+  @Test
+  fun generatesOrderedListItem() {
+    val html =
+      generateHTMLSelectingText(
+        document(
+          orderedList(
+            listItem(paragraph(text("First item"))),
+            listItem(paragraph(text("Second item"))),
+          ),
+        ),
+        "First item",
+      )
+
+    html.assertContainsHtmlInOrder("<ol", "<li", "First item", "</li>", "</ol>")
+  }
+
+  @Test
+  fun generatesNestedUnorderedListItem() {
+    val nestedItem = "Nested item"
+    val spannable =
+      render(
+        document(
+          unorderedList(
+            listItem(
+              paragraph(text("Parent item")),
+              unorderedList(
+                listItem(paragraph(text(nestedItem))),
+              ),
+            ),
+          ),
+        ),
+      )
+    val start = indexOf(spannable, nestedItem)
+    val html = generateHTML(selectedRange(spannable, start, start + nestedItem.length))
+
+    html.assertContainsHtmlInOrder("<ul", "<li", nestedItem, "</li>", "</ul>")
+  }
+
+  @Test
+  fun generatesCodeBlock() {
+    val codeBlockContent =
+      """
+      fun main() {
+        println("forest")
+      }
+      """.trimIndent()
+    val spannable = render(document(codeBlock(codeBlockContent)))
+    val html = generateHTML(spannable)
+
+    html.assertContainsHtmlInOrder("<pre", "<code", "fun main()", "println", "forest", "</code>", "</pre>")
+  }
+
+  @Test
+  fun generatesInlineImage() {
+    val url = "https://example.com/forest.jpg"
+    val spannable =
+      render(
+        document(
+          paragraph(
+            text("Before "),
+            image(url),
+            text(" after"),
+          ),
+        ),
+      )
+    val imageStart = spannable.indexOf('\uFFFC')
+    val html = generateHTML(selectedRange(spannable, imageStart, imageStart + 1))
+
+    html.assertContainsHtml("<img src=\"$url\"")
+  }
+
+  @Test
+  fun generatesBlockImage() {
+    val url = "https://example.com/forest.jpg"
+    val spannable =
+      render(
+        document(
+          paragraph(
+            image(url),
+          ),
+        ),
+      )
+    val imageStart = spannable.indexOf('\uFFFC')
+    val html = generateHTML(selectedRange(spannable, imageStart, imageStart + 1))
+
+    html.assertContainsHtml("<img src=\"$url\"")
+    html.assertContainsHtml("max-width: 100%")
+  }
+
+  @Test
+  fun generatesParagraphWithInlineImageAndText() {
+    val url = "https://example.com/forest.jpg"
+    val spannable =
+      render(
+        document(
+          paragraph(
+            text("See "),
+            image(url),
+            text(" for details."),
+          ),
+        ),
+      )
+    val html = generateHTML(spannable)
+
+    html.assertContainsHtmlInOrder("See ", "<img src=\"$url\"", " for details.")
+  }
+
+  @Test
+  fun generatesMultipleListItemsFromFullSelection() {
+    val spannable =
+      render(
+        document(
+          unorderedList(
+            listItem(paragraph(text("Alpha"))),
+            listItem(paragraph(text("Beta"))),
+          ),
+        ),
+      )
+    val html = generateHTML(spannable)
+
+    html.assertContainsHtmlInOrder("<ul", "<li", "Alpha", "</li>", "<li", "Beta", "</li>", "</ul>")
+  }
+
+  @Test
+  fun generatesBlockquoteWithFormattedText() {
+    val spannable =
+      render(
+        document(
+          blockquote(
+            paragraph(
+              text("Quote with "),
+              strong(text("bold")),
+              text(" text."),
+            ),
+          ),
+        ),
+      )
+    val start = indexOf(spannable, "Quote with ")
+    val end = spannable.indexOf(" text.") + " text.".length
+    val html = generateHTML(selectedRange(spannable, start, end))
+
+    html.assertContainsHtmlInOrder("<blockquote", "<strong", "bold", "</strong>", "</blockquote>")
+  }
+
+  @Test
+  fun escapesHtmlSpecialCharacters() {
+    val html =
+      generateHTMLSelectingText(
+        document(paragraph(text("Tom & Jerry <3"))),
+        "Tom & Jerry <3",
+      )
+
+    html.assertContainsHtml("Tom &amp; Jerry &lt;3")
+  }
+
+  @Test
+  fun generatesPartialSelectionWithinParagraph() {
+    val spannable = render(document(paragraph(text("Hello world"))))
+    val textView = createTextViewWithSelection(spannable, 0, 5)
+    val html = generateHTML(textView.text.subSequence(textView.selectionStart, textView.selectionEnd) as android.text.Spannable)
+
+    html.assertContainsHtmlInOrder("<p", "Hello", "</p>")
+  }
+
+  private fun String.toSpannable() = android.text.SpannableString(this)
+}

--- a/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/MarkdownExtractorTest.kt
+++ b/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/MarkdownExtractorTest.kt
@@ -1,14 +1,14 @@
 package com.swmansion.enriched.markdown
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createEnrichedMarkdownTextWithFullSelection
-import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewSelectingText
-import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewWithFullSelection
-import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewWithSelection
 import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.extractFromFullSelection
 import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.extractSelectingText
-import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.indexOf
-import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.render
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.createEnrichedMarkdownTextWithStoredMarkdown
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.createTextViewSelectingText
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.createTextViewWithFullSelection
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.createTextViewWithSelection
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.indexOf
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.render
 import com.swmansion.enriched.markdown.test.TestAstFactory.blockquote
 import com.swmansion.enriched.markdown.test.TestAstFactory.code
 import com.swmansion.enriched.markdown.test.TestAstFactory.codeBlock
@@ -57,7 +57,7 @@ class MarkdownExtractorTest {
         ),
       )
 
-    val textView = createEnrichedMarkdownTextWithFullSelection(original, rendered)
+    val textView = createEnrichedMarkdownTextWithStoredMarkdown(original, rendered)
 
     assertEquals(original, MarkdownExtractor.getMarkdownForSelection(textView))
   }

--- a/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/test/HTMLGeneratorTestSupport.kt
+++ b/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/test/HTMLGeneratorTestSupport.kt
@@ -1,0 +1,67 @@
+package com.swmansion.enriched.markdown.test
+
+import android.content.Context
+import android.text.Spannable
+import android.text.SpannableString
+import androidx.test.core.app.ApplicationProvider
+import com.swmansion.enriched.markdown.parser.MarkdownASTNode
+import com.swmansion.enriched.markdown.styles.StyleConfig
+import com.swmansion.enriched.markdown.utils.text.conversion.HTMLGenerator
+
+object HTMLGeneratorTestSupport {
+  private val context: Context = ApplicationProvider.getApplicationContext()
+
+  val defaultStyle: StyleConfig = StyleConfig.default(context)
+
+  fun generateHTML(spannable: Spannable): String {
+    val metrics = context.resources.displayMetrics
+    return HTMLGenerator.generateHTML(
+      text = spannable,
+      style = defaultStyle,
+      scaledDensity = metrics.scaledDensity,
+      density = metrics.density,
+      isRTL = false,
+    )
+  }
+
+  fun generateHTML(
+    spannable: SpannableString,
+    selectionStart: Int,
+    selectionEnd: Int,
+  ): String =
+    generateHTML(
+      MarkdownTextViewTestSupport.selectedRange(spannable, selectionStart, selectionEnd),
+    )
+
+  fun generateHTMLSelectingText(
+    document: MarkdownASTNode,
+    selectedText: String,
+  ): String {
+    val spannable = MarkdownTextViewTestSupport.render(document)
+    val start = MarkdownTextViewTestSupport.indexOf(spannable, selectedText)
+    return generateHTML(
+      MarkdownTextViewTestSupport.selectedRange(spannable, start, start + selectedText.length),
+    )
+  }
+}
+
+object HTMLAssertions {
+  fun String.assertContainsHtml(expected: String) {
+    org.junit.Assert.assertTrue(
+      "Expected HTML to contain \"$expected\" but was: $this",
+      contains(expected),
+    )
+  }
+
+  fun String.assertContainsHtmlInOrder(vararg parts: String) {
+    var searchFrom = 0
+    for (part in parts) {
+      val index = indexOf(part, searchFrom)
+      org.junit.Assert.assertTrue(
+        "Expected HTML to contain \"$part\" after index $searchFrom but was: $this",
+        index >= searchFrom,
+      )
+      searchFrom = index + part.length
+    }
+  }
+}

--- a/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/test/MarkdownExtractorTestSupport.kt
+++ b/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/test/MarkdownExtractorTestSupport.kt
@@ -1,65 +1,25 @@
 package com.swmansion.enriched.markdown.test
 
-import android.text.Selection
-import android.text.Spannable
-import android.text.SpannableString
-import android.widget.TextView
-import androidx.test.core.app.ApplicationProvider
-import com.swmansion.enriched.markdown.EnrichedMarkdownText
 import com.swmansion.enriched.markdown.parser.MarkdownASTNode
 import com.swmansion.enriched.markdown.utils.text.conversion.MarkdownExtractor
 
 object MarkdownExtractorTestSupport {
-  fun render(document: MarkdownASTNode): SpannableString = MarkdownRenderTestSupport.render(document)
-
-  fun createTextViewWithSelection(
-    spannable: SpannableString,
-    selectionStart: Int,
-    selectionEnd: Int,
-  ): TextView {
-    val textView = TextView(ApplicationProvider.getApplicationContext())
-    textView.setTextIsSelectable(true)
-    textView.setText(spannable, TextView.BufferType.SPANNABLE)
-    val selectableText = textView.text as Spannable
-    Selection.setSelection(selectableText, selectionStart, selectionEnd)
-    return textView
-  }
-
-  fun createTextViewWithSelection(
-    document: MarkdownASTNode,
-    selectionStart: Int,
-    selectionEnd: Int,
-  ): TextView = createTextViewWithSelection(render(document), selectionStart, selectionEnd)
-
-  fun createTextViewWithFullSelection(spannable: SpannableString): TextView =
-    createTextViewWithSelection(spannable, 0, spannable.length)
-
-  fun createTextViewWithFullSelection(document: MarkdownASTNode): TextView {
-    val spannable = render(document)
-    return createTextViewWithFullSelection(spannable)
-  }
-
-  fun createTextViewSelectingText(
-    document: MarkdownASTNode,
-    selectedText: String,
-  ): TextView {
-    val spannable = render(document)
-    val start = spannable.indexOf(selectedText)
-    require(start >= 0) { "Rendered text does not contain \"$selectedText\": \"$spannable\"" }
-    return createTextViewWithSelection(spannable, start, start + selectedText.length)
-  }
-
   fun extractFromSelection(
     document: MarkdownASTNode,
     selectionStart: Int,
     selectionEnd: Int,
   ): String? {
-    val textView = createTextViewWithSelection(document, selectionStart, selectionEnd)
+    val textView =
+      MarkdownTextViewTestSupport.createTextViewWithSelection(
+        document,
+        selectionStart,
+        selectionEnd,
+      )
     return MarkdownExtractor.getMarkdownForSelection(textView)
   }
 
   fun extractFromFullSelection(document: MarkdownASTNode): String? {
-    val textView = createTextViewWithFullSelection(document)
+    val textView = MarkdownTextViewTestSupport.createTextViewWithFullSelection(document)
     return MarkdownExtractor.getMarkdownForSelection(textView)
   }
 
@@ -67,35 +27,7 @@ object MarkdownExtractorTestSupport {
     document: MarkdownASTNode,
     selectedText: String,
   ): String? {
-    val textView = createTextViewSelectingText(document, selectedText)
+    val textView = MarkdownTextViewTestSupport.createTextViewSelectingText(document, selectedText)
     return MarkdownExtractor.getMarkdownForSelection(textView)
-  }
-
-  fun createEnrichedMarkdownTextWithFullSelection(
-    originalMarkdown: String,
-    rendered: SpannableString,
-  ): EnrichedMarkdownText {
-    val textView = EnrichedMarkdownText(ApplicationProvider.getApplicationContext())
-    textView.setTextIsSelectable(true)
-    textView.text = rendered
-    setCurrentMarkdown(textView, originalMarkdown)
-    val selectableText = textView.text as Spannable
-    Selection.setSelection(selectableText, 0, selectableText.length)
-    return textView
-  }
-
-  private fun setCurrentMarkdown(
-    textView: EnrichedMarkdownText,
-    markdown: String,
-  ) {
-    val field = EnrichedMarkdownText::class.java.getDeclaredField("currentMarkdown")
-    field.isAccessible = true
-    field.set(textView, markdown)
-  }
-
-  fun indexOf(spannable: Spannable, text: String): Int {
-    val index = spannable.indexOf(text)
-    require(index >= 0) { "Rendered text does not contain \"$text\": \"$spannable\"" }
-    return index
   }
 }

--- a/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/test/MarkdownTextViewTestSupport.kt
+++ b/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/test/MarkdownTextViewTestSupport.kt
@@ -1,0 +1,118 @@
+package com.swmansion.enriched.markdown.test
+
+import android.content.Context
+import android.text.Selection
+import android.text.Spannable
+import android.text.SpannableString
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import com.swmansion.enriched.markdown.EnrichedMarkdownText
+import com.swmansion.enriched.markdown.parser.MarkdownASTNode
+
+object MarkdownTextViewTestSupport {
+  private val context: Context = ApplicationProvider.getApplicationContext()
+
+  fun render(document: MarkdownASTNode): SpannableString = MarkdownRenderTestSupport.render(document)
+
+  fun createTextViewWithSelection(
+    spannable: SpannableString,
+    selectionStart: Int,
+    selectionEnd: Int,
+  ): TextView {
+    val textView = TextView(context)
+    applySelection(textView, spannable, selectionStart, selectionEnd)
+    return textView
+  }
+
+  fun createTextViewWithSelection(
+    document: MarkdownASTNode,
+    selectionStart: Int,
+    selectionEnd: Int,
+  ): TextView = createTextViewWithSelection(render(document), selectionStart, selectionEnd)
+
+  fun createTextViewWithFullSelection(spannable: SpannableString): TextView =
+    createTextViewWithSelection(spannable, 0, spannable.length)
+
+  fun createTextViewWithFullSelection(document: MarkdownASTNode): TextView {
+    val spannable = render(document)
+    return createTextViewWithFullSelection(spannable)
+  }
+
+  fun createTextViewSelectingText(
+    document: MarkdownASTNode,
+    selectedText: String,
+  ): TextView {
+    val spannable = render(document)
+    val start = indexOf(spannable, selectedText)
+    return createTextViewWithSelection(spannable, start, start + selectedText.length)
+  }
+
+  fun createEnrichedMarkdownTextWithSelection(
+    spannable: SpannableString,
+    selectionStart: Int,
+    selectionEnd: Int,
+  ): EnrichedMarkdownText {
+    val textView = EnrichedMarkdownText(context)
+    applySelection(textView, spannable, selectionStart, selectionEnd)
+    return textView
+  }
+
+  fun createEnrichedMarkdownTextSelectingText(
+    document: MarkdownASTNode,
+    selectedText: String,
+  ): EnrichedMarkdownText {
+    val spannable = render(document)
+    val start = indexOf(spannable, selectedText)
+    return createEnrichedMarkdownTextWithSelection(spannable, start, start + selectedText.length)
+  }
+
+  fun createEnrichedMarkdownTextWithFullSelection(document: MarkdownASTNode): EnrichedMarkdownText {
+    val spannable = render(document)
+    return createEnrichedMarkdownTextWithSelection(spannable, 0, spannable.length)
+  }
+
+  fun createEnrichedMarkdownTextWithStoredMarkdown(
+    originalMarkdown: String,
+    rendered: SpannableString,
+  ): EnrichedMarkdownText {
+    val textView = createEnrichedMarkdownTextWithSelection(rendered, 0, rendered.length)
+    setCurrentMarkdown(textView, originalMarkdown)
+    return textView
+  }
+
+  fun selectedRange(
+    spannable: SpannableString,
+    start: Int,
+    end: Int,
+  ): Spannable = spannable.subSequence(start, end) as Spannable
+
+  fun indexOf(spannable: Spannable, text: String): Int {
+    val index = spannable.indexOf(text)
+    require(index >= 0) { "Rendered text does not contain \"$text\": \"$spannable\"" }
+    return index
+  }
+
+  private fun applySelection(
+    textView: TextView,
+    spannable: SpannableString,
+    selectionStart: Int,
+    selectionEnd: Int,
+  ) {
+    textView.setTextIsSelectable(true)
+    if (textView is EnrichedMarkdownText) {
+      textView.text = spannable
+    } else {
+      textView.setText(spannable, TextView.BufferType.SPANNABLE)
+    }
+    Selection.setSelection(textView.text as Spannable, selectionStart, selectionEnd)
+  }
+
+  private fun setCurrentMarkdown(
+    textView: EnrichedMarkdownText,
+    markdown: String,
+  ) {
+    val field = EnrichedMarkdownText::class.java.getDeclaredField("currentMarkdown")
+    field.isAccessible = true
+    field.set(textView, markdown)
+  }
+}

--- a/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/test/MarkdownTextViewTestSupport.kt
+++ b/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/test/MarkdownTextViewTestSupport.kt
@@ -30,8 +30,7 @@ object MarkdownTextViewTestSupport {
     selectionEnd: Int,
   ): TextView = createTextViewWithSelection(render(document), selectionStart, selectionEnd)
 
-  fun createTextViewWithFullSelection(spannable: SpannableString): TextView =
-    createTextViewWithSelection(spannable, 0, spannable.length)
+  fun createTextViewWithFullSelection(spannable: SpannableString): TextView = createTextViewWithSelection(spannable, 0, spannable.length)
 
   fun createTextViewWithFullSelection(document: MarkdownASTNode): TextView {
     val spannable = render(document)
@@ -86,7 +85,10 @@ object MarkdownTextViewTestSupport {
     end: Int,
   ): Spannable = spannable.subSequence(start, end) as Spannable
 
-  fun indexOf(spannable: Spannable, text: String): Int {
+  fun indexOf(
+    spannable: Spannable,
+    text: String,
+  ): Int {
     val index = spannable.indexOf(text)
     require(index >= 0) { "Rendered text does not contain \"$text\": \"$spannable\"" }
     return index

--- a/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionModeTest.kt
+++ b/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionModeTest.kt
@@ -9,11 +9,14 @@ import android.widget.TextView
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewSelectingText
-import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewWithFullSelection
-import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.createTextViewWithSelection
-import com.swmansion.enriched.markdown.test.MarkdownExtractorTestSupport.render
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.createEnrichedMarkdownTextSelectingText
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.createEnrichedMarkdownTextWithSelection
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.createTextViewSelectingText
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.createTextViewWithFullSelection
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.createTextViewWithSelection
+import com.swmansion.enriched.markdown.test.MarkdownTextViewTestSupport.render
 import com.swmansion.enriched.markdown.test.TestAstFactory.document
+import com.swmansion.enriched.markdown.test.TestAstFactory.emphasis
 import com.swmansion.enriched.markdown.test.TestAstFactory.image
 import com.swmansion.enriched.markdown.test.TestAstFactory.paragraph
 import com.swmansion.enriched.markdown.test.TestAstFactory.strong
@@ -100,7 +103,7 @@ class SelectionActionModeTest {
   }
 
   @Test
-  fun clickingPlainCopyCopiesPlainTextToClipboard() {
+  fun clickingPlainCopyOnPlainTextViewCopiesPlainTextOnly() {
     val textView =
       createTextViewSelectingText(
         document(
@@ -118,6 +121,93 @@ class SelectionActionModeTest {
     assertTrue(callback.onActionItemClicked(null, menu.findItem(android.R.id.copy)))
 
     assertEquals("42", getClipboardText())
+    assertNull(getClipboardHtml())
+  }
+
+  @Test
+  fun clickingPlainCopyOnEnrichedMarkdownTextCopiesPlainTextAndHtml() {
+    val textView =
+      createEnrichedMarkdownTextSelectingText(
+        document(
+          paragraph(
+            text("Value: "),
+            strong(text("42")),
+          ),
+        ),
+        "42",
+      )
+    val callback = createSelectionActionModeCallback(textView)
+    val menu = MenuBuilder(context)
+    menu.add(0, android.R.id.copy, 0, "Copy")
+
+    assertTrue(callback.onActionItemClicked(null, menu.findItem(android.R.id.copy)))
+
+    assertEquals("42", getClipboardText())
+    getClipboardHtml().let { html ->
+      requireNotNull(html) { "Expected HTML clipboard content" }
+      assertTrue("Expected <strong> in HTML but was: $html", html.contains("<strong") && html.contains("42"))
+      assertTrue("Expected HTML wrapper but was: $html", html.startsWith("<html"))
+    }
+  }
+
+  @Test
+  fun clickingPlainCopyOnEnrichedMarkdownTextIncludesSemanticTagsForFormattedSelection() {
+    val textView =
+      createEnrichedMarkdownTextSelectingText(
+        document(
+          paragraph(
+            text("Mix "),
+            strong(text("bold")),
+            text(" and "),
+            emphasis(text("italic")),
+          ),
+        ),
+        "bold",
+      )
+    val callback = createSelectionActionModeCallback(textView)
+    val menu = MenuBuilder(context)
+    menu.add(0, android.R.id.copy, 0, "Copy")
+
+    assertTrue(callback.onActionItemClicked(null, menu.findItem(android.R.id.copy)))
+
+    assertEquals("bold", getClipboardText())
+    getClipboardHtml().let { html ->
+      requireNotNull(html)
+      assertTrue(html.contains("<strong") && html.contains("bold"))
+    }
+  }
+
+  @Test
+  fun clickingPlainCopyOnEnrichedMarkdownTextIncludesImageInHtml() {
+    val url = "https://example.com/image.png"
+    val spannable = render(document(paragraph(image(url))))
+    val imageStart = spannable.indexOf('\uFFFC')
+    val textView = createEnrichedMarkdownTextWithSelection(spannable, imageStart, imageStart + 1)
+
+    val callback = createSelectionActionModeCallback(textView)
+    val menu = MenuBuilder(context)
+    menu.add(0, android.R.id.copy, 0, "Copy")
+
+    assertTrue(callback.onActionItemClicked(null, menu.findItem(android.R.id.copy)))
+
+    getClipboardHtml().let { html ->
+      requireNotNull(html)
+      assertTrue("Expected image URL in HTML but was: $html", html.contains("src=\"$url\""))
+    }
+  }
+
+  @Test
+  fun clickingPlainCopyDoesNothingForEmptySelection() {
+    val spannable = render(document(paragraph(text("Hello"))))
+    val textView = createTextViewWithSelection(spannable, 2, 2)
+    val callback = createSelectionActionModeCallback(textView)
+    val menu = MenuBuilder(context)
+    menu.add(0, android.R.id.copy, 0, "Copy")
+
+    assertTrue(callback.onActionItemClicked(null, menu.findItem(android.R.id.copy)))
+
+    assertNull(getClipboardText())
+    assertNull(getClipboardHtml())
   }
 
   @Test
@@ -215,6 +305,11 @@ class SelectionActionModeTest {
   private fun getClipboardText(): String? {
     val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
     return clipboard.primaryClip?.getItemAt(0)?.text?.toString()
+  }
+
+  private fun getClipboardHtml(): String? {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    return clipboard.primaryClip?.getItemAt(0)?.htmlText
   }
 
   private fun copyMarkdownDirectly(textView: TextView): Boolean {

--- a/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionModeTest.kt
+++ b/packages/android-enriched-markdown/ui/src/test/java/com/swmansion/enriched/markdown/utils/text/view/SelectionActionModeTest.kt
@@ -304,7 +304,10 @@ class SelectionActionModeTest {
 
   private fun getClipboardText(): String? {
     val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-    return clipboard.primaryClip?.getItemAt(0)?.text?.toString()
+    return clipboard.primaryClip
+      ?.getItemAt(0)
+      ?.text
+      ?.toString()
   }
 
   private fun getClipboardHtml(): String? {


### PR DESCRIPTION
### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
- open the Text example in the example app
- select the text and click "Copy"
- paste it for example to gmail app
- verify the pasted text is styled



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

