### PR TITLE
chore: update configs to include autocorect settings

### DIFF
--- a/.maestro/scripts/setup-android-emulator.sh
+++ b/.maestro/scripts/setup-android-emulator.sh
@@ -83,6 +83,10 @@ until adb -s "$SERIAL" shell getprop sys.boot_completed 2>/dev/null | grep -q "^
 done
 
 adb -s "$SERIAL" shell settings put secure show_ime_with_hard_keyboard 0
+# Disable spell-check/autofill so Maestro typing isn't altered by suggestions.
+adb -s "$SERIAL" shell settings put secure spell_checker_enabled 0
+adb -s "$SERIAL" shell settings put secure selected_spell_checker '""'
+adb -s "$SERIAL" shell settings put secure autofill_service null
 
 echo "Emulator ready: $AVD_NAME ($SERIAL)"
 echo "DEVICE_ID=$SERIAL"

--- a/.maestro/scripts/setup-ios-simulator.sh
+++ b/.maestro/scripts/setup-ios-simulator.sh
@@ -42,6 +42,13 @@ if [ "$STATE" != "(Booted)" ]; then
   done
 fi
 
+# Disable autocorrect/capitalization/spell-check so Maestro typing is deterministic.
+PREFS_PLIST="$HOME/Library/Developer/CoreSimulator/Devices/$UDID/data/Library/Preferences/com.apple.Preferences.plist"
+defaults write "$PREFS_PLIST" KeyboardAutocapitalization -bool false
+defaults write "$PREFS_PLIST" KeyboardAutocorrection -bool false
+defaults write "$PREFS_PLIST" KeyboardCheckSpelling -bool false
+xcrun simctl spawn "$UDID" launchctl kickstart -k system/com.apple.SpringBoard 2>/dev/null || true
+
 open -a Simulator
 
 echo "Simulator ready: $DEVICE_NAME ($UDID)"


### PR DESCRIPTION
### What/Why?
Added Autocorrect settings to force disable autocorect for maestro settings (so we don't get for example underline "error")

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

