### PR TITLE
fix(android): sync cursor height with heading block on empty lines

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -2,6 +2,7 @@ package com.swmansion.enriched.markdown.input
 
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.res.ColorStateList
 import android.graphics.BlendMode
 import android.graphics.BlendModeColorFilter
 import android.graphics.Color
@@ -96,6 +97,9 @@ class EnrichedMarkdownTextInputView(
   private var activeMentionStart = -1
   private var activeMentionEnd = -1
   private var activeMentionText = ""
+
+  private var headingOverrideBaseSizePx: Float? = null
+  private var savedHintTextColors: ColorStateList? = null
 
   init {
     setupDetectorPipeline()
@@ -263,6 +267,7 @@ class EnrichedMarkdownTextInputView(
       }
 
       forceScrollToSelection()
+      syncCursorSizeWithBlock()
       eventEmitter.emitChangeText()
       if (emitMarkdown) eventEmitter.emitChangeMarkdown()
       updateActiveMention()
@@ -641,6 +646,7 @@ class EnrichedMarkdownTextInputView(
     }
 
     applyFormattingAndEmit()
+    syncCursorSizeWithBlock()
   }
 
   /**
@@ -659,6 +665,35 @@ class EnrichedMarkdownTextInputView(
   fun headingLevelAtCursor(): Int {
     val block = blockOnParagraphAt(selectionStart) ?: return 0
     return if (block.type in BlockType.HEADINGS) block.level else 0
+  }
+
+  /**
+   * On empty text with a heading block, overrides text size to the heading's
+   * font size so the cursor matches heading height. Hides the hint while
+   * active. Cleared automatically when text is typed or heading is toggled off.
+   */
+  private fun syncCursorSizeWithBlock() {
+    val editable = text ?: return
+    val block = blockOnParagraphAt(selectionStart)
+
+    if (block != null && block.type in BlockType.HEADINGS && editable.isEmpty()) {
+      val headingSizePx = formatter.resolveHeadingFontSizePx(block.level) ?: return
+      if (headingOverrideBaseSizePx == null) {
+        headingOverrideBaseSizePx = paint.textSize
+        savedHintTextColors = hintTextColors
+      }
+      if (paint.textSize != headingSizePx) {
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, headingSizePx)
+        setHintTextColor(Color.TRANSPARENT)
+      }
+    } else {
+      headingOverrideBaseSizePx?.let { baseSizePx ->
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, baseSizePx)
+        headingOverrideBaseSizePx = null
+        savedHintTextColors?.let { setHintTextColor(it) }
+        savedHintTextColors = null
+      }
+    }
   }
 
   fun setLinkForSelection(url: String) {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputFormatter.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputFormatter.kt
@@ -54,6 +54,8 @@ class InputFormatter {
     return true
   }
 
+  fun resolveHeadingFontSizePx(level: Int): Float? = style?.headingStyle(level)?.fontSizePx
+
   fun applyFormatting(
     spannable: Spannable,
     ranges: List<FormattingRange>,
@@ -166,22 +168,24 @@ class InputFormatter {
     }
 
     for (range in blockRanges) {
-      // A zero-length heading anchor must still size its empty line, so it is
-      // stamped INCLUSIVE_INCLUSIVE over its anchor point.
       val isHeadingAnchor = range.length == 0 && range.type in BlockType.HEADINGS
       if (!isHeadingAnchor && (range.start >= range.end || range.start < 0 || range.end > spannable.length)) continue
       if (isHeadingAnchor && (range.start < 0 || range.start > spannable.length)) continue
-      // Skip blocks outside the scope; an anchor sits on a boundary, so it is
-      // in-scope when its point falls within [start, end] inclusive.
       if (isHeadingAnchor) {
         if (range.start < start || range.start > end) continue
       } else if (range.end <= start || range.start >= end) {
         continue
       }
       val handler = blockHandlers[range.type] ?: continue
+
+      // Extend a zero-length heading anchor to cover the next character (usually
+      // '\n') so the Layout gives the empty line heading metrics. At the very end
+      // of text the span stays zero-length; the view-level paint override handles
+      // cursor height for that edge case.
+      val spanEnd = if (isHeadingAnchor && range.start < spannable.length) range.start + 1 else range.end
       val flags = if (isHeadingAnchor) Spannable.SPAN_INCLUSIVE_INCLUSIVE else Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
       for (span in handler.createSpans(range, currentStyle)) {
-        spannable.setSpan(span, range.start, range.end, flags)
+        spannable.setSpan(span, range.start, spanEnd, flags)
       }
     }
   }


### PR DESCRIPTION

### What/Why?
Extend zero-length heading anchor spans to cover the adjacent newline so Android's Layout gives the empty line heading-height metrics. For truly empty text (no character to span), temporarily override the view's textSize to the heading font size and hide the hint.



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

