### PR TITLE
chore: release 0.7.4

### DIFF
--- a/apps/react-native-example/ios/Podfile.lock
+++ b/apps/react-native-example/ios/Podfile.lock
@@ -1938,7 +1938,7 @@ PODS:
     - React-utils (= 0.86.0)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.86.0)
-  - ReactNativeEnrichedMarkdown (0.7.3):
+  - ReactNativeEnrichedMarkdown (0.7.4):
     - EnrichedMarkdownCore
     - hermes-engine
     - RCTRequired
@@ -2559,7 +2559,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   EnrichedMarkdownCore: 33ec2bafbc265cfe76df3095fb21522440dd0a30
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: 4a0ceceb51f483aef72bfeb288e965aff6defa54
+  hermes-engine: 1622a566d44d0dd4d377a1532e3ac82be7a0443c
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f
@@ -2634,7 +2634,7 @@ SPEC CHECKSUMS:
   ReactCodegen: cd296de5e1c422deebafff34134d1721b5c29704
   ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
-  ReactNativeEnrichedMarkdown: d24c9b47b2bcba8f455a1b18e61128c3de570946
+  ReactNativeEnrichedMarkdown: 1ee8a58fee138c2677bfc7481529588328f547cd
   RNCAsyncStorage: 7d913885caaae13f5fb62dd0bd04c674ea8bf97b
   RNDateTimePicker: afe0288e6c7855994f7f2617b7b2c05799fea7f3
   RNGestureHandler: 7b07d9192bc65c6883fb37fdecc05dc6b61c814f

--- a/apps/react-native-macos-example/macos/Podfile.lock
+++ b/apps/react-native-macos-example/macos/Podfile.lock
@@ -2255,7 +2255,7 @@ PODS:
     - React-perflogger (= 0.81.4)
     - React-utils (= 0.81.4)
     - SocketRocket
-  - ReactNativeEnrichedMarkdown (0.7.3):
+  - ReactNativeEnrichedMarkdown (0.7.4):
     - boost
     - DoubleConversion
     - EnrichedMarkdownCore
@@ -2589,7 +2589,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 81faffd1e23962bc11e006b2a8c975cc0cfce2f5
   ReactCodegen: 7ab7a68e6cfbf489e5da68f272c9a8b4ee99c0b7
   ReactCommon: 4702457a560d38a9b96a98a728100cae76820edc
-  ReactNativeEnrichedMarkdown: 9bce7e12213ab0e205223a71ae54b3bde9ba8f9d
+  ReactNativeEnrichedMarkdown: 56e71d430c751a0c5b101886253d0f771a70ac48
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 4e7825418aa0a50bdaa8dff6d3e5fa8a2994d308
 

--- a/packages/react-native-enriched-markdown/package.json
+++ b/packages/react-native-enriched-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-enriched-markdown",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Markdown Text component for React Native",
   "main": "./lib/module/index",
   "module": "./lib/module/index",


### PR DESCRIPTION
### What/Why?

Bumps the package version on `main` to **0.7.4** to match the published release.

`0.7.4` was cut as a scoped hotfix from the `0.7.3` tag (`0.7.4-stable` branch = 0.7.3 + the #527 iOS x86_64 simulator fix) and is already published to npm (`latest`). The fix itself is already on `main` via #531 — this PR only carries the `package.json` version bump so `main` reflects the released version.

- package.json: `0.7.3 → 0.7.4` (cherry-pick of the release bump commit)
- No code changes; the x86_64 fix is already on main.

### Testing

- `0.7.4` verified end-to-end from the npm registry in a clean consumer project: `npm install react-native-enriched-markdown@0.7.4` → `pod install` → universal-simulator Release build succeeds (the #527 scenario).

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)