### PR TITLE
fix: stricter default guards

### DIFF
--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -256,6 +256,7 @@ export const EnrichedMarkdownTextInput = ({
   ...rest
 }: EnrichedMarkdownTextInputProps) => {
   const nativeRef = useRef<NativeRef | null>(null);
+  const initialDefaultValue = useRef(defaultValue).current;
 
   const nextRequestId = useRef(1);
   const pendingRequests = useRef(new Map<number, PendingRequest<string>>());
@@ -499,7 +500,7 @@ export const EnrichedMarkdownTextInput = ({
       ref={nativeRef}
       style={style}
       markdownStyle={normalizedStyle}
-      defaultValue={defaultValue}
+      defaultValue={initialDefaultValue}
       placeholder={placeholder}
       placeholderTextColor={placeholderTextColor}
       editable={editable}

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -256,6 +256,7 @@ export const EnrichedMarkdownTextInput = ({
   ...rest
 }: EnrichedMarkdownTextInputProps) => {
   const nativeRef = useRef<NativeRef | null>(null);
+  // Freeze `defaultValue` at mount (RN TextInput semantics): post-mount changes are ignored.
   const initialDefaultValue = useRef(defaultValue).current;
 
   const nextRequestId = useRef(1);


### PR DESCRIPTION
### What/Why?
Freezes defaultValue at mount so post-mount changes are ignored, matching React Native's TextInput semantics.
Previously, changes to defaultValue were forwarded to the native side and triggered a document re-parse mid-edit. If
a caller accidentally passed a controlled value as defaultValue, the re-parse fired on every keystroke — and on the
"empty pending-format span" state (a format toggled with no selection on an empty first line), it caused phantom
trailing marker glyphs to appear in the rendered view while the serialized markdown stayed correct.

RN itself only reads defaultValue in JS to seed the initial text and never diffs it against the native side, so
aligning here removes the footgun without introducing platform-specific heuristics.

closes #368

### Testing
Reproduced against main in the Playground of the RN example app by temporarily passing `defaultValue={markdown}` on the EnrichedMarkdownTextInput:

1. Empty, focused editor on the first line.
2. Toggle Bold + Italic from the toolbar (no selection).
3. Type D.
4. Before: on-screen shows `D*` while getMarkdown() returns `***D****`.
5. After: on-screen shows a styled `D` only; getMarkdown()  returns `***D***`.


#### Screenshots 

##### Before

https://github.com/user-attachments/assets/5dbf461f-a9d2-43b7-b09a-1c471171867e

##### After

https://github.com/user-attachments/assets/17797c50-d044-482d-a860-42dd027d6fc8


### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)
