### PR TITLE
fix(android): prevent RNGH Pressable from stealing link tap gestures

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownInternalText.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownInternalText.kt
@@ -18,6 +18,7 @@ import com.swmansion.enriched.markdown.utils.text.view.applySelectableState
 import com.swmansion.enriched.markdown.utils.text.view.cancelJSTouchForCheckboxTap
 import com.swmansion.enriched.markdown.utils.text.view.cancelJSTouchForLinkTap
 import com.swmansion.enriched.markdown.utils.text.view.createSelectionActionModeCallback
+import com.swmansion.enriched.markdown.utils.text.view.reallowParentInterceptIfLinkReleased
 import com.swmansion.enriched.markdown.utils.text.view.setupAsMarkdownTextView
 import com.swmansion.enriched.markdown.views.BlockSegmentView
 
@@ -109,8 +110,9 @@ class EnrichedMarkdownInternalText
         return true
       }
       val result = super.onTouchEvent(event)
-      if (event.action == MotionEvent.ACTION_DOWN) {
-        cancelJSTouchForLinkTap(event)
+      when (event.action) {
+        MotionEvent.ACTION_DOWN -> cancelJSTouchForLinkTap(event)
+        else -> reallowParentInterceptIfLinkReleased()
       }
       return result
     }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -32,6 +32,7 @@ import com.swmansion.enriched.markdown.utils.text.view.cancelJSTouchForLinkTap
 import com.swmansion.enriched.markdown.utils.text.view.createSelectionActionModeCallback
 import com.swmansion.enriched.markdown.utils.text.view.emitLinkLongPressEvent
 import com.swmansion.enriched.markdown.utils.text.view.emitLinkPressEvent
+import com.swmansion.enriched.markdown.utils.text.view.reallowParentInterceptIfLinkReleased
 import com.swmansion.enriched.markdown.utils.text.view.setupAsMarkdownTextView
 import java.util.concurrent.Executors
 
@@ -356,8 +357,9 @@ class EnrichedMarkdownText
         return true
       }
       val result = super.onTouchEvent(event)
-      if (event.action == MotionEvent.ACTION_DOWN) {
-        cancelJSTouchForLinkTap(event)
+      when (event.action) {
+        MotionEvent.ACTION_DOWN -> cancelJSTouchForLinkTap(event)
+        else -> reallowParentInterceptIfLinkReleased()
       }
       return result
     }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkEvents.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkEvents.kt
