### PR TITLE
fix: remove extra markers from text input

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
@@ -2,6 +2,7 @@
 #import "ENRMFormattingRange.h"
 #import "ENRMInputRemend.h"
 #include "md4c.h"
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -104,6 +105,7 @@ struct ParseContext {
   std::vector<InlineSpanInfo> resolved;
   std::vector<BlockInfo> openBlockStack;
   std::vector<BlockInfo> resolvedBlocks;
+  std::vector<size_t> textStartOffsets;
   size_t lastTextEnd = 0;
 };
 
@@ -145,23 +147,23 @@ static inline NSUInteger mapByteOffset(const std::vector<NSUInteger> &map, size_
   return map[std::min(offset, maxOffset)];
 }
 
-static const size_t kClosingDelimiterByteLength[] = {
-    [ENRMInputStyleTypeStrong] = 2,        [ENRMInputStyleTypeEmphasis] = 1, [ENRMInputStyleTypeUnderline] = 1,
-    [ENRMInputStyleTypeStrikethrough] = 2, [ENRMInputStyleTypeSpoiler] = 2,
-};
-
-static size_t closingDelimiterEndByte(const InlineSpanInfo &span, const char *utf8, size_t bufferLength)
+static size_t closingDelimiterEndByte(const ParseContext &context, const InlineSpanInfo &span)
 {
   size_t position = span.contentEndByteOffset;
 
   if (span.type == ENRMInputStyleTypeLink) {
-    while (position < bufferLength && utf8[position] != ')') {
+    while (position < context.bufferLength && context.buffer[position] != ')') {
       position++;
     }
-    return (position < bufferLength) ? position + 1 : position;
+    return (position < context.bufferLength) ? position + 1 : position;
   }
 
-  return position + kClosingDelimiterByteLength[span.type];
+  // Closing delimiters occupy the gap between content end and the next text run
+  // (md4c never emits delimiters as text). Anchoring here — rather than adding a
+  // fixed per-type length — keeps stacked closers of co-terminating spans (e.g.
+  // "***", "**~~x~~**") from overlapping and leaking a trailing marker.
+  auto next = std::lower_bound(context.textStartOffsets.begin(), context.textStartOffsets.end(), position);
+  return (next != context.textStartOffsets.end()) ? *next : context.bufferLength;
 }
 
 // Block tracking. md4c's enter_block gives no byte offset, so a block's content
@@ -264,6 +266,7 @@ static int onText(MD_TEXTTYPE, const MD_CHAR *text, MD_SIZE size, void *userdata
 
   size_t textStart = text - context->buffer;
   size_t textEnd = textStart + size;
+  context->textStartOffsets.push_back(textStart);
 
   for (auto &openSpan : context->openStack) {
     if (openSpan.contentStartByteOffset == kByteOffsetUnset) {
@@ -335,8 +338,7 @@ static NSArray<ENRMInputStyledRange *> *styledRangesFromContext(const ParseConte
     NSUInteger openStart = mapByteOffset(byteMap, spanInfo.openingDelimiterByteOffset, context.bufferLength);
     NSRange openingRange = NSMakeRange(openStart, contentStart - openStart);
 
-    size_t closingEndByte =
-        std::min(closingDelimiterEndByte(spanInfo, context.buffer, context.bufferLength), context.bufferLength);
+    size_t closingEndByte = std::min(closingDelimiterEndByte(context, spanInfo), context.bufferLength);
     NSUInteger closingStart = mapByteOffset(byteMap, spanInfo.contentEndByteOffset, context.bufferLength);
     NSUInteger closingEnd = mapByteOffset(byteMap, closingEndByte, context.bufferLength);
     NSRange closingRange = NSMakeRange(closingStart, closingEnd - closingStart);

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
@@ -158,8 +158,8 @@ static size_t closingDelimiterEndByte(const ParseContext &context, const InlineS
     return (position < context.bufferLength) ? position + 1 : position;
   }
 
-  // Closing delimiters occupy the gap between content end and the next text run
-  // (md4c never emits delimiters as text). Anchoring here — rather than adding a
+  // Markdown delimiter bytes occupy the gap between content end and the next emitted text run
+  // (md4c never emits syntax bytes as text). Anchoring here — rather than adding a
   // fixed per-type length — keeps stacked closers of co-terminating spans (e.g.
   // "***", "**~~x~~**") from overlapping and leaking a trailing marker.
   auto next = std::lower_bound(context.textStartOffsets.begin(), context.textStartOffsets.end(), position);

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputRemend.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputRemend.mm
@@ -7,8 +7,8 @@ typedef struct {
 } ENRMDelimiterPair;
 
 static const ENRMDelimiterPair kDelimiterPairs[] = {
-    {@"**", @"**", YES}, {@"*", @"*", YES}, {@"_", @"_", YES}, {@"~~", @"~~", YES},
-    {@"||", @"||", YES}, {@"`", @"`", YES}, {@"[", @"]", NO},
+    {@"***", @"***", YES}, {@"**", @"**", YES}, {@"*", @"*", YES}, {@"_", @"_", YES},
+    {@"~~", @"~~", YES},   {@"||", @"||", YES}, {@"`", @"`", YES}, {@"[", @"]", NO},
 };
 static const NSUInteger kDelimiterPairCount = sizeof(kDelimiterPairs) / sizeof(kDelimiterPairs[0]);
 


### PR DESCRIPTION
### What/Why?

Adresses #516

Combined/nested inline styles didn't survive a markdown → input round-trip on iOS: the input's own serialized output re-parsed with stray delimiter characters left as literal text. Reported for `***~~tes~~***`, and generally any time 2+ styles are combined (bold+italic, bold+strikethrough, strikethrough+italic). Android rendered these correctly; iOS didn't.

Two independent iOS-only root causes:

1. **`ENRMInputRemend` was missing a `***` delimiter pair.** Every imported value (`setValue` / `defaultValue` / paste) is run through remend before md4c. Without a `***` rule, a *balanced* bold+italic run like `***…***` was misread as unbalanced and had stray closing delimiters appended, corrupting the string md4c parsed. Android already had this pair (#447); iOS was never updated — which is exactly why Android worked and iOS didn't.

2. **`ENRMInputParser` mis-computed the closing-delimiter strip for co-terminating spans.** The closing syntax range was computed as `contentEnd + fixedLength` per span. When two spans close at the same position with no text between them (`***`, `**~~x~~**`), their ranges overlapped instead of stacking, so the union under-covered the closers and a trailing marker (`*`, `**`, `~`) leaked into the plain text. The closing range is now anchored on the next text run — symmetric with how the opening range already works — which covers stacked closers correctly.

this PR is iOS-only.

### Testing

Paste or `setValue` each of these and confirm the text renders styled with **no** trailing/leftover delimiter characters:

- `***~~tes~~***` → `tes` shown bold + italic + strikethrough, no stray `***`
- `***Test***` → bold + italic, no stray `*`
- `**~~test~~**` → bold + strikethrough, no stray `**`
- `~~*test*~~` and `*~~test~~*` → strikethrough + italic, no stray marker

Regression checks (should be unchanged): `**bold**`, `*italic*`, `~~strike~~`, `**a *b* c**`, `**a** *b*`, `**bold**` on its own line, and a link `[Testing](https://example.com)`.

Verified the fix logic by compiling the actual `ENRMInputRemendComplete` and the real md4c + parser range logic against these inputs (all clean, no regressions). Example-app verification below.

#### Screenshots

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/8049413e-2eff-4c26-b669-a091a74127d4" width=300 /> | <video src="https://github.com/user-attachments/assets/f475ef17-503c-4b56-a94b-b089118b4d5c" width=300 /> |







### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)