### PR TITLE
refactor(input): remove unused blockRangeContaining API from both platforms

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
@@ -30,8 +30,6 @@ class BlockStore {
     ranges.clear()
   }
 
-  fun blockRangeContaining(position: Int): BlockRange? = ranges.firstOrNull { position >= it.start && position < it.end }
-
   /**
    * Sets/replaces the block on every paragraph the given range touches, expanding
    * to whole-line boundaries within [text]. Removes any block previously covering

--- a/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.h
@@ -15,8 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setRanges:(NSArray<ENRMBlockRange *> *)ranges;
 - (void)clearAll;
 
-- (nullable ENRMBlockRange *)blockRangeContainingPosition:(NSUInteger)position;
-
 /// Sets/replaces the block on every paragraph the given range touches, expanding
 /// to whole-line boundaries within `text`. Removes any block previously covering
 /// those paragraphs.

--- a/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
@@ -68,16 +68,6 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
   [_ranges removeAllObjects];
 }
 
-- (nullable ENRMBlockRange *)blockRangeContainingPosition:(NSUInteger)position
-{
-  for (ENRMBlockRange *blockRange in _ranges) {
-    if (position >= blockRange.range.location && position < NSMaxRange(blockRange.range)) {
-      return blockRange;
-    }
-  }
-  return nil;
-}
-
 /// Drops any stored block overlapping `paragraphRange` so a replacement can be
 /// inserted cleanly. Blocks are line-scoped and never partially overlap, so a
 /// touched block is removed wholesale.


### PR DESCRIPTION
The method was never called — orchestrators use line-start matching (headingLevelForCursorParagraph / blockOnParagraphAt) which correctly handles zero-length heading anchors. The half-open interval check (position >= start && position < end) was also wrong for anchors where start == end.

### What/Why?
The method was never called — orchestrators use line-start matching (headingLevelForCursorParagraph / blockOnParagraphAt) which correctly handles zero-length heading anchors. The half-open interval check (position >= start && position < end) was also wrong for anchors where start == end.


### Testing
<!-- How to test changed code? What testing has been done? -->


<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