@@ -26,11 +26,32 @@ fun View.emitLinkLongPressEvent(url: String) {
 /**
  * Cancels the JS touch for an active link tap, preventing parent
  * Pressable/TouchableOpacity from firing onPress for the same tap.
+ *
+ * Also requests that parent ViewGroups do not intercept subsequent touch
+ * events in this gesture. This is necessary for react-native-gesture-handler's
+ * Pressable, which intercepts at the native ViewGroup level and would otherwise
+ * steal the gesture before ACTION_UP reaches the TextView.
  */
 fun TextView.cancelJSTouchForLinkTap(event: MotionEvent) {
   val currentMovementMethod = movementMethod
   if (currentMovementMethod is LinkLongPressMovementMethod && currentMovementMethod.isLinkTouchActive) {
+    parent?.requestDisallowInterceptTouchEvent(true)
     NativeGestureUtil.notifyNativeGestureStarted(this, event)
+  }
+}
+
+/**
+ * Re-allows parent ViewGroups to intercept touch events once the link
+ * touch is no longer active (slop exceeded, gesture ended, or cancelled).
+ * This restores normal scrolling behavior for parent ScrollView/RecyclerView.
+ *
+ * Must be called after [LinkLongPressMovementMethod.onTouchEvent] has
+ * processed the event, since that is where [isLinkTouchActive] is updated.
+ */
+fun TextView.reallowParentInterceptIfLinkReleased() {
+  val currentMovementMethod = movementMethod
+  if (currentMovementMethod is LinkLongPressMovementMethod && !currentMovementMethod.isLinkTouchActive) {
+    parent?.requestDisallowInterceptTouchEvent(false)
   }
 }
 
@@ -39,5 +60,6 @@ fun TextView.cancelJSTouchForLinkTap(event: MotionEvent) {
  * Pressable/TouchableOpacity from firing onPress for the same gesture.
  */
 fun View.cancelJSTouchForCheckboxTap(event: MotionEvent) {
+  parent?.requestDisallowInterceptTouchEvent(true)
   NativeGestureUtil.notifyNativeGestureStarted(this, event)
 }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
@@ -15,6 +15,7 @@ import android.text.TextPaint
 import android.text.style.AlignmentSpan
 import android.text.style.MetricAffectingSpan
 import android.view.Gravity
+import android.view.MotionEvent
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.HorizontalScrollView
@@ -30,6 +31,8 @@ import com.swmansion.enriched.markdown.utils.common.serialization.MarkdownASTSer
 import com.swmansion.enriched.markdown.utils.text.conversion.HTMLGenerator
 import com.swmansion.enriched.markdown.utils.text.extensions.replaceMathSpansWithPlaceholders
 import com.swmansion.enriched.markdown.utils.text.view.LinkLongPressMovementMethod
+import com.swmansion.enriched.markdown.utils.text.view.cancelJSTouchForLinkTap
+import com.swmansion.enriched.markdown.utils.text.view.reallowParentInterceptIfLinkReleased
 import com.swmansion.enriched.markdown.views.ContextMenuPopup
 import kotlin.math.ceil
 import kotlin.math.max
@@ -546,6 +549,15 @@ class TableContainerView(
       layoutDirection = View.LAYOUT_DIRECTION_LOCALE
       textDirection = View.TEXT_DIRECTION_LOCALE
       importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+      val result = super.onTouchEvent(event)
+      when (event.action) {
+        MotionEvent.ACTION_DOWN -> cancelJSTouchForLinkTap(event)
+        else -> reallowParentInterceptIfLinkReleased()
+      }
+      return result
     }
   }
 


### PR DESCRIPTION
### What/Why?

On Android, links rendered by `EnrichedMarkdownText` do not fire `onLinkPress` when the component is placed inside a `Pressable` from `react-native-gesture-handler`. Tapping a link fires the parent `Pressable`'s `onPress` instead. The same link works correctly when the parent is React Native's built-in `Pressable`. iOS is unaffected.

**Root cause:** The existing code uses `NativeGestureUtil.notifyNativeGestureStarted()` to prevent parent views from intercepting link taps. This only communicates with React Native's JS-level touch system, so it works with RN's built-in `Pressable`. However, RNGH's `Pressable` intercepts touches at the native Android `ViewGroup` level via `onInterceptTouchEvent`. It claims the gesture and sends `ACTION_CANCEL` to the `TextView` before `ACTION_UP` arrives, so `LinkMovementMethod` never calls `ClickableSpan.onClick()` and the link press is silently dropped.

**Fix:** Added `parent.requestDisallowInterceptTouchEvent(true)` on `ACTION_DOWN` when a link or checkbox tap is detected. This is a standard Android API that tells all parent `ViewGroup`s — including RNGH's gesture handler wrappers — not to intercept subsequent touch events for the current gesture. The flag auto-resets on the next `ACTION_DOWN`, so only the active tap is affected.

Also added an `onTouchEvent` override to `TableContainerView.CellTextView`, which was missing touch cancellation entirely and had the same vulnerability for links inside table cells.

Closes: #475 

### Testing
<!-- How to test changed code? What testing has been done? -->



 #### Screenshots
<!-- If you attach screenshots, please use <img src="" width=200/> -->

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/e4fa6fe2-b1e7-48fb-9f69-c48956c9357c" width=300 /> | <video src="https://github.com/user-attachments/assets/42aca3ce-2b06-41fc-afaa-c5b5eba5b5cb" width=300 /> |


### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

