### PR TITLE
refactor(input): update sync method for typing attributes to use cursor block

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -1252,7 +1252,7 @@ using namespace facebook::react;
   [_pendingStyles removeAllObjects];
   [_pendingStyleRemovals removeAllObjects];
   [self rebuildPendingStylesFromContext];
-  [self syncTypingAttributesWithPendingStyles];
+  [self syncTypingAttributesWithCursorBlock];
 }
 
 - (void)rebuildPendingStylesFromContext


### PR DESCRIPTION
### What/Why?
resetPendingStylesForSelectionChange called syncTypingAttributesWithPendingStyles, which always derived the typing font from the base font — ignoring the cursor's block context. When a user tapped to move the caret into a heading line that already had content, typingAttributes stayed at the base font size, so any newly typed characters rendered at the wrong (smaller) size instead of matching the heading.

Replaced with syncTypingAttributesWithCursorBlock, which checks the cursor paragraph's heading level and uses the heading font (size/weight/color), merging pending inline traits (bold/italic) on top. When the cursor is on a plain paragraph it falls back to the base font, so this is a strict superset of the previous behavior — no change for non-heading lines.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

