### PR TITLE
fix(build): fix x86_64 simulator build and spm_dependency guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ android.iml
 #
 apps/react-native-example/ios/Pods
 apps/react-native-macos-example/macos/Pods
+apps/react-native-example/ios/.spm.pods
 
 # Ruby
 apps/react-native-example/vendor/

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -29,6 +29,17 @@ Pod::Spec.new do |s|
   # When math is enabled, consumers must use `use_frameworks! :linkage => :dynamic` (required for SPM interop).
   enable_math = ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] != '0'
 
+  # RaTeX is wired in through React Native's `spm_dependency` helper (SPM interop).
+  # On React Native versions that don't provide it, disable math entirely so the
+  # RaTeX-importing sources under ios/math are excluded from the build. Otherwise
+  # the failure would just move from `pod install` to a build-time
+  # "missing module 'RaTeX'" error.
+  if enable_math && !defined?(spm_dependency)
+    Pod::UI.warn '[ReactNativeEnrichedMarkdown] `spm_dependency` is unavailable in this ' \
+      'React Native version; disabling LaTeX math (RaTeX). Upgrade React Native to enable it.'
+    enable_math = false
+  end
+
   unless enable_math
     s.exclude_files = "ios/math/**/*.swift"
   end
@@ -36,13 +47,11 @@ Pod::Spec.new do |s|
   preprocessor_defs = '$(inherited) MD4C_USE_UTF8=1'
   if enable_math
     preprocessor_defs += ' ENRICHED_MARKDOWN_MATH=1'
-    if defined?(spm_dependency)
-      spm_dependency(s,
-        url: 'https://github.com/erweixin/RaTeX.git',
-        requirement: {kind: 'upToNextMajorVersion', minimumVersion: '0.1.12'},
-        products: ['RaTeX']
-      )
-    end
+    spm_dependency(s,
+      url: 'https://github.com/erweixin/RaTeX.git',
+      requirement: {kind: 'upToNextMajorVersion', minimumVersion: '0.1.12'},
+      products: ['RaTeX']
+    )
   end
 
   pod_xcconfig = {
@@ -52,16 +61,21 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES'
   }
 
-  if enable_math
+  # Detect Apple Silicon on the host running `pod install`. `sysctl hw.optional.arm64`
+  # reports the real hardware even under a Rosetta-translated Ruby, unlike `uname -m`.
+  apple_silicon = `sysctl -n hw.optional.arm64 2>/dev/null`.strip == '1'
+
+  if enable_math && apple_silicon
     # RaTeX's Swift wrapper is compiled from SPM source, so its RaTeX.swiftmodule
     # is emitted only for the arch(es) the build requests. Under ONLY_ACTIVE_ARCH
     # on Apple Silicon that is arm64 only, but universal simulator builds (archive,
     # "Any iOS Simulator Device", Release) also compile this pod for x86_64 and then
     # fail with "could not find module 'RaTeX' for target 'x86_64-apple-ios-simulator'".
     # Excluding x86_64 for the simulator keeps the pod and the app target arch sets in
-    # sync. Apple Silicon only; Intel simulator builds are not supported when math is on.
-    pod_xcconfig['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'x86_64'
-    s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+    # sync. Guarded to Apple Silicon so Intel Macs (which build x86_64 simulator slices)
+    # are unaffected; `$(inherited)` preserves exclusions from the user project / other pods.
+    pod_xcconfig['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = '$(inherited) x86_64'
+    s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => '$(inherited) x86_64' }
   end
 
   s.pod_target_xcconfig = pod_xcconfig

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
   preprocessor_defs = '$(inherited) MD4C_USE_UTF8=1'
   if enable_math
     preprocessor_defs += ' ENRICHED_MARKDOWN_MATH=1'
-    if defined?(:spm_dependency)
+    if defined?(spm_dependency)
       spm_dependency(s,
         url: 'https://github.com/erweixin/RaTeX.git',
         requirement: {kind: 'upToNextMajorVersion', minimumVersion: '0.1.12'},
@@ -45,12 +45,26 @@ Pod::Spec.new do |s|
     end
   end
 
-  s.pod_target_xcconfig = {
+  pod_xcconfig = {
     'HEADER_SEARCH_PATHS' => "\"#{cpp_root}/md4c\" \"#{cpp_root}/parser\" \"$(PODS_TARGET_SRCROOT)/ios/internals\" \"$(PODS_TARGET_SRCROOT)/ios/input/internals\"",
     'GCC_PREPROCESSOR_DEFINITIONS' => preprocessor_defs,
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
     'DEFINES_MODULE' => 'YES'
   }
+
+  if enable_math
+    # RaTeX's Swift wrapper is compiled from SPM source, so its RaTeX.swiftmodule
+    # is emitted only for the arch(es) the build requests. Under ONLY_ACTIVE_ARCH
+    # on Apple Silicon that is arm64 only, but universal simulator builds (archive,
+    # "Any iOS Simulator Device", Release) also compile this pod for x86_64 and then
+    # fail with "could not find module 'RaTeX' for target 'x86_64-apple-ios-simulator'".
+    # Excluding x86_64 for the simulator keeps the pod and the app target arch sets in
+    # sync. Apple Silicon only; Intel simulator builds are not supported when math is on.
+    pod_xcconfig['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'x86_64'
+    s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  end
+
+  s.pod_target_xcconfig = pod_xcconfig
 
   if enable_math
     # React Native's spm_dependency generates a module.modulemap at


### PR DESCRIPTION
### What/Why?

Fixes #527 — iOS builds fail when compiling universal simulator targets with LaTeX math (RaTeX) enabled (>= 0.7).

RaTeX's Swift wrapper is compiled from SPM source, so its `RaTeX.swiftmodule` is emitted only for the arch(es) the build requests. Under `ONLY_ACTIVE_ARCH` on Apple Silicon that's `arm64` only, but universal simulator builds (archive, "Any iOS Simulator Device", Release) also compile this pod for `x86_64` and then fail with:

> could not find module 'RaTeX' for target 'x86_64-apple-ios-simulator'; found: arm64-apple-ios-simulator

Two podspec fixes:
- **Exclude x86_64 for the simulator when math is enabled** (`EXCLUDED_ARCHS[sdk=iphonesimulator*]`), applied to both the pod target and the app target (`user_target_xcconfig`) so their arch sets stay in sync. Apple Silicon only; Intel simulator builds aren't supported when math is on (consumers can disable math via `ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] = '0'`).
- **Fix the `spm_dependency` availability guard.** `defined?(:spm_dependency)` uses a symbol literal, so it always returns `"expression"` (truthy) and never guards. On RN versions without `spm_dependency`, `pod install` crashed with `NoMethodError`. Changed to `defined?(spm_dependency)` for a clean fallback.

### Testing

- `pod install` + `xcodebuild -sdk iphonesimulator -configuration Release -destination 'generic/platform=iOS Simulator' build` in the example app — previously failed, now succeeds.
- Verified the exclusion lands in both `ReactNativeEnrichedMarkdown.*.xcconfig` and `Pods-*.xcconfig`.
- Verified the guard fix with a Ruby repro: old form passes even when the method is undefined (→ `NoMethodError`); new form skips cleanly when absent and still passes on RN 0.86. Full `pod install` re-run confirms no regression.

  ### PR Checklist

  - [x] Code compiles and runs on iOS
  - [x] Code compiles and runs on Android
  - [x] Updated documentation/README if applicable
  - [x] Ran example app to verify changes
  - [x] E2E tests are passing
  - [x] Required E2E tests have been added (if applicable)