### PR TITLE
refactor(input): deduplicate helpers shared between BlockStore and FormattingStore

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
@@ -49,7 +49,7 @@ class BlockStore {
     if (end < start || (end == start && type !in BlockType.HEADINGS)) return
 
     val block = BlockRange(type, start, end, level)
-    ranges.add(sortedInsertionIndex(start), block)
+    ranges.add(sortedInsertionIndex(ranges, start), block)
   }
 
   /**
@@ -107,12 +107,12 @@ class BlockStore {
           continue // the anchor's line was deleted
         }
       }
-      ranges.add(sortedInsertionIndex(anchor.start), anchor)
+      ranges.add(sortedInsertionIndex(ranges, anchor.start), anchor)
     }
 
     if (collapsed != null) {
       ranges.add(
-        sortedInsertionIndex(editLocation),
+        sortedInsertionIndex(ranges, editLocation),
         BlockRange(collapsed.type, editLocation, editLocation, collapsed.level),
       )
     }
@@ -174,14 +174,5 @@ class BlockStore {
     while (lineEnd < text.length && text[lineEnd] != '\n') lineEnd++
 
     return lineStart to lineEnd
-  }
-
-  private fun sortedInsertionIndex(location: Int): Int {
-    var index = 0
-    for (existing in ranges) {
-      if (existing.start > location) break
-      index++
-    }
-    return index
   }
 }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/FormattingStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/FormattingStore.kt
@@ -72,7 +72,7 @@ class FormattingStore {
     }
 
     val merged = FormattingRange(newRange.type, mergedStart, mergedEnd, newRange.url)
-    val insertAt = sortedInsertionIndex(mergedStart)
+    val insertAt = sortedInsertionIndex(ranges, mergedStart)
     ranges.add(insertAt, merged)
   }
 
@@ -104,7 +104,7 @@ class FormattingStore {
 
     // Remainders are fragments of a just-removed range and cannot overlap others.
     for (remainder in remainders) {
-      val insertAt = sortedInsertionIndex(remainder.start)
+      val insertAt = sortedInsertionIndex(ranges, remainder.start)
       ranges.add(insertAt, remainder)
     }
   }
@@ -120,14 +120,5 @@ class FormattingStore {
     insertedLength: Int,
   ) {
     RangeEditAdjustment.adjustForEdit(ranges, editLocation, deletedLength, insertedLength)
-  }
-
-  private fun sortedInsertionIndex(location: Int): Int {
-    var index = 0
-    for (existing in ranges) {
-      if (existing.start > location) break
-      index++
-    }
-    return index
   }
 }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/RangeEditAdjustment.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/RangeEditAdjustment.kt
@@ -2,6 +2,18 @@ package com.swmansion.enriched.markdown.input.formatting
 
 import com.swmansion.enriched.markdown.input.model.MutableRangeBounds
 
+internal fun <T : MutableRangeBounds> sortedInsertionIndex(
+  ranges: List<T>,
+  location: Int,
+): Int {
+  var index = 0
+  for (existing in ranges) {
+    if (existing.start > location) break
+    index++
+  }
+  return index
+}
+
 /**
  * Shared shift/clip logic applied to stored ranges after a text edit. Both
  * [FormattingStore] and [BlockStore] delegate here so the overlap

--- a/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
@@ -1,22 +1,6 @@
 #import "ENRMBlockStore.h"
 #import "ENRMRangeEditAdjustment.h"
-
-static NSUInteger sortedInsertionIndex(NSArray<ENRMBlockRange *> *ranges, NSUInteger location)
-{
-  NSUInteger index = 0;
-  for (ENRMBlockRange *existing in ranges) {
-    if (existing.range.location > location)
-      break;
-    index++;
-  }
-  return index;
-}
-
-static void removeIndexesInReverse(NSMutableArray *array, NSMutableIndexSet *indexes)
-{
-  [indexes enumerateIndexesWithOptions:NSEnumerationReverse
-                            usingBlock:^(NSUInteger idx, BOOL *stop) { [array removeObjectAtIndex:idx]; }];
-}
+#import "ENRMRangeStoreUtils.h"
 
 /// Expands a selection to cover whole paragraphs (line-scoped block boundaries).
 /// Clamps unconditionally so out-of-bounds input can't reach
@@ -97,7 +81,7 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
     [indexesToRemove addIndex:idx];
   }
 
-  removeIndexesInReverse(_ranges, indexesToRemove);
+  ENRMRemoveIndexesInReverse(_ranges, indexesToRemove);
 }
 
 - (void)setBlockType:(ENRMInputBlockType)type
@@ -108,22 +92,15 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
   NSRange paragraphRange = paragraphBoundsForRange(range, text);
   [self removeBlocksOverlappingRange:paragraphRange];
 
-  // Store content-only bounds (the parser's convention): trim the line
-  // terminator that paragraphRangeForRange includes (handles \r\n as well).
-  while (paragraphRange.length > 0) {
-    unichar last = [text characterAtIndex:NSMaxRange(paragraphRange) - 1];
-    if (last != '\n' && last != '\r') {
-      break;
-    }
-    paragraphRange.length--;
-  }
+  paragraphRange = ENRMTrimLineTerminators(paragraphRange, text);
 
   if (paragraphRange.length == 0 && ENRMHeadingLevelForBlockType(type) == 0) {
     return;
   }
 
   ENRMBlockRange *blockRange = [ENRMBlockRange rangeWithType:type range:paragraphRange level:level];
-  NSUInteger insertAt = sortedInsertionIndex(_ranges, blockRange.range.location);
+  NSUInteger insertAt = ENRMSortedInsertionIndex(
+      _ranges, blockRange.range.location, ^NSUInteger(id range) { return ((ENRMBlockRange *)range).range.location; });
   [_ranges insertObject:blockRange atIndex:insertAt];
 }
 
@@ -176,7 +153,7 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
     blockRange.range = adjusted.range;
   }
 
-  removeIndexesInReverse(_ranges, indexesToRemove);
+  ENRMRemoveIndexesInReverse(_ranges, indexesToRemove);
 
   NSMutableIndexSet *emptyIndexes = [NSMutableIndexSet indexSet];
   for (NSUInteger idx = 0; idx < _ranges.count; idx++) {
@@ -186,7 +163,7 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
     }
   }
   if (emptyIndexes.count > 0) {
-    removeIndexesInReverse(_ranges, emptyIndexes);
+    ENRMRemoveIndexesInReverse(_ranges, emptyIndexes);
   }
 }
 
@@ -203,15 +180,7 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
     ENRMBlockRange *blockRange = _ranges[idx];
     NSRange lineRange = paragraphBoundsForRange(NSMakeRange(blockRange.range.location, 0), text);
 
-    // Block content ranges never cover the line terminator; paragraphRangeForRange
-    // includes it, so trim it (handles \r\n as well).
-    while (lineRange.length > 0) {
-      unichar last = [text characterAtIndex:NSMaxRange(lineRange) - 1];
-      if (last != '\n' && last != '\r') {
-        break;
-      }
-      lineRange.length--;
-    }
+    lineRange = ENRMTrimLineTerminators(lineRange, text);
 
     BOOL isHeading = ENRMHeadingLevelForBlockType(blockRange.type) > 0;
     if ((lineRange.length == 0 && !isHeading) || (NSInteger)lineRange.location <= previousEnd) {
@@ -223,7 +192,7 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
     previousEnd = (NSInteger)NSMaxRange(lineRange);
   }
 
-  removeIndexesInReverse(_ranges, indexesToRemove);
+  ENRMRemoveIndexesInReverse(_ranges, indexesToRemove);
 }
 
 @end

--- a/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.mm
@@ -1,22 +1,6 @@
 #import "ENRMFormattingStore.h"
 #import "ENRMRangeEditAdjustment.h"
-
-static NSUInteger sortedInsertionIndex(NSArray<ENRMFormattingRange *> *ranges, NSUInteger location)
-{
-  NSUInteger index = 0;
-  for (ENRMFormattingRange *existing in ranges) {
-    if (existing.range.location > location)
-      break;
-    index++;
-  }
-  return index;
-}
-
-static void removeIndexesInReverse(NSMutableArray *array, NSMutableIndexSet *indexes)
-{
-  [indexes enumerateIndexesWithOptions:NSEnumerationReverse
-                            usingBlock:^(NSUInteger idx, BOOL *stop) { [array removeObjectAtIndex:idx]; }];
-}
+#import "ENRMRangeStoreUtils.h"
 
 @implementation ENRMFormattingStore {
   NSMutableArray<ENRMFormattingRange *> *_ranges;
@@ -143,13 +127,14 @@ static void removeIndexesInReverse(NSMutableArray *array, NSMutableIndexSet *ind
     }
   }
 
-  removeIndexesInReverse(_ranges, mergeIndexes);
+  ENRMRemoveIndexesInReverse(_ranges, mergeIndexes);
 
   ENRMFormattingRange *merged = [ENRMFormattingRange rangeWithType:newRange.type
                                                              range:NSMakeRange(mergedStart, mergedEnd - mergedStart)
                                                                url:newRange.url];
 
-  NSUInteger insertAt = sortedInsertionIndex(_ranges, merged.range.location);
+  NSUInteger insertAt = ENRMSortedInsertionIndex(
+      _ranges, merged.range.location, ^NSUInteger(id range) { return ((ENRMFormattingRange *)range).range.location; });
   [_ranges insertObject:merged atIndex:insertAt];
 }
 
@@ -187,11 +172,13 @@ static void removeIndexesInReverse(NSMutableArray *array, NSMutableIndexSet *ind
     }
   }
 
-  removeIndexesInReverse(_ranges, indexesToRemove);
+  ENRMRemoveIndexesInReverse(_ranges, indexesToRemove);
 
   // Remainders are fragments of a just-removed range and cannot overlap others.
   for (ENRMFormattingRange *remainder in remainders) {
-    NSUInteger insertAt = sortedInsertionIndex(_ranges, remainder.range.location);
+    NSUInteger insertAt = ENRMSortedInsertionIndex(_ranges, remainder.range.location, ^NSUInteger(id range) {
+      return ((ENRMFormattingRange *)range).range.location;
+    });
     [_ranges insertObject:remainder atIndex:insertAt];
   }
 }
@@ -220,7 +207,7 @@ static void removeIndexesInReverse(NSMutableArray *array, NSMutableIndexSet *ind
     }
   }
 
-  removeIndexesInReverse(_ranges, indexesToRemove);
+  ENRMRemoveIndexesInReverse(_ranges, indexesToRemove);
 
   NSMutableIndexSet *emptyIndexes = [NSMutableIndexSet indexSet];
   for (NSUInteger idx = 0; idx < _ranges.count; idx++) {
@@ -229,7 +216,7 @@ static void removeIndexesInReverse(NSMutableArray *array, NSMutableIndexSet *ind
     }
   }
   if (emptyIndexes.count > 0) {
-    removeIndexesInReverse(_ranges, emptyIndexes);
+    ENRMRemoveIndexesInReverse(_ranges, emptyIndexes);
   }
 }
 

--- a/packages/react-native-enriched-markdown/ios/input/ENRMRangeStoreUtils.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMRangeStoreUtils.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_INLINE NSUInteger ENRMSortedInsertionIndex(NSArray *ranges, NSUInteger location,
+                                              NSUInteger (^locationOfRange)(id range))
+{
+  NSUInteger index = 0;
+  for (id existing in ranges) {
+    if (locationOfRange(existing) > location)
+      break;
+    index++;
+  }
+  return index;
+}
+
+NS_INLINE void ENRMRemoveIndexesInReverse(NSMutableArray *array, NSMutableIndexSet *indexes)
+{
+  [indexes enumerateIndexesWithOptions:NSEnumerationReverse
+                            usingBlock:^(NSUInteger idx, BOOL *stop) { [array removeObjectAtIndex:idx]; }];
+}
+
+/// paragraphRangeForRange: includes the line terminator; this strips it
+/// to match the parser's content-only range convention.
+NS_INLINE NSRange ENRMTrimLineTerminators(NSRange range, NSString *text)
+{
+  while (range.length > 0) {
+    unichar last = [text characterAtIndex:NSMaxRange(range) - 1];
+    if (last != '\n' && last != '\r') {
+      break;
+    }
+    range.length--;
+  }
+  return range;
+}
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
### What/Why?
iOS: extract sortedInsertionIndex, removeIndexesInReverse and trimLineTerminators into ENRMRangeStoreUtils.h.
Android: promote sortedInsertionIndex to a shared top-level generic in RangeEditAdjustment.kt.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

