### PR TITLE
fix: resolve modal flicker on Android after setting raw markdown

### DIFF
--- a/apps/react-native-example/src/screens/playground/PlaygroundScreen.tsx
+++ b/apps/react-native-example/src/screens/playground/PlaygroundScreen.tsx
@@ -11,6 +11,7 @@ import {
   Image,
   Modal,
   TextInput,
+  Keyboard,
 } from 'react-native';
 import { useHeaderHeight } from '@react-navigation/elements';
 import {
@@ -74,6 +75,18 @@ export default function PlaygroundScreen() {
     const md = await inputRef.current?.getMarkdown();
     Alert.alert('Markdown', md ?? '(empty)', [{ text: 'OK' }]);
   }, []);
+
+  const handleSetMarkdownConfirm = useCallback(() => {
+    const value = rawInput;
+    Keyboard.dismiss();
+    setSetMarkdownModalVisible(false);
+    setRawInput('');
+
+    requestAnimationFrame(() => {
+      inputRef.current?.setValue(value);
+      setMarkdown(value);
+    });
+  }, [rawInput]);
 
   return (
     <KeyboardAvoidingView
@@ -206,56 +219,6 @@ export default function PlaygroundScreen() {
           <Text style={styles.getMarkdownText}>Get Raw Markdown</Text>
         </TouchableOpacity>
 
-        <Modal
-          visible={setMarkdownModalVisible}
-          animationType="slide"
-          transparent
-          onRequestClose={() => setSetMarkdownModalVisible(false)}
-        >
-          <KeyboardAvoidingView
-            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-            style={styles.modalOverlay}
-          >
-            <View style={styles.modalContent}>
-              <Text style={styles.modalTitle}>Set Raw Markdown</Text>
-              <TextInput
-                style={styles.modalInput}
-                value={rawInput}
-                onChangeText={setRawInput}
-                multiline
-                autoFocus
-                placeholder="Paste or type markdown..."
-                placeholderTextColor="#9CA3AF"
-                autoCorrect={false}
-                autoCapitalize="none"
-                testID="set-markdown-input"
-              />
-              <View style={styles.modalButtonRow}>
-                <TouchableOpacity
-                  style={[styles.button, styles.modalCancelButton]}
-                  onPress={() => setSetMarkdownModalVisible(false)}
-                  testID="set-markdown-cancel"
-                >
-                  <Text style={styles.buttonText}>Cancel</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.button, styles.buttonActive]}
-                  onPress={() => {
-                    inputRef.current?.setValue(rawInput);
-                    setMarkdown(rawInput);
-                    setSetMarkdownModalVisible(false);
-                  }}
-                  testID="set-markdown-confirm"
-                >
-                  <Text style={[styles.buttonText, styles.buttonTextActive]}>
-                    Set
-                  </Text>
-                </TouchableOpacity>
-              </View>
-            </View>
-          </KeyboardAvoidingView>
-        </Modal>
-
         <View style={styles.divider} />
 
         <Text style={styles.previewLabel}>Preview</Text>
@@ -286,6 +249,52 @@ export default function PlaygroundScreen() {
           )}
         </View>
       </ScrollView>
+
+      <Modal
+        visible={setMarkdownModalVisible}
+        animationType={Platform.OS === 'android' ? 'fade' : 'slide'}
+        transparent
+        onRequestClose={() => setSetMarkdownModalVisible(false)}
+      >
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={styles.modalOverlay}
+        >
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>Set Raw Markdown</Text>
+            <TextInput
+              style={styles.modalInput}
+              value={rawInput}
+              onChangeText={setRawInput}
+              multiline
+              autoFocus
+              placeholder="Paste or type markdown..."
+              placeholderTextColor="#9CA3AF"
+              autoCorrect={false}
+              autoCapitalize="none"
+              testID="set-markdown-input"
+            />
+            <View style={styles.modalButtonRow}>
+              <TouchableOpacity
+                style={[styles.button, styles.modalCancelButton]}
+                onPress={() => setSetMarkdownModalVisible(false)}
+                testID="set-markdown-cancel"
+              >
+                <Text style={styles.buttonText}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.button, styles.buttonActive]}
+                onPress={handleSetMarkdownConfirm}
+                testID="set-markdown-confirm"
+              >
+                <Text style={[styles.buttonText, styles.buttonTextActive]}>
+                  Set
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
     </KeyboardAvoidingView>
   );
 }


### PR DESCRIPTION
### What/Why?

Fixes a visual flicker on Android where the "Set Raw Markdown" modal briefly reappears after being dismissed.

The root cause was that heavy work (`setValue` + markdown preview re-render) ran in the same frame as the modal dismiss, causing Android to briefly redraw the modal overlay during the animation. Additionally, the modal was nested inside a `ScrollView`, which amplified the issue during re-renders.

Changes:
- Dismiss the modal first, then defer `setValue`/`setMarkdown` via `requestAnimationFrame`
- Move the modal outside the `ScrollView` (matching the pattern used by other modals in the app)
- Use `fade` animation on Android instead of `slide` to avoid animation overlap


### Testing
<!-- How to test changed code? What testing has been done? -->



#### Screenshots

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/21e2142a-a076-48ba-9f2e-1734625a5b9a" width=300 /> | <video src="https://github.com/user-attachments/assets/4916f759-595f-46b2-b518-d32bf4979099" width=300 /> |

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

