### PR TITLE
fix(android): exclude block spans from inline formatting pass

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputFormatter.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputFormatter.kt
@@ -62,10 +62,12 @@ class InputFormatter {
   ) {
     val currentStyle = style ?: return
 
+    val blockSpanClasses = blockHandlers.values.flatMap { it.spanClasses() }.toSet()
     val existingSpans =
       spannable
         .getSpans(0, spannable.length, CharacterStyle::class.java)
         .filterIsInstance<MarkdownSpan>()
+        .filter { span -> blockSpanClasses.none { it.isInstance(span) } }
     val linkSpanClasses = handlers[StyleType.LINK]?.spanClasses().orEmpty().toSet()
     val existingLinkSpans = existingSpans.filter { span -> linkSpanClasses.any { it.isInstance(span) } }
     for (span in existingLinkSpans) {


### PR DESCRIPTION
### What/Why?
The inline formatting pass collected all CharacterStyle+MarkdownSpan spans document-wide, including InputHeadingSpan (a MetricAffectingSpan). Since heading spans aren't in the inline desired set, the diff logic removed them. The scoped block pass only re-applied within the edit lines, so headings on other lines were silently dropped on every keystroke.

Filter out block handler span classes from the inline pass so block span lifecycle is fully managed by applyBlockFormatting.

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

