### PR TITLE
fix(android): emit list item markers when parsing input

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputParser.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputParser.kt
@@ -44,6 +44,25 @@ object InputParser {
     return ParseResult(plainText.toString(), ranges)
   }
 
+  private fun walkListItems(
+    items: List<MarkdownASTNode>,
+    isOrdered: Boolean,
+    plainText: StringBuilder,
+    ranges: MutableList<FormattingRange>,
+    blankRuns: ArrayDeque<Int>,
+  ) {
+    items.forEachIndexed { index, item ->
+      if (index > 0) plainText.append("\n")
+      plainText.append(if (isOrdered) "${index + 1}. " else "- ")
+      if (item.getAttribute("isTask") == "true") {
+        plainText.append(if (item.getAttribute("taskChecked") == "true") "[x] " else "[ ] ")
+      }
+      for (child in item.children) {
+        walkNode(child, plainText, ranges, ArrayDeque(), blankRuns)
+      }
+    }
+  }
+
   private fun walkNode(
     node: MarkdownASTNode,
     plainText: StringBuilder,
@@ -51,6 +70,20 @@ object InputParser {
     activeStyles: ArrayDeque<ActiveStyle>,
     blankRuns: ArrayDeque<Int>,
   ) {
+    when (node.type) {
+      NodeType.UnorderedList -> {
+        walkListItems(node.children, isOrdered = false, plainText, ranges, blankRuns)
+        return
+      }
+
+      NodeType.OrderedList -> {
+        walkListItems(node.children, isOrdered = true, plainText, ranges, blankRuns)
+        return
+      }
+
+      else -> {}
+    }
+
     val styleType = nodeTypeToStyleType(node.type)
 
     if (styleType != null) {


### PR DESCRIPTION
### What/Why?

- Added a walkListItems helper.
- Wired UnorderedList and OrderedList node types into walkNode.
- Reconstructs list item markers (-, 1., and [x]/[ ] for task items) when walking the AST back into markdown.

InputParser.walkNode did not handle list nodes, so markdown parsing on Android silently dropped list markers. As a result, unordered lists, ordered lists, and task lists were rendered as plain paragraphs, losing their original markdown prefixes. This change preserves the correct markdown syntax when converting the parsed AST back into plain text


### Testing
- Manual testing as shown in the gif below
- All Maestro E2E tests ran


| Before | After |
| - | - |
| <img width="300" src="https://github.com/user-attachments/assets/49bf6494-dd11-4a3a-9396-b1f02dd976ac" /> | <img width="300" height="675" alt="after" src="https://github.com/user-attachments/assets/3967b053-b963-40c9-9cab-4c85c8dc1c4d" /> |

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)


### NB
No new tests were added. Since this change affects the rendered list output on the input component, a Maestro test may be appropriate if you'd like one. I'm happy to add it if needed
