### PR TITLE
refactor(input): narrow heading level to a union type and export HeadingStyle

### DIFF
--- a/apps/react-native-example/src/components/FormattingToolbar.tsx
+++ b/apps/react-native-example/src/components/FormattingToolbar.tsx
@@ -138,7 +138,9 @@ export function FormattingToolbar({
             key={`h${level}`}
             style={[
               styles.toolbarButton,
-              state?.heading.level === level && styles.toolbarButtonActive,
+              state?.heading.isActive &&
+                state.heading.level === level &&
+                styles.toolbarButtonActive,
             ]}
             onPress={() => inputRef.current?.toggleHeading(level)}
             testID={`toolbar-h${level}`}

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -49,6 +49,14 @@ export interface LinkStyle {
   backgroundColor?: string;
 }
 
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+const VALID_HEADING_LEVELS = new Set<number>([1, 2, 3, 4, 5, 6]);
+
+function toHeadingLevel(n: number): HeadingLevel {
+  return (VALID_HEADING_LEVELS.has(n) ? n : 1) as HeadingLevel;
+}
+
 export interface HeadingStyle {
   fontSize?: number;
   fontWeight?: string;
@@ -88,7 +96,7 @@ export interface StyleState {
   strikethrough: { isActive: boolean };
   spoiler: { isActive: boolean };
   link: { isActive: boolean };
-  heading: { isActive: boolean; level: number };
+  heading: { isActive: boolean; level: HeadingLevel };
 }
 
 export interface ContextMenuItem {
@@ -122,7 +130,7 @@ export interface EnrichedMarkdownTextInputInstance {
   toggleUnderline: () => void;
   toggleStrikethrough: () => void;
   toggleSpoiler: () => void;
-  toggleHeading: (level: number) => void;
+  toggleHeading: (level: HeadingLevel) => void;
   setLink: (url: string) => void;
   insertLink: (text: string, url: string) => void;
   insertMention: (displayText: string, url: string) => void;
@@ -429,7 +437,7 @@ export const EnrichedMarkdownTextInput = ({
         strikethrough,
         spoiler,
         link,
-        heading,
+        heading: { ...heading, level: toHeadingLevel(heading.level) },
       });
     },
     [onChangeState]
@@ -509,7 +517,13 @@ export const EnrichedMarkdownTextInput = ({
       callback?.({
         text: selectedText,
         selection: { start: selectionStart, end: selectionEnd },
-        styleState,
+        styleState: {
+          ...styleState,
+          heading: {
+            ...styleState.heading,
+            level: toHeadingLevel(styleState.heading.level),
+          },
+        },
       });
     },
     []

--- a/packages/react-native-enriched-markdown/src/index.tsx
+++ b/packages/react-native-enriched-markdown/src/index.tsx
@@ -36,4 +36,6 @@ export type {
   OnChangeMentionEvent,
   OnEndMentionEvent,
   CaretRect,
+  HeadingLevel,
+  HeadingStyle,
 } from './EnrichedMarkdownTextInput';


### PR DESCRIPTION
### What/Why?
Introduce HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6 with a runtime guard at the native-bridge boundary. Export HeadingLevel and HeadingStyle from the package index. Fix toolbar active-state to check isActive alongside level.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

