### PR TITLE
fix(ios): visible source fallback when RaTeX cannot parse a math span

### DIFF
--- a/packages/react-native-enriched-markdown/ios/attachments/ENRMMathInlineAttachment.m
+++ b/packages/react-native-enriched-markdown/ios/attachments/ENRMMathInlineAttachment.m
@@ -14,13 +14,31 @@
 
 - (void)prepareIfNeeded
 {
-  if (_renderResult)
+  if (_renderResult || _fallbackSource)
     return;
 
   RCTUIColor *color = self.mathTextColor ?: [RCTUIColor blackColor];
   ENRMRaTeXRenderResult *result = [ENRMRaTeXBridge parse:self.latex displayMode:NO fontSize:self.fontSize color:color];
-  if (!result)
+  if (!result) {
+    // RaTeX parse failure: fall back to the original source, delimiters
+    // included, in body style — the formula stays visible and copyable
+    // instead of collapsing into an invisible zero-size box.
+    CGFloat size = self.fontSize > 0 ? self.fontSize : 16.0;
+    UIFont *font = [UIFont systemFontOfSize:size];
+    NSString *source = [NSString stringWithFormat:@"$%@$", self.latex ?: @""];
+    _fallbackSource = [[NSAttributedString alloc] initWithString:source
+                                                      attributes:@{
+                                                        NSFontAttributeName : font,
+                                                        NSForegroundColorAttributeName : color,
+                                                      }];
+    CGRect bounds = [_fallbackSource boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
+                                                  options:NSStringDrawingUsesLineFragmentOrigin
+                                                  context:nil];
+    _mathAscent = font.ascender;
+    _mathDescent = -font.descender;
+    _cachedSize = CGSizeMake(ceil(bounds.size.width), ceil(_mathAscent + _mathDescent));
     return;
+  }
 
   _renderResult = result;
   _mathAscent = result.ascent;
@@ -42,7 +60,7 @@
              characterIndex:(NSUInteger)characterIndex
 {
   [self prepareIfNeeded];
-  if (!_renderResult)
+  if (!_renderResult && !_fallbackSource)
     return nil;
 
   UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat preferredFormat];
@@ -51,10 +69,16 @@
   UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:_cachedSize format:format];
 
   return [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
-    CGContextRef ctx = rendererContext.CGContext;
-    CGContextSaveGState(ctx);
-    [_renderResult drawIn:ctx];
-    CGContextRestoreGState(ctx);
+    if (_renderResult) {
+      CGContextRef ctx = rendererContext.CGContext;
+      CGContextSaveGState(ctx);
+      [_renderResult drawIn:ctx];
+      CGContextRestoreGState(ctx);
+    } else {
+      [_fallbackSource drawWithRect:CGRectMake(0, 0, _cachedSize.width, _cachedSize.height)
+                            options:NSStringDrawingUsesLineFragmentOrigin
+                            context:nil];
+    }
   }];
 }
 

--- a/packages/react-native-enriched-markdown/ios/attachments/ENRMMathInlineAttachment.m
+++ b/packages/react-native-enriched-markdown/ios/attachments/ENRMMathInlineAttachment.m
@@ -1,3 +1,4 @@
+#import "ENRMMathFallback.h"
 #import "ENRMMathInlineAttachmentShared.h"
 
 #if ENRICHED_MARKDOWN_MATH
@@ -20,17 +21,8 @@
   RCTUIColor *color = self.mathTextColor ?: [RCTUIColor blackColor];
   ENRMRaTeXRenderResult *result = [ENRMRaTeXBridge parse:self.latex displayMode:NO fontSize:self.fontSize color:color];
   if (!result) {
-    // RaTeX parse failure: fall back to the original source, delimiters
-    // included, in body style — the formula stays visible and copyable
-    // instead of collapsing into an invisible zero-size box.
-    CGFloat size = self.fontSize > 0 ? self.fontSize : 16.0;
-    UIFont *font = [UIFont systemFontOfSize:size];
-    NSString *source = [NSString stringWithFormat:@"$%@$", self.latex ?: @""];
-    _fallbackSource = [[NSAttributedString alloc] initWithString:source
-                                                      attributes:@{
-                                                        NSFontAttributeName : font,
-                                                        NSForegroundColorAttributeName : color,
-                                                      }];
+    _fallbackSource = ENRMMathFallbackString(self.latex, @"$", self.fontSize, color);
+    UIFont *font = [_fallbackSource attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL];
     CGRect bounds = [_fallbackSource boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
                                                   options:NSStringDrawingUsesLineFragmentOrigin
                                                   context:nil];

--- a/packages/react-native-enriched-markdown/ios/attachments/ENRMMathInlineAttachmentShared.h
+++ b/packages/react-native-enriched-markdown/ios/attachments/ENRMMathInlineAttachmentShared.h
@@ -11,9 +11,7 @@
   CGFloat _mathAscent;
   CGFloat _mathDescent;
   ENRMRaTeXRenderResult *_renderResult;
-  // Visible-source fallback when RaTeX cannot parse the span. A parse failure
-  // must NEVER render as an invisible zero-size box — we typeset the original
-  // source (delimiters included) in body style instead.
+  // Visible-source fallback when RaTeX cannot parse the span; see ENRMMathFallback.h.
   NSAttributedString *_fallbackSource;
 }
 @end

