### PR TITLE
chore: update Android baseline profile with missing classes

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/baseline-prof.txt
+++ b/packages/react-native-enriched-markdown/android/src/main/baseline-prof.txt
@@ -4,6 +4,7 @@
 
 # Core View and Rendering
 Lcom/swmansion/enriched/markdown/EnrichedMarkdown;
+Lcom/swmansion/enriched/markdown/EnrichedMarkdown$DirtyFlag;
 Lcom/swmansion/enriched/markdown/EnrichedMarkdownInternalText;
 Lcom/swmansion/enriched/markdown/EnrichedMarkdownManager;
 Lcom/swmansion/enriched/markdown/EnrichedMarkdownText;
@@ -11,10 +12,18 @@ Lcom/swmansion/enriched/markdown/EnrichedMarkdownTextLayoutManager;
 Lcom/swmansion/enriched/markdown/EnrichedMarkdownTextManager;
 Lcom/swmansion/enriched/markdown/EnrichedMarkdownTextPackage;
 Lcom/swmansion/enriched/markdown/MeasurementStore;
+Lcom/swmansion/enriched/markdown/MeasurementStore$FontScalingSettings;
+Lcom/swmansion/enriched/markdown/MeasurementStore$MeasurementParams;
+Lcom/swmansion/enriched/markdown/MeasurementStore$PaintParams;
 
 # Accessibility
+Lcom/swmansion/enriched/markdown/accessibility/AccessibilityLabels;
 Lcom/swmansion/enriched/markdown/accessibility/AccessibleMarkdownTextView;
 Lcom/swmansion/enriched/markdown/accessibility/MarkdownAccessibilityHelper;
+Lcom/swmansion/enriched/markdown/accessibility/MarkdownAccessibilityHelper$AccessibilityItem;
+Lcom/swmansion/enriched/markdown/accessibility/MarkdownAccessibilityHelper$ListItemInfo;
+Lcom/swmansion/enriched/markdown/accessibility/MarkdownAccessibilityHelper$SpanRange;
+Lcom/swmansion/enriched/markdown/accessibility/MarkdownAccessibilityHelperKt;
 
 # Events
 Lcom/swmansion/enriched/markdown/events/ContextMenuItemPressEvent;
@@ -25,12 +34,15 @@ Lcom/swmansion/enriched/markdown/events/TaskListItemPressEvent;
 # Input - Core
 Lcom/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager;
 Lcom/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView;
+Lcom/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView$MentionCandidate;
+Lcom/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputViewKt;
 
 # Input - Autolink
 Lcom/swmansion/enriched/markdown/input/autolink/AutoDetectedLinkColorSpan;
 Lcom/swmansion/enriched/markdown/input/autolink/AutoDetectedLinkMarkerSpan;
 Lcom/swmansion/enriched/markdown/input/autolink/AutoDetectedLinkUnderlineSpan;
 Lcom/swmansion/enriched/markdown/input/autolink/AutoLinkDetector;
+Lcom/swmansion/enriched/markdown/input/autolink/AutoLinkDetectorKt;
 Lcom/swmansion/enriched/markdown/input/autolink/LinkRegexConfig;
 
 # Input - Detection
@@ -62,28 +74,48 @@ Lcom/swmansion/enriched/markdown/input/events/OnStartMentionEvent;
 
 # Input - Formatting
 Lcom/swmansion/enriched/markdown/input/formatting/FormattingStore;
+Lcom/swmansion/enriched/markdown/input/formatting/FormattingStore$EditOverlap;
 Lcom/swmansion/enriched/markdown/input/formatting/InputFormatter;
 Lcom/swmansion/enriched/markdown/input/formatting/InputParser;
 Lcom/swmansion/enriched/markdown/input/formatting/InputRemend;
+Lcom/swmansion/enriched/markdown/input/formatting/InputRemend$DelimiterPair;
 Lcom/swmansion/enriched/markdown/input/formatting/MarkdownSerializer;
+Lcom/swmansion/enriched/markdown/input/formatting/MarkdownSerializer$BoundaryEvent;
 Lcom/swmansion/enriched/markdown/input/formatting/MarkdownSpan;
