### PR TITLE
fix(input): hide placeholder when heading is toggled on empty text

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -2,7 +2,6 @@ package com.swmansion.enriched.markdown.input
 
 import android.content.ClipboardManager
 import android.content.Context
-import android.content.res.ColorStateList
 import android.graphics.BlendMode
 import android.graphics.BlendModeColorFilter
 import android.graphics.Color
@@ -99,7 +98,7 @@ class EnrichedMarkdownTextInputView(
   private var activeMentionText = ""
 
   private var headingOverrideBaseSizePx: Float? = null
-  private var savedHintTextColors: ColorStateList? = null
+  private var baseHintColor: Int? = null
 
   init {
     setupDetectorPipeline()
@@ -680,18 +679,18 @@ class EnrichedMarkdownTextInputView(
       val headingSizePx = formatter.resolveHeadingFontSizePx(block.level) ?: return
       if (headingOverrideBaseSizePx == null) {
         headingOverrideBaseSizePx = paint.textSize
-        savedHintTextColors = hintTextColors
+        baseHintColor = currentHintTextColor
+        setHintTextColor(Color.TRANSPARENT)
       }
       if (paint.textSize != headingSizePx) {
         setTextSize(TypedValue.COMPLEX_UNIT_PX, headingSizePx)
-        setHintTextColor(Color.TRANSPARENT)
       }
     } else {
       headingOverrideBaseSizePx?.let { baseSizePx ->
         setTextSize(TypedValue.COMPLEX_UNIT_PX, baseSizePx)
         headingOverrideBaseSizePx = null
-        savedHintTextColors?.let { setHintTextColor(it) }
-        savedHintTextColors = null
+        baseHintColor?.let { setHintTextColor(it) }
+        baseHintColor = null
       }
     }
   }

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -568,7 +568,9 @@ using namespace facebook::react;
 
 - (void)updatePlaceholderVisibility
 {
-  _placeholderLabel.hidden = (ENRMGetPlainText(_textView).length > 0);
+  BOOL hasText = ENRMGetPlainText(_textView).length > 0;
+  BOOL headingActive = [self headingLevelForCursorParagraph] > 0;
+  _placeholderLabel.hidden = hasText || headingActive;
 }
 
 #pragma mark - Markdown import
@@ -903,6 +905,7 @@ using namespace facebook::react;
 
   [self applyFormatting];
   [self syncTypingAttributesWithCursorBlock];
+  [self updatePlaceholderVisibility];
   [self emitFormattingChanged];
 }
 


### PR DESCRIPTION
### What/Why?
On both platforms, toggling a heading on an empty input now hides the placeholder so only the tall cursor signals heading mode. The placeholder reappears when the heading is toggled off.

iOS: updatePlaceholderVisibility checks headingLevelForCursorParagraph and hides the label when a heading block is active.

Android: syncCursorSizeWithBlock sets the hint color to transparent while the text-size override is active and restores it on clear.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

