### PR TITLE
feat(input): heading blocks (H1-H6) on the block pipeline

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -253,8 +253,12 @@ class EnrichedMarkdownTextInputView(
     try {
       formattingStore.adjustForEdit(editStart, deletedLength, insertedLength)
       blockStore.adjustForEdit(editStart, deletedLength, insertedLength)
+      // Blocks are line-scoped: snap ranges back to whole-line bounds so
+      // characters typed at a line's edges rejoin the block and a newline
+      // split clips the block to its first line.
+      text?.let { blockStore.normalizeToLineBounds(it) }
       applyPendingStyles(editStart, insertedLength)
-      applyFormatting()
+      applyFormattingScopedToEdit(editStart, insertedLength)
 
       val editable = text
       if (editable != null) {
@@ -335,6 +339,33 @@ class EnrichedMarkdownTextInputView(
     val editable = text ?: return
     formatter.applyFormatting(editable, formattingStore.allRanges)
     formatter.applyBlockFormatting(editable, blockStore.allRanges)
+  }
+
+  /**
+   * Re-applies inline formatting across the document, but re-normalizes block spans
+   * only on the paragraph(s) touched by an edit at `[editStart, editStart + insertedLength)`.
+   * Heading sizing is paragraph-scoped, so re-stamping only the edited line keeps
+   * per-keystroke work bounded instead of re-spanning the whole document.
+   */
+  private fun applyFormattingScopedToEdit(
+    editStart: Int,
+    insertedLength: Int,
+  ) {
+    val editable = text ?: return
+    formatter.applyFormatting(editable, formattingStore.allRanges)
+
+    val length = editable.length
+    val rawStart = editStart.coerceIn(0, length)
+    val rawEnd = (editStart + insertedLength).coerceIn(rawStart, length)
+
+    // Expand the edit span to whole-line bounds: a heading span covers its line, so
+    // re-stamping must cover every line the edit touched, edge-to-edge.
+    var lineStart = rawStart
+    while (lineStart > 0 && editable[lineStart - 1] != '\n') lineStart--
+    var lineEnd = rawEnd
+    while (lineEnd < length && editable[lineEnd] != '\n') lineEnd++
+
+    formatter.applyBlockFormatting(editable, blockStore.allRanges, lineStart, lineEnd)
   }
 
   private fun applyFormattingAndEmit() {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -253,9 +253,6 @@ class EnrichedMarkdownTextInputView(
     try {
       formattingStore.adjustForEdit(editStart, deletedLength, insertedLength)
       blockStore.adjustForEdit(editStart, deletedLength, insertedLength)
-      // Blocks are line-scoped: snap ranges back to whole-line bounds so
-      // characters typed at a line's edges rejoin the block and a newline
-      // split clips the block to its first line.
       text?.let { blockStore.normalizeToLineBounds(it) }
       applyPendingStyles(editStart, insertedLength)
       applyFormattingScopedToEdit(editStart, insertedLength)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
@@ -75,15 +75,9 @@ class BlockStore {
   }
 
   /**
-   * Re-normalizes every stored range back to the whole-line bounds of the line
-   * containing its start. Call after [adjustForEdit] once [text] is final:
-   * [adjustForEdit] deliberately leaves characters inserted at a range's start
-   * or end outside the range (matching [FormattingStore]'s convention), and a
-   * newline typed inside a range leaves it spanning two lines. Re-snapping to
-   * line bounds re-absorbs edge-typed characters, clips a split range to its
-   * first line (the text after the caret becomes a plain paragraph), and drops
-   * blocks that a line-join landed on an earlier block's line (first wins).
-   * Idempotent: ranges already line-scoped are untouched.
+   * Snaps every stored range to the line bounds of its start position.
+   * Absorbs edge-typed chars, clips split ranges to first line, drops
+   * duplicates. Call after [adjustForEdit] once [text] is final. Idempotent.
    */
   fun normalizeToLineBounds(text: CharSequence) {
     if (ranges.isEmpty()) return

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
@@ -75,6 +75,35 @@ class BlockStore {
   }
 
   /**
+   * Re-normalizes every stored range back to the whole-line bounds of the line
+   * containing its start. Call after [adjustForEdit] once [text] is final:
+   * [adjustForEdit] deliberately leaves characters inserted at a range's start
+   * or end outside the range (matching [FormattingStore]'s convention), and a
+   * newline typed inside a range leaves it spanning two lines. Re-snapping to
+   * line bounds re-absorbs edge-typed characters, clips a split range to its
+   * first line (the text after the caret becomes a plain paragraph), and drops
+   * blocks that a line-join landed on an earlier block's line (first wins).
+   * Idempotent: ranges already line-scoped are untouched.
+   */
+  fun normalizeToLineBounds(text: CharSequence) {
+    if (ranges.isEmpty()) return
+
+    var previousEnd = -1
+    val iterator = ranges.listIterator()
+    while (iterator.hasNext()) {
+      val range = iterator.next()
+      val (lineStart, lineEnd) = paragraphBounds(range.start, range.start, text)
+      if (lineEnd <= lineStart || lineStart <= previousEnd) {
+        iterator.remove()
+        continue
+      }
+      range.start = lineStart
+      range.end = lineEnd
+      previousEnd = lineEnd
+    }
+  }
+
+  /**
    * Drops any stored block overlapping `[start, end)` so a replacement can be
    * inserted cleanly. Blocks are line-scoped and never partially overlap, so a
    * touched block is removed wholesale.

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputFormatter.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputFormatter.kt
@@ -9,6 +9,7 @@ import com.swmansion.enriched.markdown.input.model.InputFormatterStyle
 import com.swmansion.enriched.markdown.input.model.StyleType
 import com.swmansion.enriched.markdown.input.styles.BlockHandler
 import com.swmansion.enriched.markdown.input.styles.BoldStyleHandler
+import com.swmansion.enriched.markdown.input.styles.HeadingBlockHandler
 import com.swmansion.enriched.markdown.input.styles.ItalicStyleHandler
 import com.swmansion.enriched.markdown.input.styles.LinkStyleHandler
 import com.swmansion.enriched.markdown.input.styles.SpoilerStyleHandler
@@ -34,11 +35,14 @@ class InputFormatter {
     )
 
   /**
-   * Block handlers are registered here as concrete block types are added. Empty
-   * in PR1: with no handler registered, every paragraph stays a plain paragraph
-   * and the block pipeline is a no-op.
+   * Block handlers, keyed by block type. A single [HeadingBlockHandler] serves all
+   * six heading levels — it reads the level from the [BlockRange] — so it is mapped
+   * under every `HEADING_n` key.
    */
-  val blockHandlers: Map<BlockType, BlockHandler> = emptyMap()
+  val blockHandlers: Map<BlockType, BlockHandler> =
+    HeadingBlockHandler().let { heading ->
+      BlockType.HEADINGS.associateWith { heading }
+    }
 
   fun handlerForBlock(type: BlockType): BlockHandler? = blockHandlers[type]
 
@@ -130,15 +134,32 @@ class InputFormatter {
   fun applyBlockFormatting(
     spannable: Spannable,
     blockRanges: List<BlockRange>,
+  ) = applyBlockFormatting(spannable, blockRanges, 0, spannable.length)
+
+  /**
+   * Re-stamps block spans, scoped to `[scopeStart, scopeEnd)`. Only the block spans
+   * we created that intersect the scope are removed, and only the block ranges
+   * intersecting the scope are re-applied — so an edit re-normalizes just the
+   * affected line(s) instead of the whole document on every keystroke. Pass the
+   * full document range for a wholesale re-apply (import / style change).
+   */
+  fun applyBlockFormatting(
+    spannable: Spannable,
+    blockRanges: List<BlockRange>,
+    scopeStart: Int,
+    scopeEnd: Int,
   ) {
     val currentStyle = style ?: return
     if (blockHandlers.isEmpty()) return
+
+    val start = scopeStart.coerceIn(0, spannable.length)
+    val end = scopeEnd.coerceIn(start, spannable.length)
 
     val blockSpanClasses = blockHandlers.values.flatMap { it.spanClasses() }.toSet()
 
     val existingBlockSpans =
       spannable
-        .getSpans(0, spannable.length, Any::class.java)
+        .getSpans(start, end, Any::class.java)
         .filter { span -> span is MarkdownSpan && blockSpanClasses.any { it.isInstance(span) } }
     for (span in existingBlockSpans) {
       spannable.removeSpan(span)
@@ -146,6 +167,8 @@ class InputFormatter {
 
     for (range in blockRanges) {
       if (range.start >= range.end || range.start < 0 || range.end > spannable.length) continue
+      // Skip blocks outside the scope so unaffected lines keep their existing spans.
+      if (range.end <= start || range.start >= end) continue
       val handler = blockHandlers[range.type] ?: continue
       for (span in handler.createSpans(range, currentStyle)) {
         spannable.setSpan(span, range.start, range.end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputParser.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputParser.kt
@@ -66,9 +66,9 @@ object InputParser {
     // Block-level node: record where its text content begins so we can build a
     // BlockRange on the way back out. PARAGRAPH is the implicit default and is
     // dropped below, so it produces no stored block range.
-    val blockType = nodeTypeToBlockType(node.type)
-    val blockStartPosition = plainText.length
     val blockLevel = node.getAttribute("level")?.toIntOrNull() ?: 0
+    val blockType = nodeTypeToBlockType(node.type, blockLevel)
+    val blockStartPosition = plainText.length
 
     if (node.type == NodeType.Text) {
       plainText.append(node.content)
@@ -115,13 +115,17 @@ object InputParser {
 
   /**
    * Maps a parser block node to a [BlockType], mirroring [nodeTypeToStyleType]
-   * for inline spans. A concrete block handler extends recognition by adding its
-   * node here (e.g. `NodeType.Heading -> BlockType.HEADING`). PR1 maps only the
-   * implicit PARAGRAPH, which is filtered out, so no block ranges are produced.
+   * for inline spans. A heading maps to its per-level `HEADING_n` (from the node's
+   * `level` attribute); an out-of-range level falls back to PARAGRAPH so a
+   * malformed parse degrades gracefully rather than dropping the line.
    */
-  private fun nodeTypeToBlockType(nodeType: NodeType): BlockType? =
+  private fun nodeTypeToBlockType(
+    nodeType: NodeType,
+    level: Int,
+  ): BlockType? =
     when (nodeType) {
       NodeType.Paragraph -> BlockType.PARAGRAPH
+      NodeType.Heading -> BlockType.forHeadingLevel(level) ?: BlockType.PARAGRAPH
       else -> null
     }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/model/BlockType.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/model/BlockType.kt
@@ -12,4 +12,23 @@ package com.swmansion.enriched.markdown.input.model
  */
 enum class BlockType {
   PARAGRAPH,
+  HEADING_1,
+  HEADING_2,
+  HEADING_3,
+  HEADING_4,
+  HEADING_5,
+  HEADING_6,
+  ;
+
+  companion object {
+    /** The six heading block types, indexable by level via [forHeadingLevel]. */
+    val HEADINGS: List<BlockType> =
+      listOf(HEADING_1, HEADING_2, HEADING_3, HEADING_4, HEADING_5, HEADING_6)
+
+    /**
+     * Maps an H-level (1-6) to its [BlockType], or null when out of range. Used by
+     * the parser to turn an AST heading node's `level` attribute into a block type.
+     */
+    fun forHeadingLevel(level: Int): BlockType? = HEADINGS.getOrNull(level - 1)
+  }
 }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/model/InputFormatterStyle.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/model/InputFormatterStyle.kt
@@ -9,6 +9,29 @@ data class InputFormatterStyle(
   val linkVariants: List<InputLinkVariantStyle>,
   val spoilerColor: Int,
   val spoilerBackgroundColor: Int,
+  /** Per-level heading styling, indexed 0..5 for H1..H6. Always length 6. */
+  val headings: List<InputHeadingStyle>,
+) {
+  /**
+   * Resolves the heading style for an H-level (1-6), clamping out-of-range levels
+   * to the nearest valid level so a malformed parse can never crash the formatter.
+   */
+  fun headingStyle(level: Int): InputHeadingStyle = headings[(level - 1).coerceIn(0, headings.size - 1)]
+}
+
+/**
+ * Resolved per-level heading style for the input editor.
+ *
+ * @property fontSizePx font size in pixels (already converted from the SP prop),
+ *   or null to leave the base text size unchanged.
+ * @property fontWeight parsed font weight (e.g. [android.graphics.Typeface.BOLD]),
+ *   or [com.facebook.react.common.ReactConstants.UNSET] when unspecified.
+ * @property color text color, or null to keep the editor's default color.
+ */
+data class InputHeadingStyle(
+  val fontSizePx: Float?,
+  val fontWeight: Int,
+  val color: Int?,
 )
 
 data class InputLinkVariantStyle(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/spans/InputHeadingSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/spans/InputHeadingSpan.kt
@@ -9,15 +9,9 @@ import com.swmansion.enriched.markdown.input.formatting.MarkdownSpan
 import com.swmansion.enriched.markdown.input.model.InputFormatterStyle
 
 /**
- * Sizes (and optionally weights/colors) a heading line in the editor per the
- * configured per-level [InputFormatterStyle.headingStyle]. Mirrors the readonly
- * renderer's `HeadingSpan` so edit and read views size headings identically.
- *
- * It is a [MetricAffectingSpan] that only adjusts the paint's text size, weight
- * and color — it never replaces the typeface family. The current bold/italic
- * style bits already set by inline spans are preserved through [BOLD_ITALIC_MASK],
- * so a bold word inside an H1 stays both big AND bold. Tagged [MarkdownSpan] so the
- * formatter cleans up only the heading spans it created, leaving inline spans intact.
+ * Sizes and optionally weights/colors a heading line per [InputFormatterStyle.headingStyle].
+ * Preserves inline bold/italic via [BOLD_ITALIC_MASK] so emphasis composes with heading weight.
+ * Tagged [MarkdownSpan] for formatter cleanup.
  */
 class InputHeadingSpan(
   val level: Int,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/spans/InputHeadingSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/spans/InputHeadingSpan.kt
@@ -1,0 +1,64 @@
+package com.swmansion.enriched.markdown.input.spans
+
+import android.annotation.SuppressLint
+import android.graphics.Typeface
+import android.text.TextPaint
+import android.text.style.MetricAffectingSpan
+import com.facebook.react.common.ReactConstants
+import com.swmansion.enriched.markdown.input.formatting.MarkdownSpan
+import com.swmansion.enriched.markdown.input.model.InputFormatterStyle
+
+/**
+ * Sizes (and optionally weights/colors) a heading line in the editor per the
+ * configured per-level [InputFormatterStyle.headingStyle]. Mirrors the readonly
+ * renderer's `HeadingSpan` so edit and read views size headings identically.
+ *
+ * It is a [MetricAffectingSpan] that only adjusts the paint's text size, weight
+ * and color — it never replaces the typeface family. The current bold/italic
+ * style bits already set by inline spans are preserved through [BOLD_ITALIC_MASK],
+ * so a bold word inside an H1 stays both big AND bold. Tagged [MarkdownSpan] so the
+ * formatter cleans up only the heading spans it created, leaving inline spans intact.
+ */
+class InputHeadingSpan(
+  val level: Int,
+  style: InputFormatterStyle,
+) : MetricAffectingSpan(),
+  MarkdownSpan {
+  private val resolved = style.headingStyle(level)
+
+  override fun updateDrawState(tp: TextPaint) {
+    applyHeadingStyle(tp)
+    resolved.color?.let { tp.color = it }
+  }
+
+  override fun updateMeasureState(tp: TextPaint) {
+    applyHeadingStyle(tp)
+  }
+
+  @SuppressLint("WrongConstant") // Result of mask is always valid: 0, 1, 2, or 3
+  private fun applyHeadingStyle(tp: TextPaint) {
+    resolved.fontSizePx?.let { tp.textSize = it }
+
+    if (resolved.fontWeight != ReactConstants.UNSET) {
+      // Fold the configured heading weight into whatever bold/italic an inline span
+      // already applied, so heading weight and inline emphasis compose instead of
+      // one clobbering the other.
+      val inlineStyle = (tp.typeface?.style ?: 0) and BOLD_ITALIC_MASK
+      val headingBold = if (resolved.fontWeight >= BOLD_WEIGHT_THRESHOLD) Typeface.BOLD else 0
+      val combined = inlineStyle or headingBold
+      tp.typeface =
+        if (combined != 0) {
+          Typeface.create(tp.typeface, combined)
+        } else {
+          tp.typeface
+        }
+    }
+  }
+
+  companion object {
+    private const val BOLD_ITALIC_MASK = Typeface.BOLD or Typeface.ITALIC
+
+    // React Native treats weights >= 700 as bold.
+    private const val BOLD_WEIGHT_THRESHOLD = 700
+  }
+}

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/styles/HeadingBlockHandler.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/styles/HeadingBlockHandler.kt
@@ -1,0 +1,27 @@
+package com.swmansion.enriched.markdown.input.styles
+
+import com.swmansion.enriched.markdown.input.model.BlockRange
+import com.swmansion.enriched.markdown.input.model.BlockType
+import com.swmansion.enriched.markdown.input.model.InputFormatterStyle
+import com.swmansion.enriched.markdown.input.spans.InputHeadingSpan
+
+/**
+ * Block handler for ATX headings (H1-H6). A single instance serves all six levels:
+ * it reads the H-level from each [BlockRange.level], so it is registered in the
+ * [com.swmansion.enriched.markdown.input.formatting.InputFormatter] under every
+ * `HEADING_n` key. The level — not [blockType] — drives styling and serialization,
+ * so [blockType] is only a nominal interface value and never consulted by the
+ * formatter (it dispatches on `range.type`).
+ */
+class HeadingBlockHandler : BlockHandler {
+  override val blockType: BlockType = BlockType.HEADING_1
+
+  override fun createSpans(
+    blockRange: BlockRange,
+    style: InputFormatterStyle,
+  ): List<Any> = listOf(InputHeadingSpan(blockRange.level, style))
+
+  override fun spanClasses(): List<Class<*>> = listOf(InputHeadingSpan::class.java)
+
+  override fun markdownLinePrefix(blockRange: BlockRange): String = "#".repeat(blockRange.level.coerceIn(1, 6)) + " "
+}

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/input/MarkdownStyleParser.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/input/MarkdownStyleParser.kt
@@ -1,7 +1,11 @@
 package com.swmansion.enriched.markdown.utils.input
 
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.common.ReactConstants
+import com.facebook.react.uimanager.PixelUtil
+import com.facebook.react.views.text.ReactTypefaceUtils
 import com.swmansion.enriched.markdown.input.model.InputFormatterStyle
+import com.swmansion.enriched.markdown.input.model.InputHeadingStyle
 import com.swmansion.enriched.markdown.input.model.InputLinkVariantStyle
 
 object MarkdownStyleParser {
@@ -20,8 +24,32 @@ object MarkdownStyleParser {
       linkVariants = parseLinkVariants(map),
       spoilerColor = spoilerMap!!.getInt("color"),
       spoilerBackgroundColor = spoilerMap.getInt("backgroundColor"),
+      headings = parseHeadings(map),
     )
   }
+
+  // Mirrors the readonly renderer's h1..h6 markdownStyle. fontSize arrives in SP
+  // (matching the JS prop) and is converted to px so the input span can size text
+  // identically to the read view.
+  private fun parseHeadings(map: ReadableMap): List<InputHeadingStyle> =
+    (1..6).map { level ->
+      val headingMap = map.getMap("h$level")
+      InputHeadingStyle(
+        fontSizePx =
+          if (headingMap?.hasKey("fontSize") == true) {
+            PixelUtil.toPixelFromSP(headingMap.getDouble("fontSize"))
+          } else {
+            null
+          },
+        fontWeight =
+          if (headingMap?.hasKey("fontWeight") == true) {
+            ReactTypefaceUtils.parseFontWeight(headingMap.getString("fontWeight"))
+          } else {
+            ReactConstants.UNSET
+          },
+        color = if (headingMap?.hasKey("color") == true) headingMap.getInt("color") else null,
+      )
+    }
 
   private fun parseLinkVariants(map: ReadableMap): List<InputLinkVariantStyle> {
     if (!map.hasKey("linkVariants")) return emptyList()

--- a/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.h
@@ -35,6 +35,18 @@ NS_ASSUME_NONNULL_BEGIN
                   deletedLength:(NSUInteger)deletedLength
                  insertedLength:(NSUInteger)insertedLength;
 
+/// Re-normalizes every stored range back to the whole-line bounds of the line
+/// containing its start (excluding the line terminator). Call after
+/// adjustForEditAtLocation: once `text` is final: the edit adjustment
+/// deliberately leaves characters inserted at a range's start or end outside
+/// the range (matching ENRMFormattingStore's convention), and a newline typed
+/// inside a range leaves it spanning two lines. Re-snapping to line bounds
+/// re-absorbs edge-typed characters, clips a split range to its first line
+/// (the text after the caret becomes a plain paragraph), and drops blocks
+/// that a line-join landed on an earlier block's line (first wins).
+/// Idempotent: ranges already line-scoped are untouched.
+- (void)normalizeToLineBoundsInText:(NSString *)text;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.h
@@ -35,16 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
                   deletedLength:(NSUInteger)deletedLength
                  insertedLength:(NSUInteger)insertedLength;
 
-/// Re-normalizes every stored range back to the whole-line bounds of the line
-/// containing its start (excluding the line terminator). Call after
-/// adjustForEditAtLocation: once `text` is final: the edit adjustment
-/// deliberately leaves characters inserted at a range's start or end outside
-/// the range (matching ENRMFormattingStore's convention), and a newline typed
-/// inside a range leaves it spanning two lines. Re-snapping to line bounds
-/// re-absorbs edge-typed characters, clips a split range to its first line
-/// (the text after the caret becomes a plain paragraph), and drops blocks
-/// that a line-join landed on an earlier block's line (first wins).
-/// Idempotent: ranges already line-scoped are untouched.
+/// Snaps every stored range to the line bounds of its start position.
+/// Absorbs edge-typed chars, clips split ranges to first line, drops
+/// duplicates. Call after adjustForEditAtLocation: once text is final.
+/// Idempotent.
 - (void)normalizeToLineBoundsInText:(NSString *)text;
 
 @end

--- a/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
@@ -154,4 +154,39 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
   }
 }
 
+- (void)normalizeToLineBoundsInText:(NSString *)text
+{
+  if (_ranges.count == 0) {
+    return;
+  }
+
+  NSMutableIndexSet *indexesToRemove = [NSMutableIndexSet indexSet];
+  NSInteger previousEnd = -1;
+
+  for (NSUInteger idx = 0; idx < _ranges.count; idx++) {
+    ENRMBlockRange *blockRange = _ranges[idx];
+    NSRange lineRange = paragraphBoundsForRange(NSMakeRange(blockRange.range.location, 0), text);
+
+    // Block content ranges never cover the line terminator; paragraphRangeForRange
+    // includes it, so trim it (handles \r\n as well).
+    while (lineRange.length > 0) {
+      unichar last = [text characterAtIndex:NSMaxRange(lineRange) - 1];
+      if (last != '\n' && last != '\r') {
+        break;
+      }
+      lineRange.length--;
+    }
+
+    if (lineRange.length == 0 || (NSInteger)lineRange.location <= previousEnd) {
+      [indexesToRemove addIndex:idx];
+      continue;
+    }
+
+    blockRange.range = lineRange;
+    previousEnd = (NSInteger)NSMaxRange(lineRange);
+  }
+
+  removeIndexesInReverse(_ranges, indexesToRemove);
+}
+
 @end

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputBlockType.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputBlockType.h
@@ -13,7 +13,36 @@ NS_ASSUME_NONNULL_BEGIN
 /// id<ENRMBlockHandler> registered in ENRMInputFormatter.
 typedef NS_ENUM(NSInteger, ENRMInputBlockType) {
   ENRMInputBlockTypeParagraph = 0,
+  ENRMInputBlockTypeHeading1 = 1,
+  ENRMInputBlockTypeHeading2 = 2,
+  ENRMInputBlockTypeHeading3 = 3,
+  ENRMInputBlockTypeHeading4 = 4,
+  ENRMInputBlockTypeHeading5 = 5,
+  ENRMInputBlockTypeHeading6 = 6,
 };
+
+/// Maps a heading level (1-6) to its ENRMInputBlockType. Levels outside 1-6 are
+/// clamped into range. The contiguous Heading1..Heading6 enum values make this a
+/// simple offset from the Heading1 base.
+static inline ENRMInputBlockType ENRMBlockTypeForHeadingLevel(NSInteger level)
+{
+  if (level < 1) {
+    level = 1;
+  } else if (level > 6) {
+    level = 6;
+  }
+  return (ENRMInputBlockType)(ENRMInputBlockTypeHeading1 + (level - 1));
+}
+
+/// The heading level (1-6) for a heading block type, or 0 if the type is not a
+/// heading. Inverse of ENRMBlockTypeForHeadingLevel.
+static inline NSInteger ENRMHeadingLevelForBlockType(ENRMInputBlockType type)
+{
+  if (type >= ENRMInputBlockTypeHeading1 && type <= ENRMInputBlockTypeHeading6) {
+    return (NSInteger)(type - ENRMInputBlockTypeHeading1) + 1;
+  }
+  return 0;
+}
 
 /// NSAttributedString attribute carrying the ENRMInputBlockType (boxed NSNumber)
 /// of the paragraph a character belongs to. Set by ENRMInputFormatter on the

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.h
@@ -70,6 +70,15 @@ NS_ASSUME_NONNULL_BEGIN
                    toTextView:(ENRMPlatformTextView *)textView
                         style:(ENRMInputFormatterStyle *)style;
 
+/// Same as above, but resets and re-applies attributes only within `scope`
+/// (ranges straddling the boundary are clipped — attributes outside the scope
+/// are already consistent because they move with the text on edits). Pass the
+/// full text range for a wholesale re-apply (import / style change).
+- (void)applyFormattingRanges:(NSArray<ENRMFormattingRange *> *)ranges
+                   toTextView:(ENRMPlatformTextView *)textView
+                        style:(ENRMInputFormatterStyle *)style
+                scopedToRange:(NSRange)scope;
+
 /// Applies paragraph-level attributes for each block range via its handler,
 /// after first stripping the attributes applied on the previous pass (so
 /// removed blocks don't leave stale paragraph styling behind). With no
@@ -77,6 +86,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)applyBlockRanges:(NSArray<ENRMBlockRange *> *)blockRanges
               toTextView:(ENRMPlatformTextView *)textView
                    style:(ENRMInputFormatterStyle *)style;
+
+/// Same as above, scoped: strips markers only within `scope` and re-applies
+/// only the block ranges intersecting it. `scope` must cover whole lines
+/// (blocks are line-scoped) — pass a line-expanded edit window.
+- (void)applyBlockRanges:(NSArray<ENRMBlockRange *> *)blockRanges
+              toTextView:(ENRMPlatformTextView *)textView
+                   style:(ENRMInputFormatterStyle *)style
+           scopedToRange:(NSRange)scope;
 
 @end
 

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.h
@@ -41,6 +41,21 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) RCTUIColor *spoilerColor;
 @property (nonatomic, strong, nullable) RCTUIColor *spoilerBackgroundColor;
 
+/// Per-level heading config, indexed by level 1-6. A nil/0 entry means the level
+/// uses a built-in default derived from the base font. Configured from the
+/// `markdownStyle.h1..h6` props.
+- (void)setHeadingFontSize:(CGFloat)fontSize forLevel:(NSInteger)level;
+- (void)setHeadingFontWeight:(nullable NSString *)fontWeight forLevel:(NSInteger)level;
+- (void)setHeadingColor:(nullable RCTUIColor *)color forLevel:(NSInteger)level;
+
+/// Resolved foreground color for a heading level, or nil to inherit baseTextColor.
+- (nullable RCTUIColor *)headingColorForLevel:(NSInteger)level;
+
+/// Font for a heading level, built over the base font at the configured size and
+/// weight (falling back to a default scale when unset). Does not carry inline
+/// traits — those are merged on top in the formatter's font pass.
+- (UIFont *)headingFontForLevel:(NSInteger)level;
+
 - (UIFont *)fontForTraits:(UIFontDescriptorSymbolicTraits)traits;
 - (void)invalidateFontCache;
 

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
@@ -24,6 +24,7 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
   CGFloat _headingFontSizes[7];
   NSString *_headingFontWeights[7];
   RCTUIColor *_headingColors[7];
+  UIFont *_headingFontCache[7];
 }
 
 - (instancetype)init
@@ -72,6 +73,7 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
 {
   if ([self isValidHeadingLevel:level]) {
     _headingFontSizes[level] = fontSize;
+    _headingFontCache[level] = nil;
   }
 }
 
@@ -79,6 +81,7 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
 {
   if ([self isValidHeadingLevel:level]) {
     _headingFontWeights[level] = [fontWeight copy];
+    _headingFontCache[level] = nil;
   }
 }
 
@@ -100,22 +103,37 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
     return _baseFont;
   }
 
+  [self invalidateCacheIfNeeded];
+
+  UIFont *cached = _headingFontCache[level];
+  if (cached) {
+    return cached;
+  }
+
   CGFloat size = _headingFontSizes[level];
   if (size <= 0.0) {
     size = _baseFont.pointSize * kDefaultHeadingScale[level];
   }
 
   NSString *weightString = _headingFontWeights[level];
-  if (weightString.length > 0) {
-    return [UIFont systemFontOfSize:size weight:ENRMFontWeightFromString(weightString)];
+  UIFont *font = weightString.length > 0 ? [UIFont systemFontOfSize:size weight:ENRMFontWeightFromString(weightString)]
+                                         : [_baseFont fontWithSize:size];
+  _headingFontCache[level] = font;
+  return font;
+}
+
+- (void)clearHeadingFontCache
+{
+  for (NSInteger level = 0; level <= 6; level++) {
+    _headingFontCache[level] = nil;
   }
-  return [_baseFont fontWithSize:size];
 }
 
 - (void)invalidateCacheIfNeeded
 {
   if (_lastBaseFont != _baseFont) {
     [_fontCache removeAllObjects];
+    [self clearHeadingFontCache];
     _lastBaseFont = _baseFont;
   }
 }
@@ -123,6 +141,7 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
 - (void)invalidateFontCache
 {
   [_fontCache removeAllObjects];
+  [self clearHeadingFontCache];
   _lastBaseFont = nil;
 }
 
@@ -171,11 +190,6 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
     }
     _styleHandlers = [map copy];
 
-    // Block handlers are registered here as concrete block types are added.
-    // A handler instance maps to one ENRMInputBlockType, but a single
-    // ENRMHeadingBlockHandler serves all six heading levels (it dispatches on
-    // blockRange.level), so the same instance is registered under all six
-    // heading keys.
     ENRMHeadingBlockHandler *headingHandler = [[ENRMHeadingBlockHandler alloc] init];
     NSMutableDictionary<NSNumber *, id<ENRMBlockHandler>> *blockMap = [NSMutableDictionary dictionary];
     for (NSInteger level = 1; level <= 6; level++) {
@@ -200,6 +214,17 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
                    toTextView:(ENRMPlatformTextView *)textView
                         style:(ENRMInputFormatterStyle *)style
 {
+  [self applyFormattingRanges:ranges
+                   toTextView:textView
+                        style:style
+                scopedToRange:NSMakeRange(0, textView.textStorage.length)];
+}
+
+- (void)applyFormattingRanges:(NSArray<ENRMFormattingRange *> *)ranges
+                   toTextView:(ENRMPlatformTextView *)textView
+                        style:(ENRMInputFormatterStyle *)style
+                scopedToRange:(NSRange)scope
+{
   NSTextStorage *textStorage = textView.textStorage;
   NSUInteger textLength = textStorage.length;
 
@@ -207,18 +232,24 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
     return;
   }
 
-  NSRange fullTextRange = NSMakeRange(0, textLength);
+  NSUInteger scopeStart = MIN(scope.location, textLength);
+  NSUInteger scopeEnd = MIN(NSMaxRange(scope), textLength);
+  if (scopeEnd <= scopeStart) {
+    return;
+  }
+  NSRange scopeRange = NSMakeRange(scopeStart, scopeEnd - scopeStart);
+  NSUInteger scopeLength = scopeRange.length;
 
   [textStorage beginEditing];
 
-  [textStorage addAttribute:NSFontAttributeName value:style.baseFont range:fullTextRange];
-  [textStorage addAttribute:NSForegroundColorAttributeName value:style.baseTextColor range:fullTextRange];
-  [textStorage removeAttribute:NSUnderlineStyleAttributeName range:fullTextRange];
-  [textStorage removeAttribute:NSStrikethroughStyleAttributeName range:fullTextRange];
-  [textStorage removeAttribute:NSBackgroundColorAttributeName range:fullTextRange];
+  [textStorage addAttribute:NSFontAttributeName value:style.baseFont range:scopeRange];
+  [textStorage addAttribute:NSForegroundColorAttributeName value:style.baseTextColor range:scopeRange];
+  [textStorage removeAttribute:NSUnderlineStyleAttributeName range:scopeRange];
+  [textStorage removeAttribute:NSStrikethroughStyleAttributeName range:scopeRange];
+  [textStorage removeAttribute:NSBackgroundColorAttributeName range:scopeRange];
 
   UIFontDescriptorSymbolicTraits *traitMap =
-      (UIFontDescriptorSymbolicTraits *)calloc(textLength, sizeof(UIFontDescriptorSymbolicTraits));
+      (UIFontDescriptorSymbolicTraits *)calloc(scopeLength, sizeof(UIFontDescriptorSymbolicTraits));
   if (!traitMap) {
     [textStorage endEditing];
     return;
@@ -229,6 +260,13 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
       continue;
     }
 
+    // Ranges straddling the scope boundary are clipped: attributes are
+    // per-character and the out-of-scope part is untouched by the reset above.
+    NSRange clipped = NSIntersectionRange(formattingRange.range, scopeRange);
+    if (clipped.length == 0) {
+      continue;
+    }
+
     id<ENRMStyleHandler> handler = _styleHandlers[@(formattingRange.type)];
     if (!handler) {
       continue;
@@ -236,31 +274,30 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
 
     UIFontDescriptorSymbolicTraits traits = [handler fontTraits];
     if (traits != 0) {
-      NSUInteger start = formattingRange.range.location;
-      NSUInteger end = NSMaxRange(formattingRange.range);
+      NSUInteger start = clipped.location;
+      NSUInteger end = NSMaxRange(clipped);
       for (NSUInteger i = start; i < end; i++) {
-        traitMap[i] |= traits;
+        traitMap[i - scopeStart] |= traits;
       }
     }
 
-    [handler applyNonFontAttributesToTextStorage:textStorage
-                                           range:formattingRange.range
-                                 formattingRange:formattingRange
-                                           style:style];
+    [handler applyNonFontAttributesToTextStorage:textStorage range:clipped formattingRange:formattingRange style:style];
   }
 
   NSUInteger runStart = 0;
   UIFontDescriptorSymbolicTraits currentTraits = traitMap[0];
 
-  for (NSUInteger i = 1; i <= textLength; i++) {
-    UIFontDescriptorSymbolicTraits nextTraits = (i < textLength) ? traitMap[i] : ~currentTraits;
+  for (NSUInteger i = 1; i <= scopeLength; i++) {
+    UIFontDescriptorSymbolicTraits nextTraits = (i < scopeLength) ? traitMap[i] : ~currentTraits;
     if (nextTraits != currentTraits) {
       if (currentTraits != 0) {
         UIFont *font = [style fontForTraits:currentTraits];
-        [textStorage addAttribute:NSFontAttributeName value:font range:NSMakeRange(runStart, i - runStart)];
+        [textStorage addAttribute:NSFontAttributeName
+                            value:font
+                            range:NSMakeRange(scopeStart + runStart, i - runStart)];
       }
       runStart = i;
-      currentTraits = (i < textLength) ? traitMap[i] : 0;
+      currentTraits = (i < scopeLength) ? traitMap[i] : 0;
     }
   }
 
@@ -270,8 +307,8 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
 
   NSLayoutManager *layoutManager = textStorage.layoutManagers.firstObject;
   if (layoutManager) {
-    [layoutManager invalidateLayoutForCharacterRange:fullTextRange actualCharacterRange:NULL];
-    [layoutManager ensureLayoutForCharacterRange:fullTextRange];
+    [layoutManager invalidateLayoutForCharacterRange:scopeRange actualCharacterRange:NULL];
+    [layoutManager ensureLayoutForCharacterRange:scopeRange];
   }
 
   ENRMSetNeedsDisplay(textView);
@@ -280,6 +317,17 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
 - (void)applyBlockRanges:(NSArray<ENRMBlockRange *> *)blockRanges
               toTextView:(ENRMPlatformTextView *)textView
                    style:(ENRMInputFormatterStyle *)style
+{
+  [self applyBlockRanges:blockRanges
+              toTextView:textView
+                   style:style
+           scopedToRange:NSMakeRange(0, textView.textStorage.length)];
+}
+
+- (void)applyBlockRanges:(NSArray<ENRMBlockRange *> *)blockRanges
+              toTextView:(ENRMPlatformTextView *)textView
+                   style:(ENRMInputFormatterStyle *)style
+           scopedToRange:(NSRange)scope
 {
   if (_blockHandlers.count == 0) {
     return;
@@ -291,6 +339,13 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
     return;
   }
 
+  NSUInteger scopeStart = MIN(scope.location, textLength);
+  NSUInteger scopeEnd = MIN(NSMaxRange(scope), textLength);
+  if (scopeEnd <= scopeStart) {
+    return;
+  }
+  NSRange scopeRange = NSMakeRange(scopeStart, scopeEnd - scopeStart);
+
   [textStorage beginEditing];
 
   // Reset pass: strip everything the previous block pass applied — paragraphs
@@ -301,7 +356,7 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
   // must still clear its styling.
   NSMutableArray<NSValue *> *previouslyClaimedRanges = [NSMutableArray array];
   [textStorage enumerateAttribute:ENRMBlockTypeAttributeName
-                          inRange:NSMakeRange(0, textLength)
+                          inRange:scopeRange
                           options:0
                        usingBlock:^(id value, NSRange range, BOOL *stop) {
                          if (value != nil) {
@@ -317,6 +372,12 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
 
   for (ENRMBlockRange *blockRange in blockRanges) {
     if (blockRange.range.length == 0 || NSMaxRange(blockRange.range) > textLength) {
+      continue;
+    }
+
+    // Blocks are line-scoped and the scope covers whole lines, so a block
+    // either lies fully inside the scope or fully outside it.
+    if (NSIntersectionRange(blockRange.range, scopeRange).length == 0) {
       continue;
     }
 
@@ -343,14 +404,7 @@ static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0
     attributes[ENRMBlockTypeAttributeName] = @(blockRange.type);
     attributes[ENRMBlockLevelAttributeName] = @(blockRange.level);
 
-    // Font composition: applyFormattingRanges: (inline pass) ran first and set a
-    // per-run font carrying the bold/italic traits of each character. A block
-    // that wants to change the font *size* (a heading) supplies a target font in
-    // `attributes` but must not clobber those inline traits. So instead of
-    // overwriting NSFontAttributeName wholesale, merge the block font's size onto
-    // each existing run while preserving that run's symbolic traits — a bold word
-    // inside an H1 stays bold AND large. Non-font attributes (color, paragraph
-    // style) apply uniformly over the block range.
+    // Merge block font size onto each run, preserving inline bold/italic traits.
     UIFont *blockFont = attributes[NSFontAttributeName];
     if (blockFont) {
       [attributes removeObjectForKey:NSFontAttributeName];

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
@@ -1,19 +1,29 @@
 #import "ENRMInputFormatter.h"
 #import "ENRMBlockHandler.h"
 #import "ENRMBoldStyleHandler.h"
+#import "ENRMHeadingBlockHandler.h"
 #import "ENRMItalicStyleHandler.h"
 #import "ENRMLinkStyleHandler.h"
 #import "ENRMSpoilerStyleHandler.h"
 #import "ENRMStrikethroughStyleHandler.h"
 #import "ENRMStyleHandler.h"
 #import "ENRMUnderlineStyleHandler.h"
+#import "FontUtils.h"
 
 @implementation ENRMInputLinkVariantStyle
 @end
 
+/// Default font-size multipliers applied to the base font when a heading level
+/// has no explicit fontSize prop. Indexed by level 1-6 (index 0 unused).
+static const CGFloat kDefaultHeadingScale[] = {0.0, 2.0, 1.5, 1.17, 1.0, 0.83, 0.67};
+
 @implementation ENRMInputFormatterStyle {
   NSMutableDictionary<NSNumber *, UIFont *> *_fontCache;
   UIFont *_lastBaseFont;
+  // Per-level heading config, indexed 1-6. 0 size means "derive from base font".
+  CGFloat _headingFontSizes[7];
+  NSString *_headingFontWeights[7];
+  RCTUIColor *_headingColors[7];
 }
 
 - (instancetype)init
@@ -23,6 +33,11 @@
     _baseTextColor = [RCTUIColor labelColor];
     _linkVariants = @[];
     _fontCache = [NSMutableDictionary dictionary];
+    for (NSInteger level = 0; level <= 6; level++) {
+      _headingFontSizes[level] = 0.0;
+      _headingFontWeights[level] = nil;
+      _headingColors[level] = nil;
+    }
   }
   return self;
 }
@@ -40,7 +55,61 @@
   copy.linkVariants = [_linkVariants copy];
   copy.spoilerColor = _spoilerColor;
   copy.spoilerBackgroundColor = _spoilerBackgroundColor;
+  for (NSInteger level = 1; level <= 6; level++) {
+    [copy setHeadingFontSize:_headingFontSizes[level] forLevel:level];
+    [copy setHeadingFontWeight:_headingFontWeights[level] forLevel:level];
+    [copy setHeadingColor:_headingColors[level] forLevel:level];
+  }
   return copy;
+}
+
+- (BOOL)isValidHeadingLevel:(NSInteger)level
+{
+  return level >= 1 && level <= 6;
+}
+
+- (void)setHeadingFontSize:(CGFloat)fontSize forLevel:(NSInteger)level
+{
+  if ([self isValidHeadingLevel:level]) {
+    _headingFontSizes[level] = fontSize;
+  }
+}
+
+- (void)setHeadingFontWeight:(NSString *)fontWeight forLevel:(NSInteger)level
+{
+  if ([self isValidHeadingLevel:level]) {
+    _headingFontWeights[level] = [fontWeight copy];
+  }
+}
+
+- (void)setHeadingColor:(RCTUIColor *)color forLevel:(NSInteger)level
+{
+  if ([self isValidHeadingLevel:level]) {
+    _headingColors[level] = color;
+  }
+}
+
+- (RCTUIColor *)headingColorForLevel:(NSInteger)level
+{
+  return [self isValidHeadingLevel:level] ? _headingColors[level] : nil;
+}
+
+- (UIFont *)headingFontForLevel:(NSInteger)level
+{
+  if (![self isValidHeadingLevel:level]) {
+    return _baseFont;
+  }
+
+  CGFloat size = _headingFontSizes[level];
+  if (size <= 0.0) {
+    size = _baseFont.pointSize * kDefaultHeadingScale[level];
+  }
+
+  NSString *weightString = _headingFontWeights[level];
+  if (weightString.length > 0) {
+    return [UIFont systemFontOfSize:size weight:ENRMFontWeightFromString(weightString)];
+  }
+  return [_baseFont fontWithSize:size];
 }
 
 - (void)invalidateCacheIfNeeded
@@ -103,12 +172,14 @@
     _styleHandlers = [map copy];
 
     // Block handlers are registered here as concrete block types are added.
-    // Empty in PR1: with no handler registered, every paragraph stays a plain
-    // paragraph and the block pipeline is a no-op.
-    NSArray<id<ENRMBlockHandler>> *blockHandlers = @[];
+    // A handler instance maps to one ENRMInputBlockType, but a single
+    // ENRMHeadingBlockHandler serves all six heading levels (it dispatches on
+    // blockRange.level), so the same instance is registered under all six
+    // heading keys.
+    ENRMHeadingBlockHandler *headingHandler = [[ENRMHeadingBlockHandler alloc] init];
     NSMutableDictionary<NSNumber *, id<ENRMBlockHandler>> *blockMap = [NSMutableDictionary dictionary];
-    for (id<ENRMBlockHandler> handler in blockHandlers) {
-      blockMap[@(handler.blockType)] = handler;
+    for (NSInteger level = 1; level <= 6; level++) {
+      blockMap[@(ENRMBlockTypeForHeadingLevel(level))] = headingHandler;
     }
     _blockHandlers = [blockMap copy];
   }
@@ -271,12 +342,54 @@
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     attributes[ENRMBlockTypeAttributeName] = @(blockRange.type);
     attributes[ENRMBlockLevelAttributeName] = @(blockRange.level);
+
+    // Font composition: applyFormattingRanges: (inline pass) ran first and set a
+    // per-run font carrying the bold/italic traits of each character. A block
+    // that wants to change the font *size* (a heading) supplies a target font in
+    // `attributes` but must not clobber those inline traits. So instead of
+    // overwriting NSFontAttributeName wholesale, merge the block font's size onto
+    // each existing run while preserving that run's symbolic traits — a bold word
+    // inside an H1 stays bold AND large. Non-font attributes (color, paragraph
+    // style) apply uniformly over the block range.
+    UIFont *blockFont = attributes[NSFontAttributeName];
+    if (blockFont) {
+      [attributes removeObjectForKey:NSFontAttributeName];
+      [self mergeFontSize:blockFont overRange:blockRange.range inTextStorage:textStorage];
+    }
+
     [textStorage addAttributes:attributes range:blockRange.range];
   }
 
   [textStorage endEditing];
 
   ENRMSetNeedsDisplay(textView);
+}
+
+/// Applies `blockFont` over `range` while preserving the symbolic traits already
+/// present on each existing font run (set by the inline formatting pass). The
+/// resulting font takes its size and descriptor from `blockFont` but unions in
+/// the run's traits, so inline bold/italic survives the block's size change.
+- (void)mergeFontSize:(UIFont *)blockFont overRange:(NSRange)range inTextStorage:(NSTextStorage *)textStorage
+{
+  UIFontDescriptorSymbolicTraits blockTraits = blockFont.fontDescriptor.symbolicTraits;
+
+  [textStorage enumerateAttribute:NSFontAttributeName
+                          inRange:range
+                          options:0
+                       usingBlock:^(UIFont *_Nullable runFont, NSRange runRange, BOOL *_Nonnull stop) {
+                         UIFontDescriptorSymbolicTraits runTraits = runFont ? runFont.fontDescriptor.symbolicTraits : 0;
+                         UIFontDescriptorSymbolicTraits mergedTraits = blockTraits | runTraits;
+
+                         UIFont *resolved = blockFont;
+                         if (mergedTraits != blockTraits) {
+                           UIFontDescriptor *descriptor =
+                               [blockFont.fontDescriptor fontDescriptorWithSymbolicTraits:mergedTraits];
+                           if (descriptor) {
+                             resolved = [UIFont fontWithDescriptor:descriptor size:0];
+                           }
+                         }
+                         [textStorage addAttribute:NSFontAttributeName value:resolved range:runRange];
+                       }];
 }
 
 @end

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
@@ -42,10 +42,9 @@ static bool isSupportedSpan(MD_SPANTYPE md4cType, ENRMInputStyleType &outStyleTy
 }
 
 // Block-type mapping mirrors kSupportedSpans for the inline pipeline. A block
-// handler extends recognition by adding its md4c block here (e.g. a heading
-// handler adds {MD_BLOCK_H, ENRMInputBlockTypeHeading} and reads the level from
-// MD_BLOCK_H_DETAIL in resolveBlockLevel below). MD_BLOCK_P maps to the implicit
-// Paragraph default and produces no stored block range.
+// handler extends recognition by adding its md4c block here and, if leveled,
+// reading its detail in resolveBlockLevel below. MD_BLOCK_P maps to the
+// implicit Paragraph default and produces no stored block range.
 struct BlockTypeMapping {
   MD_BLOCKTYPE md4cType;
   ENRMInputBlockType blockType;
@@ -53,6 +52,10 @@ struct BlockTypeMapping {
 
 static const BlockTypeMapping kSupportedBlocks[] = {
     {MD_BLOCK_P, ENRMInputBlockTypeParagraph},
+    // MD_BLOCK_H maps to a representative heading type; onEnterBlock resolves the
+    // level (via resolveBlockLevel) and rewrites the type to the level-specific
+    // ENRMInputBlockTypeHeadingN.
+    {MD_BLOCK_H, ENRMInputBlockTypeHeading1},
 };
 static const size_t kSupportedBlockCount = sizeof(kSupportedBlocks) / sizeof(kSupportedBlocks[0]);
 
@@ -68,11 +71,13 @@ static bool isSupportedBlock(MD_BLOCKTYPE md4cType, ENRMInputBlockType &outBlock
 }
 
 // Per-block integer payload (heading level, list depth). md4c exposes this in
-// the block's MD_BLOCK_*_DETAIL struct. PR1 has no leveled block, so this
-// returns 0; a heading handler's block adds a case reading
-// MD_BLOCK_H_DETAIL.level.
-static NSInteger resolveBlockLevel(MD_BLOCKTYPE, void *)
+// the block's MD_BLOCK_*_DETAIL struct. Headings read MD_BLOCK_H_DETAIL.level
+// (1-6); other blocks have no level and return 0.
+static NSInteger resolveBlockLevel(MD_BLOCKTYPE blockType, void *detail)
 {
+  if (blockType == MD_BLOCK_H && detail) {
+    return (NSInteger)(static_cast<MD_BLOCK_H_DETAIL *>(detail)->level);
+  }
   return 0;
 }
 
@@ -173,8 +178,10 @@ static int onEnterBlock(MD_BLOCKTYPE blockType, void *detail, void *userdata)
 
   auto *context = static_cast<ParseContext *>(userdata);
   BlockInfo blockInfo;
-  blockInfo.type = mappedType;
   blockInfo.level = resolveBlockLevel(blockType, detail);
+  // Headings share one md4c block type but split into six ENRMInputBlockTypes by
+  // level; map the resolved level onto the concrete heading type.
+  blockInfo.type = (blockType == MD_BLOCK_H) ? ENRMBlockTypeForHeadingLevel(blockInfo.level) : mappedType;
   context->openBlockStack.push_back(blockInfo);
   return 0;
 }
@@ -444,6 +451,30 @@ static NSArray<ENRMBlockRange *> *blockRangesFromContext(const ParseContext &con
     }
   }
 
+  // Block-level syntax (e.g. a heading's "# " line prefix) is structural markup,
+  // not content, and must be stripped from plain text exactly like inline
+  // delimiters — otherwise the marker survives into the editor AND the
+  // block-aware serializer re-prepends it, producing a doubled "# # ". A block's
+  // content range starts at its first text char; the marker is everything from
+  // the line start up to that char (handles "#"*level plus one-or-more spaces).
+  for (ENRMBlockRange *rawBlock in rawBlockRanges) {
+    NSUInteger contentStart = rawBlock.range.location;
+    if (contentStart == 0 || contentStart > rawLength) {
+      continue;
+    }
+    NSUInteger lineStart = contentStart;
+    while (lineStart > 0) {
+      unichar previous = [markdown characterAtIndex:lineStart - 1];
+      if (previous == '\n' || previous == '\r') {
+        break;
+      }
+      lineStart--;
+    }
+    if (contentStart > lineStart) {
+      [syntaxIndexes addIndexesInRange:NSMakeRange(lineStart, contentStart - lineStart)];
+    }
+  }
+
   // Strip \n/\r from syntax ranges — newlines are structural content, not
   // markdown syntax, and must survive into the plain text.
   NSMutableIndexSet *newlineIndexes = [NSMutableIndexSet indexSet];
@@ -510,9 +541,9 @@ static NSArray<ENRMBlockRange *> *blockRangesFromContext(const ParseContext &con
     [formattingRanges addObject:formattingRange];
   }
 
-  // Map block ranges (raw-markdown coords) onto plain-text coords. Empty in PR1
-  // since blockRangesFromContext emits no Paragraph ranges; the path is ready
-  // for a handler-claimed block type.
+  // Map block content ranges (raw-markdown coords) onto plain-text coords. The
+  // block's marker syntax was stripped above, so the content range maps cleanly
+  // onto the post-strip text and the block no longer covers the marker.
   NSMutableArray<ENRMBlockRange *> *blockRanges = [NSMutableArray arrayWithCapacity:rawBlockRanges.count];
   for (ENRMBlockRange *rawBlock in rawBlockRanges) {
     NSUInteger contentStart = rawBlock.range.location;

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
@@ -451,12 +451,8 @@ static NSArray<ENRMBlockRange *> *blockRangesFromContext(const ParseContext &con
     }
   }
 
-  // Block-level syntax (e.g. a heading's "# " line prefix) is structural markup,
-  // not content, and must be stripped from plain text exactly like inline
-  // delimiters — otherwise the marker survives into the editor AND the
-  // block-aware serializer re-prepends it, producing a doubled "# # ". A block's
-  // content range starts at its first text char; the marker is everything from
-  // the line start up to that char (handles "#"*level plus one-or-more spaces).
+  // Strip block markers (e.g. "# ") from plain text — same as inline delimiters.
+  // Without this the marker survives and the serializer doubles it ("# # ").
   for (ENRMBlockRange *rawBlock in rawBlockRanges) {
     NSUInteger contentStart = rawBlock.range.location;
     if (contentStart == 0 || contentStart > rawLength) {

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -48,6 +48,7 @@ using namespace facebook::react;
 #endif
 - (void)setupTextView;
 - (void)applyFormatting;
+- (void)applyFormattingScopedToEditAtLocation:(NSUInteger)editLocation insertedLength:(NSUInteger)insertedLength;
 - (void)toggleInlineStyle:(ENRMInputStyleType)styleType;
 - (void)resetBaseTypingAttributes;
 @end
@@ -604,9 +605,6 @@ using namespace facebook::react;
 
   [_formattingStore adjustForEditAtLocation:editLocation deletedLength:selection.length insertedLength:text.length];
   [_blockStore adjustForEditAtLocation:editLocation deletedLength:selection.length insertedLength:text.length];
-  // Blocks are line-scoped: snap ranges back to whole-line bounds so characters
-  // inserted at a line's edges rejoin the block and a newline split clips the
-  // block to its first line.
   [_blockStore normalizeToLineBoundsInText:ENRMGetPlainText(_textView)];
 
   for (ENRMFormattingRange *range in ranges) {
@@ -654,6 +652,29 @@ using namespace facebook::react;
 
 - (void)applyFormatting
 {
+  [self applyFormattingScopedToRange:NSMakeRange(0, ENRMGetPlainText(_textView).length)];
+}
+
+/// Per-keystroke variant: re-applies inline and block attributes only on the
+/// line(s) touched by the edit, mirroring Android's applyFormattingScopedToEdit.
+- (void)applyFormattingScopedToEditAtLocation:(NSUInteger)editLocation insertedLength:(NSUInteger)insertedLength
+{
+  NSString *plainText = ENRMGetPlainText(_textView);
+  NSUInteger textLength = plainText.length;
+  if (textLength == 0) {
+    [self applyFormatting];
+    return;
+  }
+
+  NSUInteger rawStart = MIN(editLocation, textLength);
+  NSUInteger rawEnd = MIN(editLocation + insertedLength, textLength);
+  rawEnd = MAX(rawEnd, rawStart);
+  NSRange scope = [plainText lineRangeForRange:NSMakeRange(rawStart, rawEnd - rawStart)];
+  [self applyFormattingScopedToRange:scope];
+}
+
+- (void)applyFormattingScopedToRange:(NSRange)scope
+{
   if (_isApplyingFormatting) {
     return;
   }
@@ -664,8 +685,11 @@ using namespace facebook::react;
 
   NSRange savedSelection = _textView.selectedRange;
 
-  [_formatter applyFormattingRanges:_formattingStore.allRanges toTextView:_textView style:_formatterStyle];
-  [_formatter applyBlockRanges:_blockStore.allRanges toTextView:_textView style:_formatterStyle];
+  [_formatter applyFormattingRanges:_formattingStore.allRanges
+                         toTextView:_textView
+                              style:_formatterStyle
+                      scopedToRange:scope];
+  [_formatter applyBlockRanges:_blockStore.allRanges toTextView:_textView style:_formatterStyle scopedToRange:scope];
   [_detectorPipeline refreshAllStyling];
   [self applyWritingDirection];
 
@@ -1502,9 +1526,6 @@ using namespace facebook::react;
 
   [_formattingStore adjustForEditAtLocation:editLocation deletedLength:deletedLength insertedLength:insertedLength];
   [_blockStore adjustForEditAtLocation:editLocation deletedLength:deletedLength insertedLength:insertedLength];
-  // Blocks are line-scoped: snap ranges back to whole-line bounds so characters
-  // inserted at a line's edges rejoin the block and a newline split clips the
-  // block to its first line.
   [_blockStore normalizeToLineBoundsInText:ENRMGetPlainText(_textView)];
 
   if (insertedLength > 0) {
@@ -1548,7 +1569,7 @@ using namespace facebook::react;
   }
 #endif
 
-  [self applyFormatting];
+  [self applyFormattingScopedToEditAtLocation:editLocation insertedLength:insertedLength];
 
   NSUInteger clampedEditLocation = MIN(editLocation, newLength);
   NSUInteger clampedInsertedLength = MIN(insertedLength, newLength - clampedEditLocation);

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -604,6 +604,10 @@ using namespace facebook::react;
 
   [_formattingStore adjustForEditAtLocation:editLocation deletedLength:selection.length insertedLength:text.length];
   [_blockStore adjustForEditAtLocation:editLocation deletedLength:selection.length insertedLength:text.length];
+  // Blocks are line-scoped: snap ranges back to whole-line bounds so characters
+  // inserted at a line's edges rejoin the block and a newline split clips the
+  // block to its first line.
+  [_blockStore normalizeToLineBoundsInText:ENRMGetPlainText(_textView)];
 
   for (ENRMFormattingRange *range in ranges) {
     NSRange shifted = NSMakeRange(range.range.location + editLocation, range.range.length);
@@ -1498,6 +1502,10 @@ using namespace facebook::react;
 
   [_formattingStore adjustForEditAtLocation:editLocation deletedLength:deletedLength insertedLength:insertedLength];
   [_blockStore adjustForEditAtLocation:editLocation deletedLength:deletedLength insertedLength:insertedLength];
+  // Blocks are line-scoped: snap ranges back to whole-line bounds so characters
+  // inserted at a line's edges rejoin the block and a newline split clips the
+  // block to its first line.
+  [_blockStore normalizeToLineBoundsInText:ENRMGetPlainText(_textView)];
 
   if (insertedLength > 0) {
     NSRange insertedRange = NSMakeRange(editLocation, insertedLength);

--- a/packages/react-native-enriched-markdown/ios/input/InputStylePropsUtils.h
+++ b/packages/react-native-enriched-markdown/ios/input/InputStylePropsUtils.h
@@ -140,5 +140,38 @@ BOOL applyInputStyleProps(ENRMInputFormatterStyle *style, const InputProps &newP
     changed = YES;
   }
 
+// Headings h1..h6 share an identical struct shape (fontSize / fontWeight /
+// color). Read each level into the formatter style's per-level heading config.
+#define ENRM_APPLY_HEADING_PROPS(levelNumber, headingKey)                                                              \
+  do {                                                                                                                 \
+    if (newProps.markdownStyle.headingKey.fontSize != oldProps.markdownStyle.headingKey.fontSize) {                    \
+      [style setHeadingFontSize:newProps.markdownStyle.headingKey.fontSize forLevel:levelNumber];                      \
+      changed = YES;                                                                                                   \
+    }                                                                                                                  \
+    if (newProps.markdownStyle.headingKey.fontWeight != oldProps.markdownStyle.headingKey.fontWeight) {                \
+      NSString *weight = newProps.markdownStyle.headingKey.fontWeight.empty()                                          \
+                             ? nil                                                                                     \
+                             : [NSString stringWithUTF8String:newProps.markdownStyle.headingKey.fontWeight.c_str()];   \
+      [style setHeadingFontWeight:weight forLevel:levelNumber];                                                        \
+      changed = YES;                                                                                                   \
+    }                                                                                                                  \
+    if (newProps.markdownStyle.headingKey.color != oldProps.markdownStyle.headingKey.color) {                          \
+      RCTUIColor *color = isColorMeaningful(newProps.markdownStyle.headingKey.color)                                   \
+                              ? RCTUIColorFromSharedColor(newProps.markdownStyle.headingKey.color)                     \
+                              : nil;                                                                                   \
+      [style setHeadingColor:color forLevel:levelNumber];                                                              \
+      changed = YES;                                                                                                   \
+    }                                                                                                                  \
+  } while (0)
+
+  ENRM_APPLY_HEADING_PROPS(1, h1);
+  ENRM_APPLY_HEADING_PROPS(2, h2);
+  ENRM_APPLY_HEADING_PROPS(3, h3);
+  ENRM_APPLY_HEADING_PROPS(4, h4);
+  ENRM_APPLY_HEADING_PROPS(5, h5);
+  ENRM_APPLY_HEADING_PROPS(6, h6);
+
+#undef ENRM_APPLY_HEADING_PROPS
+
   return changed;
 }

--- a/packages/react-native-enriched-markdown/ios/input/InputStylePropsUtils.h
+++ b/packages/react-native-enriched-markdown/ios/input/InputStylePropsUtils.h
@@ -18,6 +18,35 @@ static inline UITextAutocapitalizationType ENRMAutocapitalizationTypeFromString(
 }
 #endif
 
+/// Headings h1..h6 share an identical struct shape (fontSize / fontWeight /
+/// color) but are distinct codegen types, hence the template.
+template <typename HeadingProps>
+static BOOL applyHeadingLevelProps(ENRMInputFormatterStyle *style, NSInteger level, const HeadingProps &newHeading,
+                                   const HeadingProps &oldHeading)
+{
+  BOOL changed = NO;
+
+  if (newHeading.fontSize != oldHeading.fontSize) {
+    [style setHeadingFontSize:newHeading.fontSize forLevel:level];
+    changed = YES;
+  }
+
+  if (newHeading.fontWeight != oldHeading.fontWeight) {
+    NSString *weight =
+        newHeading.fontWeight.empty() ? nil : [NSString stringWithUTF8String:newHeading.fontWeight.c_str()];
+    [style setHeadingFontWeight:weight forLevel:level];
+    changed = YES;
+  }
+
+  if (newHeading.color != oldHeading.color) {
+    RCTUIColor *color = isColorMeaningful(newHeading.color) ? RCTUIColorFromSharedColor(newHeading.color) : nil;
+    [style setHeadingColor:color forLevel:level];
+    changed = YES;
+  }
+
+  return changed;
+}
+
 template <typename InputProps>
 BOOL applyInputStyleProps(ENRMInputFormatterStyle *style, const InputProps &newProps, const InputProps &oldProps)
 {
@@ -140,38 +169,12 @@ BOOL applyInputStyleProps(ENRMInputFormatterStyle *style, const InputProps &newP
     changed = YES;
   }
 
-// Headings h1..h6 share an identical struct shape (fontSize / fontWeight /
-// color). Read each level into the formatter style's per-level heading config.
-#define ENRM_APPLY_HEADING_PROPS(levelNumber, headingKey)                                                              \
-  do {                                                                                                                 \
-    if (newProps.markdownStyle.headingKey.fontSize != oldProps.markdownStyle.headingKey.fontSize) {                    \
-      [style setHeadingFontSize:newProps.markdownStyle.headingKey.fontSize forLevel:levelNumber];                      \
-      changed = YES;                                                                                                   \
-    }                                                                                                                  \
-    if (newProps.markdownStyle.headingKey.fontWeight != oldProps.markdownStyle.headingKey.fontWeight) {                \
-      NSString *weight = newProps.markdownStyle.headingKey.fontWeight.empty()                                          \
-                             ? nil                                                                                     \
-                             : [NSString stringWithUTF8String:newProps.markdownStyle.headingKey.fontWeight.c_str()];   \
-      [style setHeadingFontWeight:weight forLevel:levelNumber];                                                        \
-      changed = YES;                                                                                                   \
-    }                                                                                                                  \
-    if (newProps.markdownStyle.headingKey.color != oldProps.markdownStyle.headingKey.color) {                          \
-      RCTUIColor *color = isColorMeaningful(newProps.markdownStyle.headingKey.color)                                   \
-                              ? RCTUIColorFromSharedColor(newProps.markdownStyle.headingKey.color)                     \
-                              : nil;                                                                                   \
-      [style setHeadingColor:color forLevel:levelNumber];                                                              \
-      changed = YES;                                                                                                   \
-    }                                                                                                                  \
-  } while (0)
-
-  ENRM_APPLY_HEADING_PROPS(1, h1);
-  ENRM_APPLY_HEADING_PROPS(2, h2);
-  ENRM_APPLY_HEADING_PROPS(3, h3);
-  ENRM_APPLY_HEADING_PROPS(4, h4);
-  ENRM_APPLY_HEADING_PROPS(5, h5);
-  ENRM_APPLY_HEADING_PROPS(6, h6);
-
-#undef ENRM_APPLY_HEADING_PROPS
+  changed |= applyHeadingLevelProps(style, 1, newProps.markdownStyle.h1, oldProps.markdownStyle.h1);
+  changed |= applyHeadingLevelProps(style, 2, newProps.markdownStyle.h2, oldProps.markdownStyle.h2);
+  changed |= applyHeadingLevelProps(style, 3, newProps.markdownStyle.h3, oldProps.markdownStyle.h3);
+  changed |= applyHeadingLevelProps(style, 4, newProps.markdownStyle.h4, oldProps.markdownStyle.h4);
+  changed |= applyHeadingLevelProps(style, 5, newProps.markdownStyle.h5, oldProps.markdownStyle.h5);
+  changed |= applyHeadingLevelProps(style, 6, newProps.markdownStyle.h6, oldProps.markdownStyle.h6);
 
   return changed;
 }

--- a/packages/react-native-enriched-markdown/ios/input/styles/ENRMHeadingBlockHandler.h
+++ b/packages/react-native-enriched-markdown/ios/input/styles/ENRMHeadingBlockHandler.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#import "ENRMBlockHandler.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Block handler for ATX headings (H1-H6). A single instance serves all six
+/// levels: it dispatches on ENRMBlockRange.level for both styling (font size via
+/// the formatter style's per-level config) and serialization (`#`*level prefix).
+/// The formatter registers the same instance under all six heading block-type
+/// keys.
+@interface ENRMHeadingBlockHandler : NSObject <ENRMBlockHandler>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/input/styles/ENRMHeadingBlockHandler.mm
+++ b/packages/react-native-enriched-markdown/ios/input/styles/ENRMHeadingBlockHandler.mm
@@ -2,10 +2,6 @@
 
 @implementation ENRMHeadingBlockHandler
 
-/// Representative block type. One instance serves all six heading levels; the
-/// formatter registers it under every heading key explicitly rather than relying
-/// on this single value, and applyAttributesToParagraphStyle: dispatches on
-/// blockRange.level.
 - (ENRMInputBlockType)blockType
 {
   return ENRMInputBlockTypeHeading1;
@@ -21,8 +17,6 @@
     return;
   }
 
-  // The font is merged onto existing inline runs by the formatter (preserving
-  // bold/italic traits), so it is set here as the target size/weight only.
   attributes[NSFontAttributeName] = [style headingFontForLevel:level];
 
   RCTUIColor *headingColor = [style headingColorForLevel:level];
@@ -37,7 +31,6 @@
   if (level < 1 || level > 6) {
     return @"";
   }
-  // `#` * level followed by a single space, e.g. "### " for an H3.
   NSString *hashes = [@"" stringByPaddingToLength:level withString:@"#" startingAtIndex:0];
   return [hashes stringByAppendingString:@" "];
 }

--- a/packages/react-native-enriched-markdown/ios/input/styles/ENRMHeadingBlockHandler.mm
+++ b/packages/react-native-enriched-markdown/ios/input/styles/ENRMHeadingBlockHandler.mm
@@ -1,0 +1,45 @@
+#import "ENRMHeadingBlockHandler.h"
+
+@implementation ENRMHeadingBlockHandler
+
+/// Representative block type. One instance serves all six heading levels; the
+/// formatter registers it under every heading key explicitly rather than relying
+/// on this single value, and applyAttributesToParagraphStyle: dispatches on
+/// blockRange.level.
+- (ENRMInputBlockType)blockType
+{
+  return ENRMInputBlockTypeHeading1;
+}
+
+- (void)applyAttributesToParagraphStyle:(NSMutableParagraphStyle *)paragraphStyle
+                             attributes:(NSMutableDictionary<NSAttributedStringKey, id> *)attributes
+                             blockRange:(ENRMBlockRange *)blockRange
+                                  style:(ENRMInputFormatterStyle *)style
+{
+  NSInteger level = blockRange.level;
+  if (level < 1 || level > 6) {
+    return;
+  }
+
+  // The font is merged onto existing inline runs by the formatter (preserving
+  // bold/italic traits), so it is set here as the target size/weight only.
+  attributes[NSFontAttributeName] = [style headingFontForLevel:level];
+
+  RCTUIColor *headingColor = [style headingColorForLevel:level];
+  if (headingColor) {
+    attributes[NSForegroundColorAttributeName] = headingColor;
+  }
+}
+
+- (NSString *)markdownLinePrefixForBlockRange:(ENRMBlockRange *)blockRange
+{
+  NSInteger level = blockRange.level;
+  if (level < 1 || level > 6) {
+    return @"";
+  }
+  // `#` * level followed by a single space, e.g. "### " for an H3.
+  NSString *hashes = [@"" stringByPaddingToLength:level withString:@"#" startingAtIndex:0];
+  return [hashes stringByAppendingString:@" "];
+}
+
+@end

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -49,6 +49,12 @@ export interface LinkStyle {
   backgroundColor?: string;
 }
 
+export interface HeadingStyle {
+  fontSize?: number;
+  fontWeight?: string;
+  color?: string;
+}
+
 export interface MarkdownTextInputStyle {
   strong?: {
     color?: string;
@@ -62,6 +68,17 @@ export interface MarkdownTextInputStyle {
     color?: string;
     backgroundColor?: string;
   };
+  /**
+   * Per-level heading styling for the editor, mirroring the readonly
+   * renderer's `markdownStyle` h1..h6. Omitted levels fall back to defaults
+   * (font sizes 30/24/20/18/16/14).
+   */
+  h1?: HeadingStyle;
+  h2?: HeadingStyle;
+  h3?: HeadingStyle;
+  h4?: HeadingStyle;
+  h5?: HeadingStyle;
+  h6?: HeadingStyle;
 }
 
 export interface StyleState {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInputNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInputNativeComponent.ts
@@ -8,6 +8,12 @@ import {
 } from 'react-native';
 import type React from 'react';
 
+interface HeadingStyleInternal {
+  fontSize: CodegenTypes.Float;
+  fontWeight: string;
+  color: ColorValue;
+}
+
 interface MarkdownTextInputStyleInternal {
   strong: {
     color?: ColorValue;
@@ -32,6 +38,15 @@ interface MarkdownTextInputStyleInternal {
     color: ColorValue;
     backgroundColor: ColorValue;
   };
+  // Per-level heading styles, mirroring the readonly renderer's markdownStyle
+  // h1..h6 so heading sizing is configured consistently across read and edit
+  // views. Always provided with complete defaults via normalizeMarkdownTextInputStyle.
+  h1: HeadingStyleInternal;
+  h2: HeadingStyleInternal;
+  h3: HeadingStyleInternal;
+  h4: HeadingStyleInternal;
+  h5: HeadingStyleInternal;
+  h6: HeadingStyleInternal;
 }
 
 interface TargetedEvent {

--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownTextInputStyle.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownTextInputStyle.ts
@@ -1,5 +1,6 @@
 import { processColor, type ColorValue } from 'react-native';
 import type {
+  HeadingStyle,
   LinkStyle,
   MarkdownTextInputStyle,
 } from './EnrichedMarkdownTextInput';
@@ -12,6 +13,14 @@ interface LinkVariantEntryInternal {
   underline: boolean;
   backgroundColor: ColorValue;
 }
+
+interface HeadingStyleInternal {
+  fontSize: number;
+  fontWeight: string;
+  color: ColorValue;
+}
+
+type HeadingLevelKey = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 interface MarkdownTextInputStyleInternal {
   strong: {
@@ -30,12 +39,42 @@ interface MarkdownTextInputStyleInternal {
     color: ColorValue;
     backgroundColor: ColorValue;
   };
+  h1: HeadingStyleInternal;
+  h2: HeadingStyleInternal;
+  h3: HeadingStyleInternal;
+  h4: HeadingStyleInternal;
+  h5: HeadingStyleInternal;
+  h6: HeadingStyleInternal;
 }
 
 const DEFAULT_LINK_COLOR = '#2563EB';
 const DEFAULT_LINK_BG_COLOR = 'transparent';
 const DEFAULT_SPOILER_COLOR = '#374151';
 const DEFAULT_SPOILER_BG_COLOR = '#E5E7EB';
+
+// Heading defaults mirror the readonly renderer (normalizeMarkdownStyle) so
+// sizing is consistent across read and edit views. fontWeight '' inherits the
+// base font weight, matching the readonly headers.
+const HEADING_DEFAULTS: Record<
+  HeadingLevelKey,
+  { fontSize: number; fontWeight: string; color: string }
+> = {
+  h1: { fontSize: 30, fontWeight: '', color: '#111827' },
+  h2: { fontSize: 24, fontWeight: '', color: '#111827' },
+  h3: { fontSize: 20, fontWeight: '', color: '#111827' },
+  h4: { fontSize: 18, fontWeight: '', color: '#111827' },
+  h5: { fontSize: 16, fontWeight: '', color: '#374151' },
+  h6: { fontSize: 14, fontWeight: '', color: '#4B5563' },
+};
+
+const defaultHeadingInternal = (key: HeadingLevelKey): HeadingStyleInternal => {
+  const d = HEADING_DEFAULTS[key];
+  return {
+    fontSize: d.fontSize,
+    fontWeight: d.fontWeight,
+    color: processColor(d.color)!,
+  };
+};
 
 const defaultInternal: MarkdownTextInputStyleInternal = Object.freeze({
   strong: {
@@ -54,7 +93,25 @@ const defaultInternal: MarkdownTextInputStyleInternal = Object.freeze({
     color: processColor(DEFAULT_SPOILER_COLOR)!,
     backgroundColor: processColor(DEFAULT_SPOILER_BG_COLOR)!,
   },
+  h1: defaultHeadingInternal('h1'),
+  h2: defaultHeadingInternal('h2'),
+  h3: defaultHeadingInternal('h3'),
+  h4: defaultHeadingInternal('h4'),
+  h5: defaultHeadingInternal('h5'),
+  h6: defaultHeadingInternal('h6'),
 });
+
+const normalizeHeadingStyle = (
+  key: HeadingLevelKey,
+  style: HeadingStyle | undefined
+): HeadingStyleInternal => {
+  const fallback = defaultInternal[key];
+  return {
+    fontSize: style?.fontSize ?? fallback.fontSize,
+    fontWeight: style?.fontWeight ?? fallback.fontWeight,
+    color: normalizeColor(style?.color) ?? fallback.color,
+  };
+};
 
 let cachedInput: MarkdownTextInputStyle | undefined;
 let cachedResult: MarkdownTextInputStyleInternal | undefined;
@@ -108,6 +165,12 @@ export const normalizeMarkdownTextInputStyle = (
         normalizeColor(style.spoiler?.backgroundColor) ??
         defaultInternal.spoiler.backgroundColor,
     },
+    h1: normalizeHeadingStyle('h1', style.h1),
+    h2: normalizeHeadingStyle('h2', style.h2),
+    h3: normalizeHeadingStyle('h3', style.h3),
+    h4: normalizeHeadingStyle('h4', style.h4),
+    h5: normalizeHeadingStyle('h5', style.h5),
+    h6: normalizeHeadingStyle('h6', style.h6),
   };
 
   cachedInput = style;


### PR DESCRIPTION
## What

Second PR in the block-editing series: the first concrete block type — headings H1–H6 — plugging into the pipeline foundation merged in #460. Follows the extension pattern exactly: one entry in each parser's central block map + one registered handler, no orchestrator changes.

## How

**Both platforms**
- `HeadingBlockHandler` / `ENRMHeadingBlockHandler` — owns heading paragraph styling (per-level font size/weight/color) and the markdown line prefix (`"# "`…`"###### "`). One handler instance serves all six levels, registered under each `HEADING_n` key.
- `BlockType.HEADING_1..6` / `ENRMInputBlockTypeHeading1..6`; parsers map heading nodes centrally — Android `nodeTypeToBlockType` reads the AST node's `level` attribute, iOS `kSupportedBlocks` + `resolveBlockLevel` reads `MD_BLOCK_H_DETAIL.level`.
- Per-level `h1`–`h6` style props on the input, mirroring the readonly renderer's `markdownStyle` so heading sizing is configured consistently across read and edit views (normalized with complete defaults on the JS side).
- `BlockStore` gains `normalizeToLineBounds` (idempotent): after an edit is adjusted, ranges re-snap to whole-line bounds — re-absorbs characters typed at a block's edges, clips a newline-split heading to its first line, and drops blocks orphaned by line joins.

## Testing

- Example app builds green on both platforms (iOS sim via xcodebuild, Android `compileDebugKotlin`), ktlint/clang-format clean.
- Manual: type `# ` prefixes, import markdown with H1–H6, edit at heading boundaries, serialize round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)