+Lcom/swmansion/enriched/markdown/input/formatting/MarkdownSpan$SpanDescriptor;
 Lcom/swmansion/enriched/markdown/input/formatting/ParseResult;
+Lcom/swmansion/enriched/markdown/input/formatting/ParseResult$ActiveStyle;
 
 # Input - Layout
 Lcom/swmansion/enriched/markdown/input/layout/InputEventEmitter;
 Lcom/swmansion/enriched/markdown/input/layout/InputLayoutManager;
 Lcom/swmansion/enriched/markdown/input/layout/InputMeasurementStore;
+Lcom/swmansion/enriched/markdown/input/layout/InputMeasurementStore$MeasurementParams;
+Lcom/swmansion/enriched/markdown/input/layout/InputMeasurementStore$PaintParams;
 
 # Input - Model
 Lcom/swmansion/enriched/markdown/input/model/CaretRect;
 Lcom/swmansion/enriched/markdown/input/model/FormattingRange;
 Lcom/swmansion/enriched/markdown/input/model/InputFormatterStyle;
+Lcom/swmansion/enriched/markdown/input/model/InputLinkVariantStyle;
 Lcom/swmansion/enriched/markdown/input/model/StyleType;
 
 # Input - Styles
 Lcom/swmansion/enriched/markdown/input/styles/BoldStyleHandler;
 Lcom/swmansion/enriched/markdown/input/styles/ItalicStyleHandler;
 Lcom/swmansion/enriched/markdown/input/styles/LinkStyleHandler;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownBoldColorSpan;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownBoldSpan;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownItalicColorSpan;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownItalicSpan;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownLinkBackgroundColorSpan;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownLinkColorSpan;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownLinkColorSpan$ResolvedLinkStyle;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownLinkUnderlineSpan;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownSpoilerBackgroundSpan;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownSpoilerColorSpan;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownStrikethroughSpan;
+Lcom/swmansion/enriched/markdown/input/styles/MarkdownUnderlineSpan;
 Lcom/swmansion/enriched/markdown/input/styles/SpoilerStyleHandler;
 Lcom/swmansion/enriched/markdown/input/styles/StrikethroughStyleHandler;
 Lcom/swmansion/enriched/markdown/input/styles/StyleHandler;
@@ -91,33 +123,42 @@ Lcom/swmansion/enriched/markdown/input/styles/StyleMergingConfig;
 Lcom/swmansion/enriched/markdown/input/styles/UnderlineStyleHandler;
 
 # Input - Toolbar
+Lcom/swmansion/enriched/markdown/input/toolbar/FormatMenuConfig;
 Lcom/swmansion/enriched/markdown/input/toolbar/InputContextMenu;
+Lcom/swmansion/enriched/markdown/input/toolbar/InputSelectionMenuConfig;
 
 # Parser
 Lcom/swmansion/enriched/markdown/parser/Md4cFlags;
 Lcom/swmansion/enriched/markdown/parser/MarkdownASTNode;
 Lcom/swmansion/enriched/markdown/parser/MarkdownASTNode$NodeType;
+Lcom/swmansion/enriched/markdown/parser/MarkdownASTNodeKt;
 Lcom/swmansion/enriched/markdown/parser/Parser;
 
 # Renderer Classes
 Lcom/swmansion/enriched/markdown/renderer/BaselineShiftRenderer;
 Lcom/swmansion/enriched/markdown/renderer/BlockStyle;
 Lcom/swmansion/enriched/markdown/renderer/BlockStyleContext;
+Lcom/swmansion/enriched/markdown/renderer/BlockStyleEntry;
 Lcom/swmansion/enriched/markdown/renderer/BlockType;
+Lcom/swmansion/enriched/markdown/renderer/BlockType$ListType;
 Lcom/swmansion/enriched/markdown/renderer/BlockquoteRenderer;
 Lcom/swmansion/enriched/markdown/renderer/CodeBlockRenderer;
