### PR TITLE
fix: autolink detection while working with ref

### DIFF
--- a/.maestro/enrichedMarkdownInput/flows/basic/inline_elements/link_autolink_roundtrip_test.yaml
+++ b/.maestro/enrichedMarkdownInput/flows/basic/inline_elements/link_autolink_roundtrip_test.yaml
@@ -1,0 +1,28 @@
+appId: swmansion.enriched.markdown.example
+tags:
+  - input
+  - inline
+  - link
+---
+# Regression for #516: typing a markdown link must NOT get auto-linked and
+# double-wrapped into a corrupted destination like
+# "[[Testing](http://example.com)](https://[Testing](http://example.com))".
+- launchApp:
+    clearState: true
+
+- runFlow:
+    file: '../../../../subflows/move_to_playground.yaml'
+
+- tapOn:
+    id: focus-button
+
+- inputText: '[Testing](http://example.com)'
+
+- tapOn:
+    id: get-markdown-button
+
+# The serialized markdown is shown in the "Markdown" alert.
+- assertVisible: '\[Testing\]\(http://example\.com\)'
+# The over-capture bug prepended "https://" to the whole token — its absence
+# proves the token was left untouched by the auto-link detector.
+- assertNotVisible: 'https://'

--- a/.maestro/enrichedMarkdownInput/flows/basic/inline_elements/link_autolink_roundtrip_test.yaml
+++ b/.maestro/enrichedMarkdownInput/flows/basic/inline_elements/link_autolink_roundtrip_test.yaml
@@ -23,6 +23,8 @@ tags:
 
 # The serialized markdown is shown in the "Markdown" alert.
 - assertVisible: '\[Testing\]\(http://example\.com\)'
-# The over-capture bug prepended "https://" to the whole token — its absence
-# proves the token was left untouched by the auto-link detector.
-- assertNotVisible: 'http://'
+# The over-capture bug prepended "https://" to the whole token, producing a
+# destination like "https://[Testing](http://example.com)". The correct output
+# uses the original "http://" scheme and never introduces "https://", so its
+# absence proves the token was left untouched by the auto-link detector.
+- assertNotVisible: 'https://'

--- a/.maestro/enrichedMarkdownInput/flows/basic/inline_elements/link_autolink_roundtrip_test.yaml
+++ b/.maestro/enrichedMarkdownInput/flows/basic/inline_elements/link_autolink_roundtrip_test.yaml
@@ -25,4 +25,4 @@ tags:
 - assertVisible: '\[Testing\]\(http://example\.com\)'
 # The over-capture bug prepended "https://" to the whole token — its absence
 # proves the token was left untouched by the auto-link detector.
-- assertNotVisible: 'https://'
+- assertNotVisible: 'http://'

--- a/packages/react-native-enriched-markdown/ios/input/ENRMAutoLinkDetector.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMAutoLinkDetector.mm
@@ -134,39 +134,38 @@ static NSAttributedStringKey const ENRMAutomaticLinkAttributeName = @"ENRMAutoma
   NSRange localMatch = NSMakeRange(NSNotFound, 0);
   NSString *matchedUrl = [self tryMatchWord:word matchedRange:&localMatch];
 
-  if (matchedUrl != nil && localMatch.location != NSNotFound) {
-    NSRange matchRange = NSMakeRange(wordRange.location + localMatch.location, localMatch.length);
-
-    // A manual link overlapping the matched slice takes precedence — test the
-    // whole slice, not just its first character.
-    ENRMFormattingStore *store = _formattingStore;
-    if (store != nil && [store isStyleActive:ENRMInputStyleTypeLink inRange:matchRange]) {
-      [self clearAutoLinkInRange:wordRange];
-      return nil;
-    }
-
-    NSRange effectiveRange;
-    id existing = [textStorage attribute:ENRMAutomaticLinkAttributeName
-                                 atIndex:matchRange.location
-                          effectiveRange:&effectiveRange];
-    BOOL alreadyApplied = [matchedUrl isEqual:existing] && NSEqualRanges(effectiveRange, matchRange);
-
-    if (!alreadyApplied) {
-      [textStorage beginEditing];
-      [textStorage removeAttribute:ENRMAutomaticLinkAttributeName range:wordRange];
-      [textStorage addAttribute:ENRMAutomaticLinkAttributeName value:matchedUrl range:matchRange];
-      [self applyVisualStylingToRange:matchRange];
-      [textStorage endEditing];
-    }
-
-    if (outMatchedRange != NULL) {
-      *outMatchedRange = localMatch;
-    }
-  } else {
+  if (matchedUrl == nil || localMatch.location == NSNotFound) {
     [self clearAutoLinkInRange:wordRange];
     return nil;
   }
 
+  NSRange matchRange = NSMakeRange(wordRange.location + localMatch.location, localMatch.length);
+
+  // A manual link overlapping the matched slice takes precedence — test the
+  // whole slice, not just its first character.
+  ENRMFormattingStore *store = _formattingStore;
+  if (store != nil && [store isStyleActive:ENRMInputStyleTypeLink inRange:matchRange]) {
+    [self clearAutoLinkInRange:wordRange];
+    return nil;
+  }
+
+  NSRange effectiveRange;
+  id existing = [textStorage attribute:ENRMAutomaticLinkAttributeName
+                               atIndex:matchRange.location
+                        effectiveRange:&effectiveRange];
+  BOOL alreadyApplied = [matchedUrl isEqual:existing] && NSEqualRanges(effectiveRange, matchRange);
+
+  if (!alreadyApplied) {
+    [textStorage beginEditing];
+    [textStorage removeAttribute:ENRMAutomaticLinkAttributeName range:wordRange];
+    [textStorage addAttribute:ENRMAutomaticLinkAttributeName value:matchedUrl range:matchRange];
+    [self applyVisualStylingToRange:matchRange];
+    [textStorage endEditing];
+  }
+
+  if (outMatchedRange != NULL) {
+    *outMatchedRange = localMatch;
+  }
   return matchedUrl;
 }
 

