### PR TITLE
fix: reset cached style state in Fabric prepareForRecycle to stop stale-markdown flicker

### DIFF
--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -949,8 +949,16 @@ static char kENRMSegmentFadeAnimatorKey;
 
   _cachedMarkdown = nil;
   _renderedMarkdown = nil;
+  _config = nil;
+  _md4cFlags = [ENRMMd4cFlags defaultFlags];
+  _maxFontSizeMultiplier = 0;
+  _allowTrailingMargin = NO;
   _streamingAnimation = NO;
   _tableStreamingMode = ENRMTableStreamingModeProgressive;
+  _renderedStyleFingerprint = 0;
+  _pendingStyleFingerprint = 0;
+  _contextMenuItemTexts = nil;
+  _contextMenuItemIcons = nil;
   _dirtyFlags = ENRMDirtyNone;
 
   [super prepareForRecycle];

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -931,7 +931,8 @@ static char kENRMSegmentFadeAnimatorKey;
 
 - (void)prepareForRecycle
 {
-  _props = std::make_shared<const EnrichedMarkdownProps>();
+  const auto resetProps = std::make_shared<const EnrichedMarkdownProps>();
+  _props = resetProps;
   [_renderCoordinator invalidate];
 
   for (RCTUIView *segment in _segmentViews) {
@@ -951,6 +952,11 @@ static char kENRMSegmentFadeAnimatorKey;
   _renderedMarkdown = nil;
   _config = nil;
   _md4cFlags = [ENRMMd4cFlags defaultFlags];
+  _md4cFlags.underline = resetProps->md4cFlags.underline;
+  _md4cFlags.superscript = resetProps->md4cFlags.superscript;
+  _md4cFlags.subscript = resetProps->md4cFlags.subscript;
+  _md4cFlags.latexMath = resetProps->md4cFlags.latexMath;
+  _md4cFlags.highlight = resetProps->md4cFlags.highlight;
   _maxFontSizeMultiplier = 0;
   _allowTrailingMargin = NO;
   _streamingAnimation = NO;

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -67,6 +67,7 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
 static char kENRMSegmentFadeAnimatorKey;
 
 @interface EnrichedMarkdown () <RCTEnrichedMarkdownViewProtocol, UITextViewDelegate>
++ (ENRMMd4cFlags *)flagsFromProps:(const EnrichedMarkdownMd4cFlagsStruct &)props;
 - (void)emitLinkPress:(NSString *)url;
 - (void)emitLinkLongPress:(NSString *)url;
 - (void)emitTaskListItemPress:(NSInteger)index checked:(BOOL)checked text:(NSString *)text;
@@ -123,6 +124,17 @@ static char kENRMSegmentFadeAnimatorKey;
   return concreteComponentDescriptorProvider<EnrichedMarkdownComponentDescriptor>();
 }
 
++ (ENRMMd4cFlags *)flagsFromProps:(const EnrichedMarkdownMd4cFlagsStruct &)props
+{
+  ENRMMd4cFlags *flags = [ENRMMd4cFlags defaultFlags];
+  flags.underline = props.underline;
+  flags.superscript = props.superscript;
+  flags.subscript = props.subscript;
+  flags.latexMath = props.latexMath;
+  flags.highlight = props.highlight;
+  return flags;
+}
+
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
@@ -131,7 +143,7 @@ static char kENRMSegmentFadeAnimatorKey;
 
     self.backgroundColor = [RCTUIColor clearColor];
     _parser = [[ENRMMarkdownParser alloc] init];
-    _md4cFlags = [ENRMMd4cFlags defaultFlags];
+    _md4cFlags = [EnrichedMarkdown flagsFromProps:defaultProps->md4cFlags];
     _segmentViews = [NSMutableArray array];
     _segmentSignatures = [NSMutableArray array];
     _dirtyFlags = ENRMDirtyNone;
@@ -783,24 +795,12 @@ static char kENRMSegmentFadeAnimatorKey;
     _dirtyFlags |= ENRMDirtyRecreateSegments | ENRMDirtyForceHeight | ENRMDirtyRender;
   }
 