+Lcom/swmansion/enriched/markdown/renderer/CodeBlockRenderer$CodeBlockBoundaryPaddingSpan;
 Lcom/swmansion/enriched/markdown/renderer/CodeRenderer;
 Lcom/swmansion/enriched/markdown/renderer/DocumentRenderer;
 Lcom/swmansion/enriched/markdown/renderer/EmphasisRenderer;
 Lcom/swmansion/enriched/markdown/renderer/HeadingRenderer;
+Lcom/swmansion/enriched/markdown/renderer/HighlightRenderer;
 Lcom/swmansion/enriched/markdown/renderer/ImageRenderer;
 Lcom/swmansion/enriched/markdown/renderer/LineBreakRenderer;
 Lcom/swmansion/enriched/markdown/renderer/LinkRenderer;
 Lcom/swmansion/enriched/markdown/renderer/ListContextManager;
+Lcom/swmansion/enriched/markdown/renderer/ListContextManager$ListEntryState;
 Lcom/swmansion/enriched/markdown/renderer/ListItemRenderer;
 Lcom/swmansion/enriched/markdown/renderer/ListRenderer;
 Lcom/swmansion/enriched/markdown/renderer/MathInlineRenderer;
 Lcom/swmansion/enriched/markdown/renderer/NodeRenderer;
+Lcom/swmansion/enriched/markdown/renderer/NodeRenderer$DeferredSpan;
 Lcom/swmansion/enriched/markdown/renderer/ParagraphRenderer;
 Lcom/swmansion/enriched/markdown/renderer/Renderer;
 Lcom/swmansion/enriched/markdown/renderer/RendererConfig;
@@ -126,12 +167,15 @@ Lcom/swmansion/enriched/markdown/renderer/SpanStyleCache;
 Lcom/swmansion/enriched/markdown/renderer/SpoilerRenderer;
 Lcom/swmansion/enriched/markdown/renderer/StrikethroughRenderer;
 Lcom/swmansion/enriched/markdown/renderer/StrongRenderer;
+Lcom/swmansion/enriched/markdown/renderer/SubscriptRenderer;
+Lcom/swmansion/enriched/markdown/renderer/SuperscriptRenderer;
 Lcom/swmansion/enriched/markdown/renderer/TextRenderer;
 Lcom/swmansion/enriched/markdown/renderer/ThematicBreakRenderer;
 Lcom/swmansion/enriched/markdown/renderer/UnderlineRenderer;
 
 # Spans
 Lcom/swmansion/enriched/markdown/spans/BaselineShiftSpan;
+Lcom/swmansion/enriched/markdown/spans/BaselineShiftSpan$SpanType;
 Lcom/swmansion/enriched/markdown/spans/BaseListSpan;
 Lcom/swmansion/enriched/markdown/spans/BlockquoteSpan;
 Lcom/swmansion/enriched/markdown/spans/CodeBackgroundSpan;
@@ -140,7 +184,10 @@ Lcom/swmansion/enriched/markdown/spans/CodeSpan;
 Lcom/swmansion/enriched/markdown/spans/EmphasisSpan;
 Lcom/swmansion/enriched/markdown/spans/FadeInSpan;
 Lcom/swmansion/enriched/markdown/spans/HeadingSpan;
+Lcom/swmansion/enriched/markdown/spans/HighlightSpan;
 Lcom/swmansion/enriched/markdown/spans/ImageSpan;
+Lcom/swmansion/enriched/markdown/spans/ImageSpan$CacheKey;
+Lcom/swmansion/enriched/markdown/spans/ImageSpan$ScaledImageDrawable;
 Lcom/swmansion/enriched/markdown/spans/LineHeightSpan;
 Lcom/swmansion/enriched/markdown/spans/LinkSpan;
 Lcom/swmansion/enriched/markdown/spans/MarginBottomSpan;
@@ -163,6 +210,7 @@ Lcom/swmansion/enriched/markdown/spoiler/ParticleStrategy;
 Lcom/swmansion/enriched/markdown/spoiler/SegmentKey;
 Lcom/swmansion/enriched/markdown/spoiler/SegmentRect;
 Lcom/swmansion/enriched/markdown/spoiler/SolidStrategy;