--- a/packages/react-native-enriched-markdown/ios/attachments/ENRMMathInlineAttachmentShared.h
+++ b/packages/react-native-enriched-markdown/ios/attachments/ENRMMathInlineAttachmentShared.h
@@ -11,6 +11,10 @@
   CGFloat _mathAscent;
   CGFloat _mathDescent;
   ENRMRaTeXRenderResult *_renderResult;
+  // Visible-source fallback when RaTeX cannot parse the span. A parse failure
+  // must NEVER render as an invisible zero-size box — we typeset the original
+  // source (delimiters included) in body style instead.
+  NSAttributedString *_fallbackSource;
 }
 @end
 

--- a/packages/react-native-enriched-markdown/ios/utils/ENRMMathFallback.h
+++ b/packages/react-native-enriched-markdown/ios/utils/ENRMMathFallback.h
@@ -1,0 +1,26 @@
+#pragma once
+#import "ENRMUIKit.h"
+#import <Foundation/Foundation.h>
+
+static const CGFloat kENRMMathFallbackDefaultFontSize = 16.0;
+
+NS_ASSUME_NONNULL_BEGIN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Builds the visible-source fallback for a RaTeX parse failure: the original
+ * LaTeX source wrapped in its delimiters ($ inline, $$ block), typeset in body
+ * style. A parse failure must never render as an invisible zero-size box —
+ * the formula stays visible and copyable instead.
+ */
+NSAttributedString *ENRMMathFallbackString(NSString *_Nullable latex, NSString *delimiter, CGFloat fontSize,
+                                           RCTUIColor *_Nullable color);
+
+#ifdef __cplusplus
+}
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/utils/ENRMMathFallback.m
+++ b/packages/react-native-enriched-markdown/ios/utils/ENRMMathFallback.m
@@ -1,6 +1,9 @@
 #import "ENRMMathFallback.h"
 
-NSAttributedString *ENRMMathFallbackString(NSString *latex, NSString *delimiter, CGFloat fontSize, RCTUIColor *color)
+NS_ASSUME_NONNULL_BEGIN
+
+NSAttributedString *ENRMMathFallbackString(NSString *_Nullable latex, NSString *delimiter, CGFloat fontSize,
+                                           RCTUIColor *_Nullable color)
 {
   CGFloat size = fontSize > 0 ? fontSize : kENRMMathFallbackDefaultFontSize;
   UIFont *font = [UIFont systemFontOfSize:size];
@@ -11,3 +14,5 @@ NSAttributedString *ENRMMathFallbackString(NSString *latex, NSString *delimiter,
                                            NSForegroundColorAttributeName : color ?: [RCTUIColor blackColor],
                                          }];
 }
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/utils/ENRMMathFallback.m
+++ b/packages/react-native-enriched-markdown/ios/utils/ENRMMathFallback.m
@@ -1,0 +1,13 @@
+#import "ENRMMathFallback.h"
+
+NSAttributedString *ENRMMathFallbackString(NSString *latex, NSString *delimiter, CGFloat fontSize, RCTUIColor *color)
+{
+  CGFloat size = fontSize > 0 ? fontSize : kENRMMathFallbackDefaultFontSize;
+  UIFont *font = [UIFont systemFontOfSize:size];
+  NSString *source = [NSString stringWithFormat:@"%@%@%@", delimiter, latex ?: @"", delimiter];
+  return [[NSAttributedString alloc] initWithString:source
+                                         attributes:@{
+                                           NSFontAttributeName : font,
+                                           NSForegroundColorAttributeName : color ?: [RCTUIColor blackColor],
+                                         }];
+}

