### PR TITLE
fix(ios): sync typing attributes after text edit to fix heading cursor on Enter 

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -1242,7 +1242,7 @@ using namespace facebook::react;
 - (void)resetPendingStylesForSelectionChange
 {
   // Skip system-driven selection adjustments (e.g., predictive text) that fire
-  // immediately after a text edit.
+  // immediately after a text edit (PR #406).
   static const CFTimeInterval kPostEditGracePeriod = 0.1;
   BOOL isPostEditAdjustment =
       (_lastTextChangeTime > 0 && (CACurrentMediaTime() - _lastTextChangeTime) < kPostEditGracePeriod);
@@ -1719,6 +1719,14 @@ using namespace facebook::react;
 #endif
 
   [self applyFormattingScopedToEditAtLocation:editLocation insertedLength:insertedLength];
+
+  // Sync typing attributes after every edit. The selection-change callback
+  // is either suppressed (_isTextChanging) or guarded by the grace period,
+  // so it won't reliably sync after Enter from a heading line. This call
+  // is idempotent and cheap — on same-line edits it's a no-op in practice.
+  if (_textView.selectedRange.length == 0) {
+    [self syncTypingAttributesWithCursorBlock];
+  }
 
   NSUInteger clampedEditLocation = MIN(editLocation, newLength);
   NSUInteger clampedInsertedLength = MIN(insertedLength, newLength - clampedEditLocation);


### PR DESCRIPTION
### What/Why?
Pressing Enter from a heading line left the cursor at heading font size because the selection-change callback is suppressed during the edit and skipped by the post-edit grace period. Sync typing attributes at the end of handleTextChanged so the cursor always reflects the current block.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