+Lcom/swmansion/enriched/markdown/spoiler/SolidStrategy$SegmentState;
 Lcom/swmansion/enriched/markdown/spoiler/SpoilerAnimator;
 Lcom/swmansion/enriched/markdown/spoiler/SpoilerCapable;
 Lcom/swmansion/enriched/markdown/spoiler/SpoilerConstantsKt;
@@ -171,6 +219,8 @@ Lcom/swmansion/enriched/markdown/spoiler/SpoilerDrawUtilsKt;
 Lcom/swmansion/enriched/markdown/spoiler/SpoilerOverlay;
 Lcom/swmansion/enriched/markdown/spoiler/SpoilerOverlayDrawer;
 Lcom/swmansion/enriched/markdown/spoiler/SpoilerParticleDrawable;
+Lcom/swmansion/enriched/markdown/spoiler/SpoilerParticleDrawable$DotType;
+Lcom/swmansion/enriched/markdown/spoiler/SpoilerStrategy;
 Lcom/swmansion/enriched/markdown/spoiler/SpoilerStrategyKt;
 
 # Style Configuration
@@ -180,6 +230,7 @@ Lcom/swmansion/enriched/markdown/styles/CodeBlockStyle;
 Lcom/swmansion/enriched/markdown/styles/CodeStyle;
 Lcom/swmansion/enriched/markdown/styles/EmphasisStyle;
 Lcom/swmansion/enriched/markdown/styles/HeadingStyle;
+Lcom/swmansion/enriched/markdown/styles/HighlightStyle;
 Lcom/swmansion/enriched/markdown/styles/ImageStyle;
 Lcom/swmansion/enriched/markdown/styles/InlineImageStyle;
 Lcom/swmansion/enriched/markdown/styles/InlineMathStyle;
@@ -202,19 +253,26 @@ Lcom/swmansion/enriched/markdown/styles/ThematicBreakStyle;
 Lcom/swmansion/enriched/markdown/styles/UnderlineStyle;
 
 # Utilities - Common
+Lcom/swmansion/enriched/markdown/utils/common/BreakStrategyUtils;
 Lcom/swmansion/enriched/markdown/utils/common/FeatureFlags;
 Lcom/swmansion/enriched/markdown/utils/common/MarkdownSegment;
 Lcom/swmansion/enriched/markdown/utils/common/MarkdownSegment$Math;
 Lcom/swmansion/enriched/markdown/utils/common/MarkdownSegment$Table;
 Lcom/swmansion/enriched/markdown/utils/common/MarkdownSegment$Text;
 Lcom/swmansion/enriched/markdown/utils/common/MarkdownSegmentKt;
+Lcom/swmansion/enriched/markdown/utils/common/MarkdownSegmentRenderer;
 Lcom/swmansion/enriched/markdown/utils/common/MarkdownViewManagerUtilsKt;
+Lcom/swmansion/enriched/markdown/utils/common/MotionPreferencesKt;
 Lcom/swmansion/enriched/markdown/utils/common/ReadableMapExtensionsKt;
+Lcom/swmansion/enriched/markdown/utils/common/ReconciliationResult;
 Lcom/swmansion/enriched/markdown/utils/common/RenderedSegment;
 Lcom/swmansion/enriched/markdown/utils/common/RenderedSegment$Math;
 Lcom/swmansion/enriched/markdown/utils/common/RenderedSegment$Table;
 Lcom/swmansion/enriched/markdown/utils/common/RenderedSegment$Text;
-Lcom/swmansion/enriched/markdown/utils/common/RenderedSegmentKt;
+Lcom/swmansion/enriched/markdown/utils/common/SegmentReconciler;
+Lcom/swmansion/enriched/markdown/utils/common/SegmentSignature;
+Lcom/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter;
+Lcom/swmansion/enriched/markdown/utils/common/TableStreamingMode;
 Lcom/swmansion/enriched/markdown/utils/common/layout/RTLUtilsKt;
 Lcom/swmansion/enriched/markdown/utils/common/serialization/MarkdownASTSerializer;
 