--- a/packages/react-native-enriched-markdown/ios/views/ENRMMathContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMMathContainerView.m
@@ -208,6 +208,7 @@
 #if !TARGET_OS_OSX
     _scrollView.frame = self.bounds;
     _scrollView.contentSize = self.bounds.size;
+    _scrollView.contentOffset = CGPointZero;
     _scrollView.scrollEnabled = NO;
 #endif
     _mathView.frame = CGRectMake(padding, padding, MAX(self.bounds.size.width - padding * 2, 1),

--- a/packages/react-native-enriched-markdown/ios/views/ENRMMathContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMMathContainerView.m
@@ -19,14 +19,21 @@
 
 @interface ENRMRaTeXCanvasView : RCTUIView
 @property (nonatomic, strong, nullable) ENRMRaTeXRenderResult *renderResult;
+// Visible-source fallback when RaTeX cannot parse the block: the original
+// `$$…$$` source, drawn wrapped, instead of an invisible zero-height bar.
+@property (nonatomic, strong, nullable) NSAttributedString *fallbackSource;
 @end
 
 @implementation ENRMRaTeXCanvasView
 
 - (void)drawRect:(CGRect)rect
 {
-  if (!_renderResult)
+  if (!_renderResult) {
+    if (_fallbackSource) {
+      [_fallbackSource drawWithRect:self.bounds options:NSStringDrawingUsesLineFragmentOrigin context:nil];
+    }
     return;
+  }
   CGContextRef ctx = UIGraphicsGetCurrentContext();
   if (!ctx)
     return;
@@ -96,6 +103,22 @@
                                                 fontSize:config.mathFontSize
                                                    color:config.mathColor];
   _mathView.renderResult = result;
+  if (!result) {
+    // RaTeX parse failure: keep the block visible — typeset the original
+    // source with its delimiters (wrapped in layoutSubviews/measureHeight)
+    // instead of collapsing into a zero-height bar.
+    CGFloat fontSize = config.mathFontSize > 0 ? config.mathFontSize : 16.0;
+    UIFont *font = [UIFont systemFontOfSize:fontSize];
+    NSString *source = [NSString stringWithFormat:@"$$%@$$", latex ?: @""];
+    _mathView.fallbackSource = [[NSAttributedString alloc]
+        initWithString:source
+            attributes:@{
+              NSFontAttributeName : font,
+              NSForegroundColorAttributeName : config.mathColor ?: [RCTUIColor blackColor],
+            }];
+  } else {
+    _mathView.fallbackSource = nil;
+  }
 
   CGFloat padding = config.mathPadding;
   _mathView.frame = CGRectMake(padding, padding, ceil(result.width), ceil(result.totalHeight));
@@ -164,6 +187,13 @@
 - (CGFloat)measureHeight:(CGFloat)maxWidth
 {
   CGFloat padding = self.config.mathPadding;
+  if (!_mathView.renderResult && _mathView.fallbackSource) {
+    CGFloat available = MAX(maxWidth - padding * 2, 1);
+    CGRect bounds = [_mathView.fallbackSource boundingRectWithSize:CGSizeMake(available, CGFLOAT_MAX)
+                                                           options:NSStringDrawingUsesLineFragmentOrigin
+                                                           context:nil];
+    return ceil(bounds.size.height) + padding * 2;
+  }
   return [self mathViewIntrinsicSize].height + padding * 2;
 }
 
@@ -186,6 +216,24 @@
   [super layoutSubviews];
 
   CGFloat padding = self.config.mathPadding;
+
+  if (!_mathView.renderResult && _mathView.fallbackSource) {
+    // Fallback source fills the available width and wraps; no horizontal scroll.
+#if !TARGET_OS_OSX
+    _scrollView.frame = self.bounds;
+    _scrollView.contentSize = self.bounds.size;
+    _scrollView.scrollEnabled = NO;
+#endif
+    _mathView.frame = CGRectMake(padding, padding, MAX(self.bounds.size.width - padding * 2, 1),
+                                 MAX(self.bounds.size.height - padding * 2, 1));
+#if !TARGET_OS_OSX
+    [_mathView setNeedsDisplay];
+#else
+    [_mathView setNeedsDisplay:YES];
+#endif
+    return;
+  }
+
   CGSize intrinsicSize = [self mathViewIntrinsicSize];
   CGFloat contentWidth = intrinsicSize.width + padding * 2;
   CGFloat contentHeight = self.bounds.size.height;

--- a/packages/react-native-enriched-markdown/ios/views/ENRMMathContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMMathContainerView.m
@@ -4,6 +4,7 @@
 #include <TargetConditionals.h>
 
 #if ENRICHED_MARKDOWN_MATH
+#import "ENRMMathFallback.h"
 #import "PasteboardUtils.h"
 #if __has_include("ReactNativeEnrichedMarkdown-Swift.h")
 #import "ReactNativeEnrichedMarkdown-Swift.h"
@@ -19,8 +20,8 @@
 
 @interface ENRMRaTeXCanvasView : RCTUIView
 @property (nonatomic, strong, nullable) ENRMRaTeXRenderResult *renderResult;
-// Visible-source fallback when RaTeX cannot parse the block: the original
-// `$$…$$` source, drawn wrapped, instead of an invisible zero-height bar.
+// Visible-source fallback when RaTeX cannot parse the block, drawn wrapped;
+// see ENRMMathFallback.h.
 @property (nonatomic, strong, nullable) NSAttributedString *fallbackSource;
 @end
 
@@ -103,22 +104,7 @@
                                                 fontSize:config.mathFontSize
                                                    color:config.mathColor];
   _mathView.renderResult = result;