--- a/packages/react-native-enriched-markdown/ios/input/ENRMAutoLinkDetector.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMAutoLinkDetector.mm
@@ -34,9 +34,19 @@ static NSAttributedStringKey const ENRMAutomaticLinkAttributeName = @"ENRMAutoma
 
 - (void)processWord:(ENRMWordResult *)wordResult
 {
-  NSString *detectedUrl = [self detectNewLinkAtRange:wordResult.range inText:wordResult.word];
+  NSRange matchedRange = NSMakeRange(NSNotFound, 0);
+  NSString *detectedUrl = [self detectNewLinkAtRange:wordResult.range
+                                              inText:wordResult.word
+                                        matchedRange:&matchedRange];
   if (detectedUrl != nil && _onLinkDetected != nil) {
-    _onLinkDetected(wordResult.word, detectedUrl, wordResult.range);
+    // Emit the actual linked slice, not the whole whitespace token — surrounding
+    // punctuation is not part of the link.
+    BOOL hasSlice = matchedRange.location != NSNotFound;
+    NSString *matchedText = hasSlice ? [wordResult.word substringWithRange:matchedRange] : wordResult.word;
+    NSRange absoluteRange = hasSlice
+                                ? NSMakeRange(wordResult.range.location + matchedRange.location, matchedRange.length)
+                                : wordResult.range;
+    _onLinkDetected(matchedText, detectedUrl, absoluteRange);
   }
 }
 
@@ -92,8 +102,14 @@ static NSAttributedStringKey const ENRMAutomaticLinkAttributeName = @"ENRMAutoma
 
 #pragma mark - Link matching
 
-- (nullable NSString *)detectNewLinkAtRange:(NSRange)wordRange inText:(NSString *)word
+- (nullable NSString *)detectNewLinkAtRange:(NSRange)wordRange
+                                     inText:(NSString *)word
+                               matchedRange:(NSRange *)outMatchedRange
 {
+  if (outMatchedRange != NULL) {
+    *outMatchedRange = NSMakeRange(NSNotFound, 0);
+  }
+
   if (_regexConfig != nil && _regexConfig.isDisabled) {
     return nil;
   }
@@ -107,61 +123,89 @@ static NSAttributedStringKey const ENRMAutomaticLinkAttributeName = @"ENRMAutoma
     return nil;
   }
 
