### PR TITLE
chore(exampleapp): pair Get Raw Markdown and Copy to Clipboard on one row

### DIFF
--- a/apps/react-native-example/src/screens/playground/PlaygroundScreen.tsx
+++ b/apps/react-native-example/src/screens/playground/PlaygroundScreen.tsx
@@ -217,21 +217,23 @@ export default function PlaygroundScreen() {
           <Text style={styles.getMarkdownText}>Set Raw Markdown</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity
-          style={styles.getMarkdownButton}
-          onPress={handleGetMarkdown}
-          testID="get-markdown-button"
-        >
-          <Text style={styles.getMarkdownText}>Get Raw Markdown</Text>
-        </TouchableOpacity>
+        <View style={styles.buttonRowSplit}>
+          <TouchableOpacity
+            style={[styles.getMarkdownButton, styles.buttonHalf]}
+            onPress={handleGetMarkdown}
+            testID="get-markdown-button"
+          >
+            <Text style={styles.getMarkdownText}>Get Raw Markdown</Text>
+          </TouchableOpacity>
 
-        <TouchableOpacity
-          style={styles.getMarkdownButton}
-          onPress={handleCopyToClipboard}
-          testID="copy-to-clipboard-button"
-        >
-          <Text style={styles.getMarkdownText}>Copy Input to Clipboard</Text>
-        </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.getMarkdownButton, styles.buttonHalf]}
+            onPress={handleCopyToClipboard}
+            testID="copy-to-clipboard-button"
+          >
+            <Text style={styles.getMarkdownText}>Copy Input to Clipboard</Text>
+          </TouchableOpacity>
+        </View>
 
         <Modal
           visible={setMarkdownModalVisible}
@@ -420,6 +422,13 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     backgroundColor: '#BEEBD0',
     alignItems: 'center',
+  },
+  buttonRowSplit: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  buttonHalf: {
+    flex: 1,
   },
   getMarkdownText: {
     fontSize: 14,

--- a/apps/react-native-example/src/screens/playground/PlaygroundScreen.tsx
+++ b/apps/react-native-example/src/screens/playground/PlaygroundScreen.tsx
@@ -217,7 +217,7 @@ export default function PlaygroundScreen() {
           <Text style={styles.getMarkdownText}>Set Raw Markdown</Text>
         </TouchableOpacity>
 
-        <View style={styles.buttonRowSplit}>
+        <View style={styles.buttonRow}>
           <TouchableOpacity
             style={[styles.getMarkdownButton, styles.buttonHalf]}
             onPress={handleGetMarkdown}
@@ -422,10 +422,6 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     backgroundColor: '#BEEBD0',
     alignItems: 'center',
-  },
-  buttonRowSplit: {
-    flexDirection: 'row',
-    gap: 8,
   },
   buttonHalf: {
     flex: 1,


### PR DESCRIPTION
  ## Summary
  - Puts the Playground's `Get Raw Markdown` and `Copy Input to Clipboard`
    buttons on the same row (split 50/50 with an 8pt gap).
  - Reduces the Playground vertical footprint by one full button row.
  - Restores the preview-container to (approximately) its position at the
    time of #467 — the last time e2e reference screenshots were captured —
    so maestro's `cropOn: preview-container` captures the same viewport
    slice as the committed baselines instead of a cropped shorter one.

  ## Why
  After #461 (which added the Copy to Clipboard button) and #469 (which
  reworked the modal), the Playground grew one button row taller than
  what existed when the maestro baselines were captured in #467. That
  meant `cropOn: preview-container` was capturing a shorter slice of the
  preview than the baselines expect — surfacing diffs across ~30
  unrelated screenshot tests any time someone re-captured.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ef8ea728-6978-4c5f-974f-09b126a5b82f" />
