### PR TITLE
refactor(input): generalize empty-line anchor machinery beyond headings (lists 1/5)

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -338,16 +338,16 @@ class EnrichedMarkdownTextInputView(
   }
 
   /**
-   * Drops heading ranges no longer anchored at a line start (e.g. Backspace merged
+   * Drops anchored blocks no longer anchored at a line start (e.g. Backspace merged
    * their line into the previous one). Must run BEFORE [BlockStore.normalizeToLineBounds]
    * so a merged range is judged on its unsnapped anchor and can't grow over the line
    * it merged into.
    */
-  private fun pruneOrphanedHeadingAnchors() {
+  private fun pruneOrphanedAnchors() {
     val editable = text ?: return
     val orphans =
       blockStore.allRanges.filter { range ->
-        range.type in BlockType.HEADINGS && !isAtLineStart(editable, range.start)
+        range.type in BlockType.ANCHORED && !isAtLineStart(editable, range.start)
       }
     for (orphan in orphans) {
       blockStore.removeBlock(orphan.start, orphan.start, editable)
@@ -365,7 +365,7 @@ class EnrichedMarkdownTextInputView(
 
   /**
    * Adjusts both [formattingStore] and [blockStore] for a text edit, then prunes
-   * orphaned heading anchors and normalizes block ranges to line bounds. Every
+   * orphaned anchors and normalizes block ranges to line bounds. Every
    * code path that mutates the text buffer must call this so block ranges stay in
    * sync — mirrors iOS's `replaceTextInRange:withText:formattingRanges:blockRanges:`.
    */
@@ -376,7 +376,7 @@ class EnrichedMarkdownTextInputView(
   ) {
     formattingStore.adjustForEdit(editStart, deletedLength, insertedLength)
     blockStore.adjustForEdit(editStart, deletedLength, insertedLength)
-    pruneOrphanedHeadingAnchors()
+    pruneOrphanedAnchors()
     text?.let { blockStore.normalizeToLineBounds(it) }
   }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
@@ -44,9 +44,9 @@ class BlockStore {
   ) {
     val (start, end) = paragraphBounds(paragraphStart, paragraphEnd, text)
     removeBlocksOverlapping(start, end)
-    // A heading on an empty line is kept as a zero-length anchor (see adjustForEdit);
-    // other blocks need real content, so an empty line yields no block.
-    if (end < start || (end == start && type !in BlockType.HEADINGS)) return
+    // An anchored block on an empty line is kept as a zero-length anchor (see
+    // adjustForEdit); other blocks need real content.
+    if (end < start || (end == start && type !in BlockType.ANCHORED)) return
 
     val block = BlockRange(type, start, end, level)
     ranges.add(sortedInsertionIndex(ranges, start), block)
@@ -67,10 +67,10 @@ class BlockStore {
 
   /**
    * Shifts/clips block ranges to follow a text edit (see [RangeEditAdjustment]),
-   * with heading persistence layered on top: a heading deleted exactly to its
-   * end collapses to a zero-length anchor at the edit location (its line
-   * survives), and existing anchors shift/keep/drop with their line. The view's
-   * prune/normalize pass reconciles anchors against the final text.
+   * with anchored-block persistence layered on top: a block
+   * deleted exactly to its end collapses to a zero-length anchor at the edit
+   * location (its line survives), and existing anchors shift/keep/drop with their
+   * line. The view's prune/normalize pass reconciles anchors against the final text.
    */
   fun adjustForEdit(
     editLocation: Int,
@@ -82,14 +82,14 @@ class BlockStore {
     val deleteEnd = editLocation + deletedLength
     val delta = insertedLength - deletedLength
 
-    val anchors = ranges.filter { it.length == 0 && it.type in BlockType.HEADINGS }
+    val anchors = ranges.filter { it.length == 0 && it.type in BlockType.ANCHORED }
     ranges.removeAll { it.length == 0 }
 
     // At most one range can end exactly at deleteEnd, so this restores at most
-    // one collapsed heading.
+    // one collapsed block.
     val collapsed =
       ranges.firstOrNull {
-        it.type in BlockType.HEADINGS && it.start >= editLocation && it.end == deleteEnd
+        it.type in BlockType.ANCHORED && it.start >= editLocation && it.end == deleteEnd
       }
 
     RangeEditAdjustment.adjustForEdit(ranges, editLocation, deletedLength, insertedLength)
@@ -121,9 +121,9 @@ class BlockStore {
   /**
    * Snaps every stored range to the line bounds of its start position.
    * Absorbs edge-typed chars, clips split ranges to first line, drops
-   * duplicates. On an empty line a heading persists as a zero-length anchor;
-   * any other collapsed range is dropped. Call after [adjustForEdit] once
-   * [text] is final. Idempotent.
+   * duplicates. On an empty line an anchored block (heading) persists as a
+   * zero-length anchor; any other collapsed range is dropped. Call after
+   * [adjustForEdit] once [text] is final. Idempotent.
    */
   fun normalizeToLineBounds(text: CharSequence) {
     if (ranges.isEmpty()) return
@@ -134,7 +134,7 @@ class BlockStore {
       val range = iterator.next()
       val (lineStart, lineEnd) = paragraphBounds(range.start, range.start, text)
       val isEmptyLine = lineEnd == lineStart
-      if ((isEmptyLine && range.type !in BlockType.HEADINGS) || lineStart <= previousEnd) {
+      if ((isEmptyLine && range.type !in BlockType.ANCHORED) || lineStart <= previousEnd) {
         iterator.remove()
         continue
       }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputFormatter.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputFormatter.kt
@@ -170,22 +170,22 @@ class InputFormatter {
     }
 
     for (range in blockRanges) {
-      val isHeadingAnchor = range.length == 0 && range.type in BlockType.HEADINGS
-      if (!isHeadingAnchor && (range.start >= range.end || range.start < 0 || range.end > spannable.length)) continue
-      if (isHeadingAnchor && (range.start < 0 || range.start > spannable.length)) continue
-      if (isHeadingAnchor) {
+      val isAnchor = range.length == 0 && range.type in BlockType.ANCHORED
+      if (!isAnchor && (range.start >= range.end || range.start < 0 || range.end > spannable.length)) continue
+      if (isAnchor && (range.start < 0 || range.start > spannable.length)) continue
+      if (isAnchor) {
         if (range.start < start || range.start > end) continue
       } else if (range.end <= start || range.start >= end) {
         continue
       }
       val handler = blockHandlers[range.type] ?: continue
 
-      // Extend a zero-length heading anchor to cover the next character (usually
-      // '\n') so the Layout gives the empty line heading metrics. At the very end
-      // of text the span stays zero-length; the view-level paint override handles
+      // Extend a zero-length anchor to cover the next character (usually '\n') so
+      // the Layout gives the empty line the block's metrics. At the very end of
+      // text the span stays zero-length; the view-level paint override handles
       // cursor height for that edge case.
-      val spanEnd = if (isHeadingAnchor && range.start < spannable.length) range.start + 1 else range.end
-      val flags = if (isHeadingAnchor) Spannable.SPAN_INCLUSIVE_INCLUSIVE else Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+      val spanEnd = if (isAnchor && range.start < spannable.length) range.start + 1 else range.end
+      val flags = if (isAnchor) Spannable.SPAN_INCLUSIVE_INCLUSIVE else Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
       for (span in handler.createSpans(range, currentStyle)) {
         spannable.setSpan(span, range.start, spanEnd, flags)
       }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/model/BlockType.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/model/BlockType.kt
@@ -26,6 +26,12 @@ enum class BlockType {
       listOf(HEADING_1, HEADING_2, HEADING_3, HEADING_4, HEADING_5, HEADING_6)
 
     /**
+     * Block types whose emptied line persists as a zero-length anchor (an emptied
+     * heading stays a heading) until toggled off.
+     */
+    val ANCHORED: Set<BlockType> = HEADINGS.toSet()
+
+    /**
      * Maps an H-level (1-6) to its [BlockType], or null when out of range. Used by
      * the parser to turn an AST heading node's `level` attribute into a block type.
      */

--- a/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
@@ -94,7 +94,7 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
 
   paragraphRange = ENRMTrimLineTerminators(paragraphRange, text);
 
-  if (paragraphRange.length == 0 && ENRMHeadingLevelForBlockType(type) == 0) {
+  if (paragraphRange.length == 0 && !ENRMBlockTypePersistsWhenEmpty(type)) {
     return;
   }
 
@@ -122,13 +122,13 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
 
   for (NSUInteger idx = 0; idx < _ranges.count; idx++) {
     ENRMBlockRange *blockRange = _ranges[idx];
-    BOOL isHeading = ENRMHeadingLevelForBlockType(blockRange.type) > 0;
+    BOOL persists = ENRMBlockTypePersistsWhenEmpty(blockRange.type);
 
-    // Zero-length heading anchors don't follow the shared adjustment: one at
-    // the edit location stays put (normalize grows it over the typed text),
-    // one past the edit shifts with it, one inside the deletion is dropped.
+    // Zero-length anchors don't follow the shared adjustment: one at the edit
+    // location stays put (normalize grows it over the typed text), one past
+    // the edit shifts with it, one inside the deletion is dropped.
     if (blockRange.range.length == 0) {
-      if (!isHeading) {
+      if (!persists) {
         [indexesToRemove addIndex:idx];
       } else if (blockRange.range.location >= deleteEnd && blockRange.range.location > editLocation) {
         blockRange.range = NSMakeRange(blockRange.range.location - deletedLength + insertedLength, 0);
@@ -140,10 +140,10 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
 
     ENRMAdjustedRange adjusted = ENRMAdjustRangeForEdit(blockRange.range, editLocation, deletedLength, insertedLength);
     if (adjusted.shouldRemove) {
-      // A heading deleted exactly to its end collapses to a zero-length anchor
-      // (the line's newline survived, so the line stays a heading); a deletion
-      // running past its end removed the line, so drop the heading with it.
-      if (isHeading && NSMaxRange(blockRange.range) == deleteEnd && blockRange.range.location >= editLocation) {
+      // A persisting block deleted exactly to its end collapses to a zero-length
+      // anchor (the line's newline survived, so the line stays the block); a
+      // deletion running past its end removed the line, so drop the block with it.
+      if (persists && NSMaxRange(blockRange.range) == deleteEnd && blockRange.range.location >= editLocation) {
         blockRange.range = NSMakeRange(editLocation, 0);
       } else {
         [indexesToRemove addIndex:idx];
@@ -155,10 +155,12 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
 
   ENRMRemoveIndexesInReverse(_ranges, indexesToRemove);
 
+  // Prune zero-length ranges, but keep zero-length persisting blocks: they anchor
+  // an emptied-but-still-present heading/bullet line (see the collapse rule above).
   NSMutableIndexSet *emptyIndexes = [NSMutableIndexSet indexSet];
   for (NSUInteger idx = 0; idx < _ranges.count; idx++) {
     ENRMBlockRange *range = _ranges[idx];
-    if (range.range.length == 0 && ENRMHeadingLevelForBlockType(range.type) == 0) {
+    if (range.range.length == 0 && !ENRMBlockTypePersistsWhenEmpty(range.type)) {
       [emptyIndexes addIndex:idx];
     }
   }
@@ -182,8 +184,9 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
 
     lineRange = ENRMTrimLineTerminators(lineRange, text);
 
-    BOOL isHeading = ENRMHeadingLevelForBlockType(blockRange.type) > 0;
-    if ((lineRange.length == 0 && !isHeading) || (NSInteger)lineRange.location <= previousEnd) {
+    BOOL emptyLine = lineRange.length == 0;
+    if ((emptyLine && !ENRMBlockTypePersistsWhenEmpty(blockRange.type)) ||
+        (NSInteger)lineRange.location <= previousEnd) {
       [indexesToRemove addIndex:idx];
       continue;
     }

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputBlockType.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputBlockType.h
@@ -44,6 +44,13 @@ static inline NSInteger ENRMHeadingLevelForBlockType(ENRMInputBlockType type)
   return 0;
 }
 
+/// Whether an emptied line of this type keeps a zero-length anchor (an emptied
+/// heading stays a heading) instead of reverting to a plain paragraph.
+static inline BOOL ENRMBlockTypePersistsWhenEmpty(ENRMInputBlockType type)
+{
+  return type >= ENRMInputBlockTypeHeading1 && type <= ENRMInputBlockTypeHeading6;
+}
+
 /// NSAttributedString attribute carrying the ENRMInputBlockType (boxed NSNumber)
 /// of the paragraph a character belongs to. Set by ENRMInputFormatter on the
 /// paragraphs a block claims; the next block pass uses it to find and strip the

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -608,7 +608,7 @@ using namespace facebook::react;
   NSString *plainText = ENRMGetPlainText(_textView);
   [_formattingStore adjustForEditAtLocation:editLocation deletedLength:selection.length insertedLength:text.length];
   [_blockStore adjustForEditAtLocation:editLocation deletedLength:selection.length insertedLength:text.length];
-  [self pruneOrphanedHeadingBlocks];
+  [self pruneOrphanedBlockAnchors];
   [_blockStore normalizeToLineBoundsInText:plainText];
 
   for (ENRMFormattingRange *range in ranges) {
@@ -953,15 +953,15 @@ using namespace facebook::react;
   _textView.typingAttributes = attrs;
 }
 
-/// Reverts to a plain paragraph any heading no longer anchored at a line start
-/// (e.g. Backspace merged its line into the previous one). Must run BEFORE
+/// Reverts to a plain paragraph any anchored block no longer anchored at a line
+/// start (e.g. Backspace merged its line into the previous one). Must run BEFORE
 /// normalizeToLineBoundsInText: so a merged range is judged on its unsnapped
 /// anchor and can't grow over the line it merged into. Mirrors Android.
-- (void)pruneOrphanedHeadingBlocks
+- (void)pruneOrphanedBlockAnchors
 {
   NSString *text = _textView.textStorage.string;
   for (ENRMBlockRange *block in _blockStore.allRanges) {
-    if (ENRMHeadingLevelForBlockType(block.type) == 0) {
+    if (!ENRMBlockTypePersistsWhenEmpty(block.type)) {
       continue;
     }
     NSUInteger anchor = MIN(block.range.location, text.length);
@@ -1670,7 +1670,7 @@ using namespace facebook::react;
 
   [_formattingStore adjustForEditAtLocation:editLocation deletedLength:deletedLength insertedLength:insertedLength];
   [_blockStore adjustForEditAtLocation:editLocation deletedLength:deletedLength insertedLength:insertedLength];
-  [self pruneOrphanedHeadingBlocks];
+  [self pruneOrphanedBlockAnchors];
   [_blockStore normalizeToLineBoundsInText:ENRMGetPlainText(_textView)];
 
   if (insertedLength > 0) {


### PR DESCRIPTION
**The list stack** (per [the review ask](https://github.com/software-mansion/react-native-enriched-markdown/pull/509#pullrequestreview-4631629409), now including **ordered lists** — the shared machinery made them cheap to add):

1. #510 — anchor machinery refactor (no behavior change)
2. #511 — list block types + marker rendering
3. #512 — parser + serializer
4. #513 — commands + keyboard + ZWSP/empty anchors
5. #514 — state + toolbar + docs + e2e

GitHub can't base a fork PR on another fork branch, so every PR targets `main` and the diff shown for PR *N* is cumulative — **this PR's own change is its last commit** (each stage is exactly one commit on the previous branch). We'll merge bottom-up; after each merge the next PR's diff collapses to just its own commit. Checkout `feat/list-5-state` to test the full feature end-to-end.


## This PR

Introduces `BlockType.ANCHORED` (Android) and `ENRMBlockTypePersistsWhenEmpty` (iOS) and routes the block store's adjust/normalize passes, the formatter's zero-length anchor stamping, and the views' orphan-anchor prune through them instead of heading-only checks. Pure refactor — headings are the only anchored type until #511 adds the list types.

Verified: ktlint + compileDebugKotlin green, TS green, example iOS build green (whole stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