@@ -228,27 +286,42 @@ Lcom/swmansion/enriched/markdown/utils/text/ImageCache;
 Lcom/swmansion/enriched/markdown/utils/text/ImageDownloader;
 Lcom/swmansion/enriched/markdown/utils/text/TailFadeInAnimator;
 Lcom/swmansion/enriched/markdown/utils/text/conversion/HTMLGenerator;
+Lcom/swmansion/enriched/markdown/utils/text/conversion/HTMLGenerator$CachedStyles;
+Lcom/swmansion/enriched/markdown/utils/text/conversion/HTMLGenerator$GeneratorState;
+Lcom/swmansion/enriched/markdown/utils/text/conversion/HTMLGenerator$ParagraphInfo;
 Lcom/swmansion/enriched/markdown/utils/text/conversion/MarkdownExtractor;
+Lcom/swmansion/enriched/markdown/utils/text/conversion/MarkdownExtractor$ExtractionState;
+Lcom/swmansion/enriched/markdown/utils/text/conversion/MarkdownExtractor$HeadingAccumulator;
 Lcom/swmansion/enriched/markdown/utils/text/extensions/ParagraphUtilsKt;
 Lcom/swmansion/enriched/markdown/utils/text/extensions/SpannableExtensionsKt;
 Lcom/swmansion/enriched/markdown/utils/text/extensions/TextPaintExtensionsKt;
 Lcom/swmansion/enriched/markdown/utils/text/interaction/CheckboxTouchHelper;
 Lcom/swmansion/enriched/markdown/utils/text/interaction/TaskListHitTestResult;
 Lcom/swmansion/enriched/markdown/utils/text/interaction/TaskListTapUtils;
-Lcom/swmansion/enriched/markdown/utils/text/interaction/TaskListTapUtilsKt;
 Lcom/swmansion/enriched/markdown/utils/text/interaction/TaskListToggleUtils;
 Lcom/swmansion/enriched/markdown/utils/text/span/BlockSpacingKt;
 Lcom/swmansion/enriched/markdown/utils/text/span/SpanFlagsKt;
 Lcom/swmansion/enriched/markdown/utils/text/view/LinkEventsKt;
 Lcom/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod;
 Lcom/swmansion/enriched/markdown/utils/text/view/SelectionActionModeKt;
+Lcom/swmansion/enriched/markdown/utils/text/view/SelectionMenuConfig;
+Lcom/swmansion/enriched/markdown/utils/text/view/TextSelectionColorsKt;
 Lcom/swmansion/enriched/markdown/utils/text/view/TextViewSetupKt;
 
 # Views
 Lcom/swmansion/enriched/markdown/views/BlockSegmentView;
 Lcom/swmansion/enriched/markdown/views/ContextMenuPopup;
+Lcom/swmansion/enriched/markdown/views/ContextMenuPopup$Builder;
+Lcom/swmansion/enriched/markdown/views/ContextMenuPopup$Icon;
+Lcom/swmansion/enriched/markdown/views/ContextMenuPopup$MenuItem;
 Lcom/swmansion/enriched/markdown/views/MathContainerView;
 Lcom/swmansion/enriched/markdown/views/TableContainerView;
+Lcom/swmansion/enriched/markdown/views/TableContainerView$CellBackgroundView;
+Lcom/swmansion/enriched/markdown/views/TableContainerView$CellTextView;
+Lcom/swmansion/enriched/markdown/views/TableContainerView$GridContainerView;
+Lcom/swmansion/enriched/markdown/views/TableContainerView$HeaderTypefaceSpan;
+Lcom/swmansion/enriched/markdown/views/TableContainerView$TableCellData;
 
 # Math (optional, from src/math source set)
 Lcom/swmansion/enriched/markdown/spans/MathMeasureHelper;
+Lcom/swmansion/enriched/markdown/views/MathContainerView$RaTeXCanvasView;


### PR DESCRIPTION
### What/Why?
Add 75 missing entries (top-level classes, inner types, Kt facades) and remove 2 stale entries (RenderedSegmentKt, TaskListTapUtilsKt). Covers new feature areas (highlight, sub/superscript, accessibility labels, streaming/reconciliation) and input style companion spans.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