-  ENRMFormattingStore *store = _formattingStore;
-  if (store != nil) {
-    ENRMFormattingRange *manualLink = [store rangeOfType:ENRMInputStyleTypeLink containingPosition:wordRange.location];
-    if (manualLink != nil) {
-      return nil;
-    }
+  // Tokens carrying markdown link syntax (e.g. "[label](url)") belong to the
+  // parser, not the auto-linker. Auto-linking them re-wraps the destination and
+  // yields a corrupted URL like "https://[label](url)" on serialize.
+  if ([word hasPrefix:@"["] || [word rangeOfString:@"]("].location != NSNotFound) {
+    [self clearAutoLinkInRange:wordRange];
+    return nil;
   }
 
-  NSString *matchedUrl = [self tryMatchWord:word];
+  NSRange localMatch = NSMakeRange(NSNotFound, 0);
+  NSString *matchedUrl = [self tryMatchWord:word matchedRange:&localMatch];
 
-  if (matchedUrl != nil) {
+  if (matchedUrl != nil && localMatch.location != NSNotFound) {
+    NSRange matchRange = NSMakeRange(wordRange.location + localMatch.location, localMatch.length);
+
+    // A manual link overlapping the matched slice takes precedence — check the
+    // whole slice, not just its first character.
+    ENRMFormattingStore *store = _formattingStore;
+    if (store != nil) {
+      for (NSUInteger position = matchRange.location; position < NSMaxRange(matchRange); position++) {
+        if ([store rangeOfType:ENRMInputStyleTypeLink containingPosition:position] != nil) {
+          [self clearAutoLinkInRange:wordRange];
+          return nil;
+        }
+      }
+    }
+
     NSRange effectiveRange;
     id existing = [textStorage attribute:ENRMAutomaticLinkAttributeName
-                                 atIndex:wordRange.location
+                                 atIndex:matchRange.location
                           effectiveRange:&effectiveRange];
-    BOOL alreadyApplied = [matchedUrl isEqual:existing] && NSEqualRanges(effectiveRange, wordRange);
+    BOOL alreadyApplied = [matchedUrl isEqual:existing] && NSEqualRanges(effectiveRange, matchRange);
 
     if (!alreadyApplied) {
       [textStorage beginEditing];
-      [textStorage addAttribute:ENRMAutomaticLinkAttributeName value:matchedUrl range:wordRange];
-      [self applyVisualStylingToRange:wordRange];
+      // Clear any stale marker spanning the token before re-applying to the slice.
+      [textStorage removeAttribute:ENRMAutomaticLinkAttributeName range:wordRange];
+      [textStorage addAttribute:ENRMAutomaticLinkAttributeName value:matchedUrl range:matchRange];
+      [self applyVisualStylingToRange:matchRange];
       [textStorage endEditing];
+    }
+
+    if (outMatchedRange != NULL) {
+      *outMatchedRange = localMatch;
     }
   } else {
-    id existing = [textStorage attribute:ENRMAutomaticLinkAttributeName atIndex:wordRange.location effectiveRange:nil];
-    if (existing != nil) {
-      [textStorage beginEditing];
-      [textStorage removeAttribute:ENRMAutomaticLinkAttributeName range:wordRange];
-      [textStorage endEditing];
-    }
+    [self clearAutoLinkInRange:wordRange];
+    return nil;
   }
 
   return matchedUrl;
 }
 
-- (nullable NSString *)tryMatchWord:(NSString *)word
+- (nullable NSString *)tryMatchWord:(NSString *)word matchedRange:(NSRange *)outRange
 {
+  if (outRange != NULL) {
+    *outRange = NSMakeRange(NSNotFound, 0);
+  }
+
   if (word.length == 0) {
     return nil;
   }
 
-  NSRange matchRange = NSMakeRange(0, word.length);
+  NSRange fullRange = NSMakeRange(0, word.length);
 
-  if (_regexConfig != nil && !_regexConfig.isDefault && _regexConfig.parsedRegex != nil) {
-    if ([_regexConfig.parsedRegex numberOfMatchesInString:word options:0 range:matchRange]) {
-      return [ENRMAutoLinkDetector normalizeUrl:word];
-    }
+  // A custom regex describes the whole-token contract, so keep whole-word
+  // semantics for it. The default detector extracts just the matched URL slice
+  // so surrounding punctuation isn't swallowed into the link.
+  BOOL customExact = _regexConfig != nil && !_regexConfig.isDefault && _regexConfig.parsedRegex != nil;
+  NSRegularExpression *regex = customExact ? _regexConfig.parsedRegex : [ENRMAutoLinkDetector defaultRegex];
+  if (regex == nil) {
     return nil;
   }
 
-  if ([[ENRMAutoLinkDetector defaultRegex] numberOfMatchesInString:word options:0 range:matchRange]) {
-    return [ENRMAutoLinkDetector normalizeUrl:word];
+  NSTextCheckingResult *match = [regex firstMatchInString:word options:0 range:fullRange];
+  if (match == nil || match.range.location == NSNotFound) {
+    return nil;
   }
 
-  return nil;
+  NSRange matchRange = customExact ? fullRange : match.range;
+  if (outRange != NULL) {
+    *outRange = matchRange;
+  }
+  return [ENRMAutoLinkDetector normalizeUrl:[word substringWithRange:matchRange]];
 }
 
 + (NSString *)normalizeUrl:(NSString *)url

--- a/packages/react-native-enriched-markdown/ios/input/ENRMAutoLinkDetector.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMAutoLinkDetector.mm
@@ -157,7 +157,6 @@ static NSAttributedStringKey const ENRMAutomaticLinkAttributeName = @"ENRMAutoma
 
     if (!alreadyApplied) {
       [textStorage beginEditing];
-      // Clear any stale marker spanning the token before re-applying to the slice.
       [textStorage removeAttribute:ENRMAutomaticLinkAttributeName range:wordRange];
       [textStorage addAttribute:ENRMAutomaticLinkAttributeName value:matchedUrl range:matchRange];
       [self applyVisualStylingToRange:matchRange];

--- a/packages/react-native-enriched-markdown/ios/input/ENRMAutoLinkDetector.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMAutoLinkDetector.mm
@@ -137,16 +137,12 @@ static NSAttributedStringKey const ENRMAutomaticLinkAttributeName = @"ENRMAutoma
   if (matchedUrl != nil && localMatch.location != NSNotFound) {
     NSRange matchRange = NSMakeRange(wordRange.location + localMatch.location, localMatch.length);
 
-    // A manual link overlapping the matched slice takes precedence — check the
+    // A manual link overlapping the matched slice takes precedence — test the
     // whole slice, not just its first character.
     ENRMFormattingStore *store = _formattingStore;
-    if (store != nil) {
-      for (NSUInteger position = matchRange.location; position < NSMaxRange(matchRange); position++) {
-        if ([store rangeOfType:ENRMInputStyleTypeLink containingPosition:position] != nil) {
-          [self clearAutoLinkInRange:wordRange];
-          return nil;
-        }
-      }
+    if (store != nil && [store isStyleActive:ENRMInputStyleTypeLink inRange:matchRange]) {
+      [self clearAutoLinkInRange:wordRange];
+      return nil;
     }
 
     NSRange effectiveRange;


### PR DESCRIPTION
### What/Why?

Fixes #516 (link corruption on iOS).

When the input's plain text contained link-like tokens, the iOS auto-link detector (`ENRMAutoLinkDetector`) corrupted them on serialize. Typing a markdown link like `[Testing](http://example.com)` produced this from `getMarkdown()`:

```
[[Testing](http://example.com)](https://[Testing](http://example.com))
```

Two defects, both in `ENRMAutoLinkDetector.mm`:

1. **Over-capture of the URL** - `tryMatchWord:` only *tested* for a regex match, then returned `normalizeUrl:` of the **entire** whitespace-delimited token. For the token `[Testing](http://example.com)` that yields `https://[Testing](http://example.com)` - the exact garbage destination from the issue.
2. **Whole-token attribution** - the auto-link attribute was applied over the full token range, so `allRangesIncludingTransient` serialized an auto-link *wrapping* the markdown syntax that was already there, giving the double-wrap above.

The existing manual-link guard didn't catch this because it only checked the token's *first* character against the formatting store.

Fix:

- `tryMatchWord:matchedRange:` now uses `firstMatchInString:` and returns **only the matched URL sub-range** (custom regexes keep their whole-token contract).
- `detectNewLinkAtRange:…matchedRange:` applies the link to that sub-range only, checks the manual-link store across the **whole** slice, and **skips tokens carrying markdown link syntax** (`[…` / `…](…`) so the parser owns them.
- `processWord:` emits the actual linked slice to `onLinkDetected` instead of the whole token.

This is iOS-only; Android was already correct.

### Testing

Using the example app the cases in table below were tested:

| Typed/set via ref input | Before (iOS) | After (iOS) |
| - | - | - |
| `[Testing](http://example.com)` | `[[Testing](http://example.com)](https://[Testing](http://example.com))` | `[Testing](http://example.com)` |
| `see:http://example.com done` | over-captured whole token | `see:[http://example.com](http://example.com) done` |
| `http://example.com` | correct | correct (still auto-links) |

*On android every case worked before the fix*

Added an E2E regression flow: `.maestro/enrichedMarkdownInput/flows/basic/inline_elements/link_autolink_roundtrip_test.yaml`
(passing).

### Screenshots

| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/10dbfcd9-a40d-4dc1-9693-e3f0f2215f72" width="300" style="max-width: 300px;" controls></video> | <video src="https://github.com/user-attachments/assets/0bc580a5-85a9-41a5-a4c0-d0093393fb6c" width="300" style="max-width: 300px;" controls></video> |
| <video src="https://github.com/user-attachments/assets/f3a5ef2d-2c38-44b0-8db8-33caf5e9ada2" width="300" style="max-width: 300px;" controls></video> | <video src="https://github.com/user-attachments/assets/16ef74eb-9bac-485e-8903-31fb6ab3313d" width="300" style="max-width: 300px;" controls></video> |
| <video src="https://github.com/user-attachments/assets/f4f6ff17-7a49-42f4-aec4-71ad3e1553e6" width="300" style="max-width: 300px;" controls></video> | <video src="https://github.com/user-attachments/assets/bc782848-5303-4e26-b8c4-3f0c3b6cd933" width="300" style="max-width: 300px;" controls></video> |**



### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable 
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)