-  if (newViewProps.md4cFlags.underline != oldViewProps.md4cFlags.underline) {
-    _md4cFlags.underline = newViewProps.md4cFlags.underline;
-    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
-  }
-  if (newViewProps.md4cFlags.superscript != oldViewProps.md4cFlags.superscript) {
-    _md4cFlags.superscript = newViewProps.md4cFlags.superscript;
-    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
-  }
-  if (newViewProps.md4cFlags.subscript != oldViewProps.md4cFlags.subscript) {
-    _md4cFlags.subscript = newViewProps.md4cFlags.subscript;
-    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
-  }
-  if (newViewProps.md4cFlags.latexMath != oldViewProps.md4cFlags.latexMath) {
-    _md4cFlags.latexMath = newViewProps.md4cFlags.latexMath;
-    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
-  }
-  if (newViewProps.md4cFlags.highlight != oldViewProps.md4cFlags.highlight) {
-    _md4cFlags.highlight = newViewProps.md4cFlags.highlight;
+  if (newViewProps.md4cFlags.underline != oldViewProps.md4cFlags.underline ||
+      newViewProps.md4cFlags.superscript != oldViewProps.md4cFlags.superscript ||
+      newViewProps.md4cFlags.subscript != oldViewProps.md4cFlags.subscript ||
+      newViewProps.md4cFlags.latexMath != oldViewProps.md4cFlags.latexMath ||
+      newViewProps.md4cFlags.highlight != oldViewProps.md4cFlags.highlight) {
+    _md4cFlags = [EnrichedMarkdown flagsFromProps:newViewProps.md4cFlags];
     _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
   }
 
@@ -951,16 +951,13 @@ static char kENRMSegmentFadeAnimatorKey;
   _cachedMarkdown = nil;
   _renderedMarkdown = nil;
   _config = nil;
-  _md4cFlags = [ENRMMd4cFlags defaultFlags];
-  _md4cFlags.underline = resetProps->md4cFlags.underline;
-  _md4cFlags.superscript = resetProps->md4cFlags.superscript;
-  _md4cFlags.subscript = resetProps->md4cFlags.subscript;
-  _md4cFlags.latexMath = resetProps->md4cFlags.latexMath;
-  _md4cFlags.highlight = resetProps->md4cFlags.highlight;
+  _md4cFlags = [EnrichedMarkdown flagsFromProps:resetProps->md4cFlags];
   _maxFontSizeMultiplier = 0;
   _allowTrailingMargin = NO;
   _streamingAnimation = NO;
   _tableStreamingMode = ENRMTableStreamingModeProgressive;
+  _lineBreakStrategy = NSLineBreakStrategyNone;
+  _writingDirectionMode = ENRMWritingDirectionModeFirstStrong;
   _renderedStyleFingerprint = 0;
   _pendingStyleFingerprint = 0;
   _contextMenuItemTexts = nil;

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -962,6 +962,10 @@ static char kENRMSegmentFadeAnimatorKey;
   _pendingStyleFingerprint = 0;
   _contextMenuItemTexts = nil;
   _contextMenuItemIcons = nil;
+  _fontScaleObserver.allowFontScaling = resetProps->allowFontScaling;
+  _accessibilityLabels = nil;
+  _spoilerOverlay =
+      ENRMSpoilerOverlayFromString([[NSString alloc] initWithUTF8String:resetProps->spoilerOverlay.c_str()]);
   _dirtyFlags = ENRMDirtyNone;
 
   [super prepareForRecycle];

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -647,6 +647,8 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   _pendingStyleFingerprint = 0;
   _contextMenuItemTexts = nil;
   _contextMenuItemIcons = nil;
+  _fontScaleObserver.allowFontScaling = resetProps->allowFontScaling;
+  _accessibilityLabels = nil;
   _accessibilityElements = nil;
   _accessibilityInfo = nil;
   _accessibilityNeedsRebuild = NO;

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -629,7 +629,8 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
 
 - (void)prepareForRecycle
 {
-  _props = std::make_shared<const EnrichedMarkdownTextProps>();
+  const auto resetProps = std::make_shared<const EnrichedMarkdownTextProps>();
+  _props = resetProps;
   [_renderCoordinator invalidate];
 
   [_fadeAnimator cancel];
@@ -641,6 +642,11 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   _renderedMarkdown = nil;
   _config = nil;
   _md4cFlags = [ENRMMd4cFlags defaultFlags];
+  _md4cFlags.underline = resetProps->md4cFlags.underline;
+  _md4cFlags.superscript = resetProps->md4cFlags.superscript;
+  _md4cFlags.subscript = resetProps->md4cFlags.subscript;
+  _md4cFlags.latexMath = resetProps->md4cFlags.latexMath;
+  _md4cFlags.highlight = resetProps->md4cFlags.highlight;
   _maxFontSizeMultiplier = 0;
   _lastElementMarginBottom = 0;
   _allowTrailingMargin = NO;

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -46,6 +46,7 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
 };
 
 @interface EnrichedMarkdownText () <RCTEnrichedMarkdownTextViewProtocol, UITextViewDelegate>
++ (ENRMMd4cFlags *)flagsFromProps:(const EnrichedMarkdownTextMd4cFlagsStruct &)props;
 - (void)setupTextView;
 - (void)renderMarkdownContent:(NSString *)markdownString;
 - (void)applyRenderedText:(NSMutableAttributedString *)attributedText;
@@ -117,6 +118,17 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   return concreteComponentDescriptorProvider<EnrichedMarkdownTextComponentDescriptor>();
 }
 