-  if (!result) {
-    // RaTeX parse failure: keep the block visible — typeset the original
-    // source with its delimiters (wrapped in layoutSubviews/measureHeight)
-    // instead of collapsing into a zero-height bar.
-    CGFloat fontSize = config.mathFontSize > 0 ? config.mathFontSize : 16.0;
-    UIFont *font = [UIFont systemFontOfSize:fontSize];
-    NSString *source = [NSString stringWithFormat:@"$$%@$$", latex ?: @""];
-    _mathView.fallbackSource = [[NSAttributedString alloc]
-        initWithString:source
-            attributes:@{
-              NSFontAttributeName : font,
-              NSForegroundColorAttributeName : config.mathColor ?: [RCTUIColor blackColor],
-            }];
-  } else {
-    _mathView.fallbackSource = nil;
-  }
+  _mathView.fallbackSource = result ? nil : ENRMMathFallbackString(latex, @"$$", config.mathFontSize, config.mathColor);
 
   CGFloat padding = config.mathPadding;
   _mathView.frame = CGRectMake(padding, padding, ceil(result.width), ceil(result.totalHeight));


### PR DESCRIPTION
### What/Why?

When `RaTeXEngine.parse` throws, the iOS math pipeline currently swallows the failure:

- `ENRMMathInlineAttachment.prepareIfNeeded` leaves `_renderResult` nil → zero-size bounds + nil image → the span **silently vanishes** from the paragraph (no error, no trace — prose closes up seamlessly).
- `ENRMMathContainerView.applyLatex:` has the same shape for display blocks: nil render result → zero intrinsic size → the block collapses into an invisible bar.

Malformed LaTeX (`$x^$`, `$\frac{1}$`, fused `$x+1$$y+2$`) is routine in LLM/OCR-produced markdown, and invisible content loss is the worst possible failure mode for it. This PR makes parse failures render the **original source, delimiters included**, instead:

- inline: body style (ambient font size + configured math color), baseline-aligned, no loud error UI;
- display: math container style, wraps to the available width, horizontal scrolling disabled in fallback mode;
- copy actions and the accessibility label already read `cachedLatex` and keep working unchanged.

### Testing

Verified on a production K12 app (iPhone simulator dev build) that has been running this change via `patch-package` against 0.7.3 (the touched files are byte-identical to current `main`):

- `$x^$` and `$x+1$$y+2$` (md4c fuses the glued pair into one span whose body contains `$$`) previously vanished; with the patch they render as visible source text.
- Block-level `$$\frac{1}$$` previously collapsed; now renders `$$\frac{1}$$` wrapped inside the math container.
- Regression sweep: root-level `$$` blocks (`cases`, `pmatrix`, quadratic formula), inline math, CJK-adjacent math — unchanged.
- Corpus datapoint: 4,977 real-world math spans through this RaTeX build — 92.4% parse OK; the 7.6% failures are exactly the population this fallback makes visible.

Repro snippets for the example app:

```
坏公式 $x^$ 应当看得见这行字后面有东西。
相邻：$x+1$$y+2$ 尾。
前文。\n\n$$\frac{1}$$\n\n后文。
```

Note: iOS only. `MathInlineSpan.kt` / `MathContainerView.kt` on Android have the same silent-failure shape, but we ship iOS-only and did not device-verify an Android fix, so it is deliberately out of scope here.

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android (Android sources untouched — iOS-only change)
- [ ] Updated documentation/README if applicable (no documented behavior contract changes)
- [ ] Ran example app to verify changes (verified in a production app via patch-package instead — see Testing)
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
