### PR TITLE
fix(ios): dedupe RaTeX XCFramework signature for Xcode 26 archive (#491)

### DIFF
--- a/apps/react-native-example/ios/Podfile.lock
+++ b/apps/react-native-example/ios/Podfile.lock
@@ -2559,7 +2559,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   EnrichedMarkdownCore: 33ec2bafbc265cfe76df3095fb21522440dd0a30
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: 24defc72310bc7b45e7797e47e02fe8e627f6ecc
+  hermes-engine: 4a0ceceb51f483aef72bfeb288e965aff6defa54
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f
@@ -2634,7 +2634,7 @@ SPEC CHECKSUMS:
   ReactCodegen: cd296de5e1c422deebafff34134d1721b5c29704
   ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
-  ReactNativeEnrichedMarkdown: 19e936a11df8f82d438a63211f56f3e92b2e665e
+  ReactNativeEnrichedMarkdown: b4c77916d8523cd08f36db1381568d90c20ee244
   RNCAsyncStorage: 7d913885caaae13f5fb62dd0bd04c674ea8bf97b
   RNDateTimePicker: afe0288e6c7855994f7f2617b7b2c05799fea7f3
   RNGestureHandler: 7b07d9192bc65c6883fb37fdecc05dc6b61c814f

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -68,6 +68,20 @@ Pod::Spec.new do |s|
           sed -i '' -E '/^(framework )?module RaTeXFFI /,/^\}/d' "$MODULEMAP"
         SCRIPT
         execution_position: :before_compile
+      },
+      {
+        name: 'Dedupe RaTeX XCFramework Signature',
+        script: <<~'SCRIPT',
+          # Xcode 26 generates a .signature file for each signed XCFramework.
+          # When the RaTeX XCFramework is consumed via spm_dependency inside a
+          # CocoaPods target, both the SPM product and the pod target produce a
+          # copy. During archive assembly Xcode copies all signatures into a flat
+          # Signatures/ directory, and the second copy collides with the first.
+          # Removing the pod-target copy prevents the collision. This is a no-op
+          # on older Xcode versions or simulator builds where the file is absent.
+          rm -f "${CONFIGURATION_BUILD_DIR}/RaTeX.xcframework-ios.signature"
+        SCRIPT
+        execution_position: :after_compile
       }
     ]
   end


### PR DESCRIPTION
### What/Why?

Xcode 26 introduced signature collection for signed XCFrameworks during archive assembly. When the RaTeX XCFramework is consumed via `spm_dependency` inside a CocoaPods target, both the SPM product target and the pod target produce a `RaTeX.xcframework-ios.signature` file. During `xcodebuild archive`, Xcode copies all collected signatures into a flat `<archive>/Signatures/` directory, and the second copy collides with the first:

```
xcodebuild: error: "RaTeX.xcframework-ios.signature" couldn't be copied to "Signatures"
because an item with the same name already exists.
```

This only affects archive builds (device builds via EAS / Xcode Organizer). Simulator builds and `xcodebuild build` are unaffected.

The fix adds a post-compile script phase to the podspec that removes the pod-target's duplicate signature file (`rm -f`). This is the same approach used by [lottie-react-native](https://github.com/LottieFiles/dotlottie-react-native/pull/66) and [maplibre-react-native](https://github.com/maplibre/maplibre-react-native/issues/1489). The command is a no-op on older Xcode versions and simulator builds where the file doesn't exist.

Fixes #491

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