++ (ENRMMd4cFlags *)flagsFromProps:(const EnrichedMarkdownTextMd4cFlagsStruct &)props
+{
+  ENRMMd4cFlags *flags = [ENRMMd4cFlags defaultFlags];
+  flags.underline = props.underline;
+  flags.superscript = props.superscript;
+  flags.subscript = props.subscript;
+  flags.latexMath = props.latexMath;
+  flags.highlight = props.highlight;
+  return flags;
+}
+
 #pragma mark - Measuring and State
 
 - (CGSize)measureSize:(CGFloat)maxWidth
@@ -185,7 +197,7 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
 
     self.backgroundColor = [RCTUIColor clearColor];
     _parser = [[ENRMMarkdownParser alloc] init];
-    _md4cFlags = [ENRMMd4cFlags defaultFlags];
+    _md4cFlags = [EnrichedMarkdownText flagsFromProps:defaultProps->md4cFlags];
 
     _renderCoordinator =
         [[ENRMAsyncRenderCoordinator alloc] initWithQueueLabel:"com.swmansion.enriched.markdown.render"];
@@ -503,28 +515,12 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
     _dirtyFlags |= ENRMDirtyRender;
   }
 
-  if (newViewProps.md4cFlags.underline != oldViewProps.md4cFlags.underline) {
-    _md4cFlags.underline = newViewProps.md4cFlags.underline;
-    _forceHeightUpdateOnNextRender = YES;
-    _dirtyFlags |= ENRMDirtyRender;
-  }
-  if (newViewProps.md4cFlags.superscript != oldViewProps.md4cFlags.superscript) {
-    _md4cFlags.superscript = newViewProps.md4cFlags.superscript;
-    _forceHeightUpdateOnNextRender = YES;
-    _dirtyFlags |= ENRMDirtyRender;
-  }
-  if (newViewProps.md4cFlags.subscript != oldViewProps.md4cFlags.subscript) {
-    _md4cFlags.subscript = newViewProps.md4cFlags.subscript;
-    _forceHeightUpdateOnNextRender = YES;
-    _dirtyFlags |= ENRMDirtyRender;
-  }
-  if (newViewProps.md4cFlags.latexMath != oldViewProps.md4cFlags.latexMath) {
-    _md4cFlags.latexMath = newViewProps.md4cFlags.latexMath;
-    _forceHeightUpdateOnNextRender = YES;
-    _dirtyFlags |= ENRMDirtyRender;
-  }
-  if (newViewProps.md4cFlags.highlight != oldViewProps.md4cFlags.highlight) {
-    _md4cFlags.highlight = newViewProps.md4cFlags.highlight;
+  if (newViewProps.md4cFlags.underline != oldViewProps.md4cFlags.underline ||
+      newViewProps.md4cFlags.superscript != oldViewProps.md4cFlags.superscript ||
+      newViewProps.md4cFlags.subscript != oldViewProps.md4cFlags.subscript ||
+      newViewProps.md4cFlags.latexMath != oldViewProps.md4cFlags.latexMath ||
+      newViewProps.md4cFlags.highlight != oldViewProps.md4cFlags.highlight) {
+    _md4cFlags = [EnrichedMarkdownText flagsFromProps:newViewProps.md4cFlags];
     _forceHeightUpdateOnNextRender = YES;
     _dirtyFlags |= ENRMDirtyRender;
   }
@@ -641,15 +637,12 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   _cachedMarkdown = nil;
   _renderedMarkdown = nil;
   _config = nil;
-  _md4cFlags = [ENRMMd4cFlags defaultFlags];
-  _md4cFlags.underline = resetProps->md4cFlags.underline;
-  _md4cFlags.superscript = resetProps->md4cFlags.superscript;
-  _md4cFlags.subscript = resetProps->md4cFlags.subscript;
-  _md4cFlags.latexMath = resetProps->md4cFlags.latexMath;
-  _md4cFlags.highlight = resetProps->md4cFlags.highlight;
+  _md4cFlags = [EnrichedMarkdownText flagsFromProps:resetProps->md4cFlags];
   _maxFontSizeMultiplier = 0;
   _lastElementMarginBottom = 0;
   _allowTrailingMargin = NO;
+  _lineBreakStrategy = NSLineBreakStrategyNone;
+  _writingDirectionMode = ENRMWritingDirectionModeFirstStrong;
   _renderedStyleFingerprint = 0;
   _pendingStyleFingerprint = 0;
   _contextMenuItemTexts = nil;

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -639,10 +639,20 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   _forceHeightUpdateOnNextRender = NO;
   _cachedMarkdown = nil;
   _renderedMarkdown = nil;
+  _config = nil;
+  _md4cFlags = [ENRMMd4cFlags defaultFlags];
+  _maxFontSizeMultiplier = 0;
+  _lastElementMarginBottom = 0;
+  _allowTrailingMargin = NO;
+  _renderedStyleFingerprint = 0;
+  _pendingStyleFingerprint = 0;
+  _contextMenuItemTexts = nil;
+  _contextMenuItemIcons = nil;
   _accessibilityElements = nil;
   _accessibilityInfo = nil;
   _accessibilityNeedsRebuild = NO;
   [_spoilerManager removeAllOverlays];
+  _spoilerManager = nil;
   if (_textView != nil) {
     ENRMSetAttributedText(_textView, [[NSAttributedString alloc] initWithString:@""]);
     _textView.hidden = YES;


### PR DESCRIPTION
### What/Why?

On the Fabric (new architecture) iOS path, recycled `EnrichedMarkdown` / `EnrichedMarkdownText` views kept cached style and md4c-flag state from their previous mount, so a recycled view briefly showed stale markdown (a flicker) before the next props update repainted it. `prepareForRecycle` now resets the cached style state back to the generated-props baseline, and resets `_md4cFlags` from that same baseline (not the library default), so a recycled view with `md4cFlags.latexMath` disabled no longer parses `$...$` as math. Fixes #110.

### Testing

Change is confined to the iOS `prepareForRecycle` reset path on the Fabric renderer. Verified by code inspection that the reset now mirrors the reset `_props` baseline so the subsequent `updateProps` diff applies the incoming flags correctly. On-device iOS/Android runs and the example app were not exercised in this environment, so the iOS/Android build-and-run checklist items are left unchecked for a maintainer with a simulator to confirm.

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [x] Updated documentation/README if applicable (none needed for this fix)
- Ran example app to verify changes: not performed in this environment (no iOS simulator); reset path verified by inspection and review
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
