### PR TITLE
perf(ios): cache fontScale to avoid dispatch_sync on every measurement

### DIFF
--- a/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
@@ -36,6 +36,7 @@ static inline CGFloat ENRMFontScaleForMeasurement(bool allowFontScaling)
     }
     cachedScale.store(scale, std::memory_order_relaxed);
 
+#if !TARGET_OS_OSX
     dispatch_async(dispatch_get_main_queue(), ^{
       [[NSNotificationCenter defaultCenter]
           addObserverForName:UIContentSizeCategoryDidChangeNotification
@@ -45,6 +46,7 @@ static inline CGFloat ENRMFontScaleForMeasurement(bool allowFontScaling)
                     cachedScale.store(RCTFontSizeMultiplier(), std::memory_order_relaxed);
                   }];
     });
+#endif
   });
 
   return cachedScale.load(std::memory_order_relaxed);

--- a/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
@@ -16,7 +16,7 @@ namespace facebook::react {
 // synchronously joins the layout queue from main. A synchronous
 // layout flush from main would deadlock.
 
-static inline CGFloat ENRMFontScaleForMeasurement(bool allowFontScaling)
+inline CGFloat ENRMFontScaleForMeasurement(bool allowFontScaling)
 {
   if (!allowFontScaling) {
     return 1.0;

--- a/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
@@ -4,6 +4,7 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTUtils.h>
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/utils/ManagedObjectWrapper.h>
@@ -21,16 +22,32 @@ static inline CGFloat ENRMFontScaleForMeasurement(bool allowFontScaling)
     return 1.0;
   }
 
-  __block CGFloat fontScale = 1.0;
-  void (^readFontScale)(void) = ^{ fontScale = RCTFontSizeMultiplier(); };
+  static std::atomic<double> cachedScale{0.0};
+  static std::once_flag flag;
 
-  if ([NSThread isMainThread]) {
-    readFontScale();
-  } else {
-    dispatch_sync(dispatch_get_main_queue(), readFontScale);
-  }
+  std::call_once(flag, [] {
+    __block CGFloat scale = 1.0;
+    void (^readScale)(void) = ^{ scale = RCTFontSizeMultiplier(); };
 
-  return fontScale;
+    if ([NSThread isMainThread]) {
+      readScale();
+    } else {
+      dispatch_sync(dispatch_get_main_queue(), readScale);
+    }
+    cachedScale.store(scale, std::memory_order_relaxed);
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [[NSNotificationCenter defaultCenter]
+          addObserverForName:UIContentSizeCategoryDidChangeNotification
+                      object:nil
+                       queue:[NSOperationQueue mainQueue]
+                  usingBlock:^(NSNotification *) {
+                    cachedScale.store(RCTFontSizeMultiplier(), std::memory_order_relaxed);
+                  }];
+    });
+  });
+
+  return cachedScale.load(std::memory_order_relaxed);
 }
 
 static inline Size ENRMClampMeasuredSize(CGSize size, const LayoutConstraints &layoutConstraints)

--- a/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
@@ -3,9 +3,11 @@
 #include "MeasurementCache.h"
 #import <Foundation/Foundation.h>
 #import <React/RCTUtils.h>
+#include <TargetConditionals.h>
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <mutex>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/utils/ManagedObjectWrapper.h>
 


### PR DESCRIPTION
## Summary

- Replaces per-measurement `dispatch_sync` to main thread for reading `RCTFontSizeMultiplier()` with a cached `std::atomic<double>`
- First read still uses `dispatch_sync`; all subsequent measurements read the atomic directly — no main-thread hop
- Registers a `UIContentSizeCategoryDidChangeNotification` observer to update the cache when the user changes Dynamic Type font size

## Test plan

- [ ] Verify measurement results are correct with default font scale
- [ ] Change Dynamic Type size in Settings > Accessibility > Display & Text Size, verify markdown re-measures correctly
- [ ] Profile a scrolling feed with many markdown cells — confirm no `dispatch_sync` to main in `ENRMFontScaleForMeasurement` after first call


Made with [Cursor](https://cursor.com)