### PR TITLE
feat: add horizontalOverflow style prop for edge-to-edge scrollable tables

### DIFF
--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/Table.stories.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/Table.stories.tsx
@@ -21,6 +21,12 @@ const MARKDOWN = `| col1 | col2 | looooooooong col | a |
 | the | one | piece is | real
 | third | Row | to test trailing | symbols | |asdf|||||blabla|`;
 
+const WIDE_MARKDOWN = `| Product | Category | Q1 Revenue | Q2 Revenue | Q3 Revenue | Q4 Revenue | Total |
+| --- | --- | --- | --- | --- | --- | --- |
+| Widget Pro | Hardware | $12,400 | $15,200 | $14,800 | $18,100 | $60,500 |
+| Cloud Suite | Software | $8,900 | $9,300 | $11,700 | $12,000 | $41,900 |
+| Support Plan | Services | $4,200 | $4,500 | $4,800 | $5,100 | $18,600 |`;
+
 const argTypes = {
   ...githubFlavorArgTypes('Tables require flavor="github" (GFM).'),
   fontSize: numberControl('markdownStyle.table.fontSize', {
@@ -88,6 +94,11 @@ const argTypes = {
     'markdownStyle.table.cellPaddingVertical',
     { min: 4, max: 24, step: 2 }
   ),
+  horizontalOverflow: numberControl('markdownStyle.table.horizontalOverflow', {
+    min: 0,
+    max: 48,
+    step: 2,
+  }),
 };
 
 export default storyMeta('Block', 'Table');
@@ -105,6 +116,27 @@ export const Default: TextStory<TableStyleControls> = {
       <EnrichedMarkdownTextStory
         title="Table"
         description="GFM tables. Use the controls to tune markdownStyle.table."
+        {...rest}
+        style={{ table: toTableStyle(controls) }}
+      />
+    );
+  },
+};
+
+export const HorizontalOverflow: TextStory<TableStyleControls> = {
+  args: {
+    markdown: WIDE_MARKDOWN,
+    flavor: 'github',
+    ...tableStyledDefaults,
+    horizontalOverflow: 10,
+  },
+  argTypes,
+  render: (args) => {
+    const { controls, rest } = splitStyleControls(args, tableStyledDefaults);
+    return (
+      <EnrichedMarkdownTextStory
+        title="Table Horizontal Overflow"
+        description="Scrollable tables extend beyond the markdown container by markdownStyle.table.horizontalOverflow on each side (edge-to-edge layout). Set it to the parent's horizontal padding; here 10 matches the output box padding."
         {...rest}
         style={{ table: toTableStyle(controls) }}
       />

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookMarkdownStyles.ts
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookMarkdownStyles.ts
@@ -162,6 +162,7 @@ export type TableStyleControls = {
   borderRadius: number;
   cellPaddingHorizontal: number;
   cellPaddingVertical: number;
+  horizontalOverflow: number;
 };
 
 export const tableStyledDefaults: TableStyleControls = {
@@ -182,6 +183,7 @@ export const tableStyledDefaults: TableStyleControls = {
   borderRadius: 8,
   cellPaddingHorizontal: 12,
   cellPaddingVertical: 8,
+  horizontalOverflow: 0,
 };
 
 export type TaskListStyleControls = {

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookStyleBuilders.ts
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookStyleBuilders.ts
@@ -171,6 +171,7 @@ export function toTableStyle(
     borderRadius: controls.borderRadius,
     cellPaddingHorizontal: controls.cellPaddingHorizontal,
     cellPaddingVertical: controls.cellPaddingVertical,
+    horizontalOverflow: controls.horizontalOverflow,
   };
 }
 

--- a/apps/react-native-example/ios/Podfile.lock
+++ b/apps/react-native-example/ios/Podfile.lock
@@ -2559,7 +2559,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   EnrichedMarkdownCore: 33ec2bafbc265cfe76df3095fb21522440dd0a30
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: 1622a566d44d0dd4d377a1532e3ac82be7a0443c
+  hermes-engine: 4a0ceceb51f483aef72bfeb288e965aff6defa54
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f

--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -428,6 +428,7 @@ Table styles only apply when `flavor="github"` is set. Tables inherit the base b
 | `borderRadius` | `number` | Corner radius of the table container |
 | `cellPaddingHorizontal` | `number` | Horizontal padding inside cells |
 | `cellPaddingVertical` | `number` | Vertical padding inside cells |
+| `horizontalOverflow` | `number` | When set, scrollable tables extend beyond the markdown container by this amount on each side (edge-to-edge / "bleed" layout). Set to the parent's horizontal padding to make wide tables reach the screen edges. Has no effect on tables that fit within the container width. Default: `0` |
 
 ### Task List-specific
 

--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -428,7 +428,7 @@ Table styles only apply when `flavor="github"` is set. Tables inherit the base b
 | `borderRadius` | `number` | Corner radius of the table container |
 | `cellPaddingHorizontal` | `number` | Horizontal padding inside cells |
 | `cellPaddingVertical` | `number` | Vertical padding inside cells |
-| `horizontalOverflow` | `number` | When set, scrollable tables extend beyond the markdown container by this amount on each side (edge-to-edge / "bleed" layout). Set to the parent's horizontal padding to make wide tables reach the screen edges. Has no effect on tables that fit within the container width. Default: `0` |
+| `horizontalOverflow` | `number` | When set, scrollable tables extend beyond the markdown container by this amount on each side (edge-to-edge / "bleed" layout). Set to the parent's horizontal padding to make wide tables reach the screen edges. Has no effect on tables that fit within the container width. iOS, Android, and macOS only. Default: `0` |
 
 ### Task List-specific
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -572,13 +572,13 @@ class EnrichedMarkdown
       val containerWidth = width
       if (containerWidth <= 0) return
 
-      val needsOverflow =
+      val needsOverhang =
         segmentViews.any { view ->
           view is TableContainerView &&
             ceil(view.tableStyle.horizontalOverflow.toDouble()).toInt() > 0
         }
-      if (clipChildren == needsOverflow) {
-        clipChildren = !needsOverflow
+      if (clipChildren == needsOverhang) {
+        clipChildren = !needsOverhang
       }
 
       var currentY = 0
@@ -592,18 +592,18 @@ class EnrichedMarkdown
 
         currentY += segment?.segmentMarginTop ?: 0
 
-        val tableOverflow =
+        val overhang =
           if (view is TableContainerView) {
             max(ceil(view.tableStyle.horizontalOverflow.toDouble()).toInt(), 0)
           } else {
             0
           }
 
-        if (tableOverflow > 0) {
-          val extendedWidth = containerWidth + tableOverflow * 2
+        if (overhang > 0) {
+          val extendedWidth = containerWidth + overhang * 2
           val extWidthSpec = MeasureSpec.makeMeasureSpec(extendedWidth, MeasureSpec.EXACTLY)
           view.measure(extWidthSpec, heightSpec)
-          view.layout(-tableOverflow, currentY, containerWidth + tableOverflow, currentY + view.measuredHeight)
+          view.layout(-overhang, currentY, containerWidth + overhang, currentY + view.measuredHeight)
         } else {
           view.measure(widthSpec, heightSpec)
           view.layout(0, currentY, containerWidth, currentY + view.measuredHeight)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -32,6 +32,7 @@ import com.swmansion.enriched.markdown.views.TableContainerView
 import java.util.EnumSet
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import kotlin.math.ceil
 import kotlin.math.max
 
 class EnrichedMarkdown
@@ -571,6 +572,15 @@ class EnrichedMarkdown
       val containerWidth = width
       if (containerWidth <= 0) return
 
+      val needsOverflow =
+        segmentViews.any { view ->
+          view is TableContainerView &&
+            ceil(view.tableStyle.horizontalOverflow.toDouble()).toInt() > 0
+        }
+      if (clipChildren == needsOverflow) {
+        clipChildren = !needsOverflow
+      }
+
       var currentY = 0
       val lastIndex = segmentViews.lastIndex
       val widthSpec = MeasureSpec.makeMeasureSpec(containerWidth, MeasureSpec.EXACTLY)
@@ -584,13 +594,12 @@ class EnrichedMarkdown
 
         val tableOverflow =
           if (view is TableContainerView) {
-            max(view.tableStyle.horizontalOverflow.toInt(), 0)
+            max(ceil(view.tableStyle.horizontalOverflow.toDouble()).toInt(), 0)
           } else {
             0
           }
 
         if (tableOverflow > 0) {
-          if (clipChildren) clipChildren = false
           val extendedWidth = containerWidth + tableOverflow * 2
           val extWidthSpec = MeasureSpec.makeMeasureSpec(extendedWidth, MeasureSpec.EXACTLY)
           view.measure(extWidthSpec, heightSpec)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -32,6 +32,7 @@ import com.swmansion.enriched.markdown.views.TableContainerView
 import java.util.EnumSet
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import kotlin.math.max
 
 class EnrichedMarkdown
   @JvmOverloads
@@ -580,9 +581,24 @@ class EnrichedMarkdown
         val shouldAddBottomMargin = index != lastIndex || allowTrailingMargin
 
         currentY += segment?.segmentMarginTop ?: 0
-        view.measure(widthSpec, heightSpec)
 
-        view.layout(0, currentY, containerWidth, currentY + view.measuredHeight)
+        val tableOverflow =
+          if (view is TableContainerView) {
+            max(view.tableStyle.horizontalOverflow.toInt(), 0)
+          } else {
+            0
+          }
+
+        if (tableOverflow > 0) {
+          if (clipChildren) clipChildren = false
+          val extendedWidth = containerWidth + tableOverflow * 2
+          val extWidthSpec = MeasureSpec.makeMeasureSpec(extendedWidth, MeasureSpec.EXACTLY)
+          view.measure(extWidthSpec, heightSpec)
+          view.layout(-tableOverflow, currentY, containerWidth + tableOverflow, currentY + view.measuredHeight)
+        } else {
+          view.measure(widthSpec, heightSpec)
+          view.layout(0, currentY, containerWidth, currentY + view.measuredHeight)
+        }
         currentY += view.measuredHeight
 
         if (shouldAddBottomMargin) {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/TableStyle.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/TableStyle.kt
@@ -20,6 +20,7 @@ data class TableStyle(
   val borderRadius: Float,
   val cellPaddingHorizontal: Float,
   val cellPaddingVertical: Float,
+  val horizontalOverflow: Float,
 ) : BaseBlockStyle {
   companion object {
     fun fromReadableMap(
@@ -44,6 +45,7 @@ data class TableStyle(
       val borderRadius = parser.toPixelFromDIP(map.getDouble("borderRadius").toFloat())
       val cellPaddingHorizontal = parser.toPixelFromDIP(map.getDouble("cellPaddingHorizontal").toFloat())
       val cellPaddingVertical = parser.toPixelFromDIP(map.getDouble("cellPaddingVertical").toFloat())
+      val horizontalOverflow = parser.toPixelFromDIP(map.getDouble("horizontalOverflow").toFloat())
 
       return TableStyle(
         fontSize = fontSize,
@@ -63,6 +65,7 @@ data class TableStyle(
         borderRadius = borderRadius,
         cellPaddingHorizontal = cellPaddingHorizontal,
         cellPaddingVertical = cellPaddingVertical,
+        horizontalOverflow = horizontalOverflow,
       )
     }
   }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
@@ -43,7 +43,7 @@ class TableContainerView(
   private val styleConfig: StyleConfig,
 ) : FrameLayout(context),
   BlockSegmentView {
-  private val tableStyle: TableStyle = styleConfig.tableStyle
+  internal val tableStyle: TableStyle = styleConfig.tableStyle
 
   override val segmentMarginTop: Int get() = tableStyle.marginTop.toInt()
   override val segmentMarginBottom: Int get() = tableStyle.marginBottom.toInt()
@@ -327,12 +327,31 @@ class TableContainerView(
     right: Int,
     bottom: Int,
   ) {
-    scrollView.layout(0, 0, right - left, bottom - top)
     val viewWidth = right - left
-    scrollView.isHorizontalScrollBarEnabled = totalTableWidth > viewWidth
+    val overflow = max(tableStyle.horizontalOverflow.toInt(), 0)
+    val originalWidth = viewWidth - overflow * 2
+    val needsEdgeToEdge = overflow > 0 && totalTableWidth > originalWidth
 
-    if (isRtl && totalTableWidth > viewWidth) {
-      scrollView.scrollTo((totalTableWidth - viewWidth).toInt(), 0)
+    if (needsEdgeToEdge) {
+      scrollView.setPadding(overflow, 0, overflow, 0)
+      scrollView.clipToPadding = false
+      scrollView.isHorizontalScrollBarEnabled = true
+    } else if (overflow > 0) {
+      scrollView.setPadding(overflow, 0, overflow, 0)
+      scrollView.clipToPadding = true
+      scrollView.isHorizontalScrollBarEnabled = false
+    } else {
+      scrollView.setPadding(0, 0, 0, 0)
+      scrollView.isHorizontalScrollBarEnabled = totalTableWidth > viewWidth
+    }
+
+    scrollView.layout(0, 0, viewWidth, bottom - top)
+
+    if (isRtl) {
+      val effectiveWidth = if (needsEdgeToEdge) originalWidth.toFloat() else viewWidth.toFloat()
+      if (totalTableWidth > effectiveWidth) {
+        scrollView.scrollTo((totalTableWidth - effectiveWidth).toInt(), 0)
+      }
     }
   }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
@@ -328,9 +328,8 @@ class TableContainerView(
     bottom: Int,
   ) {
     val viewWidth = right - left
-    val overflow = max(tableStyle.horizontalOverflow.toInt(), 0)
-    val originalWidth = viewWidth - overflow * 2
-    val needsEdgeToEdge = overflow > 0 && totalTableWidth > originalWidth
+    val overflow = max(ceil(tableStyle.horizontalOverflow.toDouble()).toInt(), 0)
+    val needsEdgeToEdge = overflow > 0 && totalTableWidth > viewWidth
 
     if (needsEdgeToEdge) {
       scrollView.setPadding(overflow, 0, overflow, 0)
@@ -348,7 +347,7 @@ class TableContainerView(
     scrollView.layout(0, 0, viewWidth, bottom - top)
 
     if (isRtl) {
-      val effectiveWidth = if (needsEdgeToEdge) originalWidth.toFloat() else viewWidth.toFloat()
+      val effectiveWidth = if (needsEdgeToEdge) (viewWidth - overflow * 2).toFloat() else viewWidth.toFloat()
       if (totalTableWidth > effectiveWidth) {
         scrollView.scrollTo((totalTableWidth - effectiveWidth).toInt(), 0)
       }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
@@ -328,26 +328,18 @@ class TableContainerView(
     bottom: Int,
   ) {
     val viewWidth = right - left
-    val overflow = max(ceil(tableStyle.horizontalOverflow.toDouble()).toInt(), 0)
-    val needsEdgeToEdge = overflow > 0 && totalTableWidth > viewWidth
+    val overhang = max(ceil(tableStyle.horizontalOverflow.toDouble()).toInt(), 0)
+    val contentWidth = viewWidth - overhang * 2
+    val tableOverflows = totalTableWidth > contentWidth
 
-    if (needsEdgeToEdge) {
-      scrollView.setPadding(overflow, 0, overflow, 0)
-      scrollView.clipToPadding = false
-      scrollView.isHorizontalScrollBarEnabled = true
-    } else if (overflow > 0) {
-      scrollView.setPadding(overflow, 0, overflow, 0)
-      scrollView.clipToPadding = true
-      scrollView.isHorizontalScrollBarEnabled = false
-    } else {
-      scrollView.setPadding(0, 0, 0, 0)
-      scrollView.isHorizontalScrollBarEnabled = totalTableWidth > viewWidth
-    }
+    scrollView.setPadding(overhang, 0, overhang, 0)
+    scrollView.clipToPadding = !tableOverflows
+    scrollView.isHorizontalScrollBarEnabled = tableOverflows
 
     scrollView.layout(0, 0, viewWidth, bottom - top)
 
     if (isRtl) {
-      val effectiveWidth = if (needsEdgeToEdge) (viewWidth - overflow * 2).toFloat() else viewWidth.toFloat()
+      val effectiveWidth = if (tableOverflows) contentWidth.toFloat() else viewWidth.toFloat()
       if (totalTableWidth > effectiveWidth) {
         scrollView.scrollTo((totalTableWidth - effectiveWidth).toInt(), 0)
       }

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -248,6 +248,29 @@ static char kENRMSegmentFadeAnimatorKey;
   if (_segmentViews.count == 0)
     return CGSizeZero;
 
+  if (applyFrames) {
+    CGFloat overflow = MAX(_config.tableHorizontalOverflow, 0);
+    BOOL needsOverflow = NO;
+    if (overflow > 0) {
+      for (RCTUIView *seg in _segmentViews) {
+        if ([seg isKindOfClass:[TableContainerView class]]) {
+          needsOverflow = YES;
+          break;
+        }
+      }
+    }
+#if TARGET_OS_OSX
+    BOOL isClipping = self.layer.masksToBounds;
+    if (isClipping && needsOverflow)
+      self.layer.masksToBounds = NO;
+    else if (!isClipping && !needsOverflow)
+      self.layer.masksToBounds = YES;
+#else
+    if (self.clipsToBounds != !needsOverflow)
+      self.clipsToBounds = !needsOverflow;
+#endif
+  }
+
   __block CGFloat yOffset = 0.0;
   __block CGFloat maxContentWidth = 0.0;
   const NSUInteger lastIndex = _segmentViews.count - 1;

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -257,6 +257,7 @@ static char kENRMSegmentFadeAnimatorKey;
     const BOOL shouldAddBottomMargin = (!isLast || _allowTrailingMargin);
 
     CGFloat segmentHeight = 0;
+    const BOOL isTable = [segment isKindOfClass:[TableContainerView class]];
 
     if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {
       EnrichedMarkdownInternalText *textView = (EnrichedMarkdownInternalText *)segment;
@@ -265,7 +266,7 @@ static char kENRMSegmentFadeAnimatorKey;
       segmentHeight = textSize.height;
       maxContentWidth = MAX(maxContentWidth, textSize.width);
 
-    } else if ([segment isKindOfClass:[TableContainerView class]]) {
+    } else if (isTable) {
       yOffset += _config.tableMarginTop;
       segmentHeight = [(TableContainerView *)segment measureHeight:width];
       maxContentWidth = width;
@@ -279,7 +280,16 @@ static char kENRMSegmentFadeAnimatorKey;
 #endif
 
     if (applyFrames) {
-      CGRect segmentFrame = CGRectMake(0, yOffset, width, segmentHeight);
+      CGFloat segmentX = 0;
+      CGFloat segmentWidth = width;
+      if (isTable) {
+        CGFloat overflow = MAX(_config.tableHorizontalOverflow, 0);
+        if (overflow > 0) {
+          segmentX = -overflow;
+          segmentWidth = width + overflow * 2;
+        }
+      }
+      CGRect segmentFrame = CGRectMake(segmentX, yOffset, segmentWidth, segmentHeight);
       segment.frame = segmentFrame;
 #if TARGET_OS_OSX
       if ([segment isKindOfClass:[EnrichedMarkdownInternalText class]]) {

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -249,25 +249,25 @@ static char kENRMSegmentFadeAnimatorKey;
     return CGSizeZero;
 
   if (applyFrames) {
-    CGFloat overflow = MAX(_config.tableHorizontalOverflow, 0);
-    BOOL needsOverflow = NO;
-    if (overflow > 0) {
+    CGFloat overhang = MAX(_config.tableHorizontalOverflow, 0);
+    BOOL needsOverhang = NO;
+    if (overhang > 0) {
       for (RCTUIView *seg in _segmentViews) {
         if ([seg isKindOfClass:[TableContainerView class]]) {
-          needsOverflow = YES;
+          needsOverhang = YES;
           break;
         }
       }
     }
 #if TARGET_OS_OSX
     BOOL isClipping = self.layer.masksToBounds;
-    if (isClipping && needsOverflow)
+    if (isClipping && needsOverhang)
       self.layer.masksToBounds = NO;
-    else if (!isClipping && !needsOverflow)
+    else if (!isClipping && !needsOverhang)
       self.layer.masksToBounds = YES;
 #else
-    if (self.clipsToBounds != !needsOverflow)
-      self.clipsToBounds = !needsOverflow;
+    if (self.clipsToBounds != !needsOverhang)
+      self.clipsToBounds = !needsOverhang;
 #endif
   }
 
@@ -306,10 +306,10 @@ static char kENRMSegmentFadeAnimatorKey;
       CGFloat segmentX = 0;
       CGFloat segmentWidth = width;
       if (isTable) {
-        CGFloat overflow = MAX(_config.tableHorizontalOverflow, 0);
-        if (overflow > 0) {
-          segmentX = -overflow;
-          segmentWidth = width + overflow * 2;
+        CGFloat overhang = MAX(_config.tableHorizontalOverflow, 0);
+        if (overhang > 0) {
+          segmentX = -overhang;
+          segmentWidth = width + overhang * 2;
         }
       }
       CGRect segmentFrame = CGRectMake(segmentX, yOffset, segmentWidth, segmentHeight);

--- a/packages/react-native-enriched-markdown/ios/internals/MeasurementCache.h
+++ b/packages/react-native-enriched-markdown/ios/internals/MeasurementCache.h
@@ -134,7 +134,7 @@ template <typename StyleStruct> inline size_t computeStyleFingerprint(const Styl
   // Complex Components
   hashTextLayout(s.table);
   hashFields(s.table.headerFontFamily, s.table.cellPaddingHorizontal, s.table.cellPaddingVertical, s.table.borderWidth,
-             s.table.borderRadius);
+             s.table.borderRadius, s.table.horizontalOverflow);
   hashFields(s.math.fontSize, s.math.padding, s.math.marginTop, s.math.marginBottom, s.math.textAlign);
   hashFields(s.taskList.checkboxSize, s.taskList.checkboxBorderRadius);
 

--- a/packages/react-native-enriched-markdown/ios/styles/StyleConfig.h
+++ b/packages/react-native-enriched-markdown/ios/styles/StyleConfig.h
@@ -348,6 +348,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setTableCellPaddingHorizontal:(CGFloat)newValue;
 - (CGFloat)tableCellPaddingVertical;
 - (void)setTableCellPaddingVertical:(CGFloat)newValue;
+- (CGFloat)tableHorizontalOverflow;
+- (void)setTableHorizontalOverflow:(CGFloat)newValue;
 // Task list checkbox properties
 - (RCTUIColor *)taskListCheckedColor;
 - (void)setTaskListCheckedColor:(RCTUIColor *)newValue;

--- a/packages/react-native-enriched-markdown/ios/styles/StyleConfig.mm
+++ b/packages/react-native-enriched-markdown/ios/styles/StyleConfig.mm
@@ -208,6 +208,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   CGFloat _tableBorderRadius;
   CGFloat _tableCellPaddingHorizontal;
   CGFloat _tableCellPaddingVertical;
+  CGFloat _tableHorizontalOverflow;
   // Task list checkbox
   RCTUIColor *_taskListCheckedColor;
   RCTUIColor *_taskListBorderColor;
@@ -468,6 +469,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   copy->_tableBorderRadius = _tableBorderRadius;
   copy->_tableCellPaddingHorizontal = _tableCellPaddingHorizontal;
   copy->_tableCellPaddingVertical = _tableCellPaddingVertical;
+  copy->_tableHorizontalOverflow = _tableHorizontalOverflow;
   copy->_taskListCheckedColor = [_taskListCheckedColor copy];
   copy->_taskListBorderColor = [_taskListBorderColor copy];
   copy->_taskListCheckboxSize = _taskListCheckboxSize;
@@ -2272,6 +2274,16 @@ static const CGFloat kDefaultMinGap = 4.0;
 - (void)setTableCellPaddingVertical:(CGFloat)newValue
 {
   _tableCellPaddingVertical = newValue;
+}
+
+- (CGFloat)tableHorizontalOverflow
+{
+  return _tableHorizontalOverflow;
+}
+
+- (void)setTableHorizontalOverflow:(CGFloat)newValue
+{
+  _tableHorizontalOverflow = newValue;
 }
 
 // Task list

--- a/packages/react-native-enriched-markdown/ios/utils/StylePropsUtils.h
+++ b/packages/react-native-enriched-markdown/ios/utils/StylePropsUtils.h
@@ -991,6 +991,11 @@ BOOL applyMarkdownStyleToConfig(StyleConfig *config, const MarkdownStyle &newSty
     changed = YES;
   }
 
+  if (newStyle.table.horizontalOverflow != oldStyle.table.horizontalOverflow) {
+    [config setTableHorizontalOverflow:newStyle.table.horizontalOverflow];
+    changed = YES;
+  }
+
   // ── Task List ───────────────────────────────────────────────────────────────
 
   if (newStyle.taskList.checkedColor != oldStyle.taskList.checkedColor) {

--- a/packages/react-native-enriched-markdown/ios/views/TableContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/TableContainerView.m
@@ -559,7 +559,7 @@
   CGFloat originalWidth = containerWidth - overflow * 2;
   BOOL needsEdgeToEdge = (overflow > 0 && _totalTableWidth > originalWidth);
 
-  if (needsEdgeToEdge) {
+  if (needsEdgeToEdge && _totalTableWidth > containerWidth) {
     UIEdgeInsets inset = UIEdgeInsetsMake(0, overflow, 0, overflow);
     if (!UIEdgeInsetsEqualToEdgeInsets(_scrollView.contentInset, inset)) {
       _scrollView.contentInset = inset;
@@ -570,11 +570,13 @@
     _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
   } else if (overflow > 0) {
     _scrollView.contentInset = UIEdgeInsetsZero;
+    _scrollView.contentOffset = CGPointZero;
     _scrollView.contentSize = CGSizeMake(containerWidth, _totalTableHeight);
     _scrollView.scrollEnabled = NO;
     _gridContainer.frame = CGRectMake(overflow, 0, _totalTableWidth, _totalTableHeight);
   } else {
     _scrollView.contentInset = UIEdgeInsetsZero;
+    _scrollView.contentOffset = CGPointZero;
     _scrollView.contentSize = CGSizeMake(MAX(_totalTableWidth, containerWidth), _totalTableHeight);
     _scrollView.scrollEnabled = (_totalTableWidth > containerWidth);
     _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
@@ -582,24 +584,14 @@
 #else
   CGFloat overflow = MAX(self.config.tableHorizontalOverflow, 0);
   CGFloat containerWidth = self.bounds.size.width;
-  CGFloat originalWidth = containerWidth - overflow * 2;
-  BOOL needsEdgeToEdge = (overflow > 0 && _totalTableWidth > originalWidth);
-
-  if (_totalTableWidth > 0 && _totalTableHeight > 0) {
-    _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
-  }
+  BOOL needsEdgeToEdge = (overflow > 0 && _totalTableWidth > containerWidth);
 
   if (needsEdgeToEdge) {
-    NSEdgeInsets inset = NSEdgeInsetsMake(0, overflow, 0, overflow);
-    NSScrollView *scrollView = (NSScrollView *)_scrollView;
-    scrollView.automaticallyAdjustsContentInsets = NO;
-    scrollView.contentInsets = inset;
-    [scrollView.contentView scrollToPoint:NSMakePoint(-overflow, 0)];
+    _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
   } else if (overflow > 0) {
-    NSScrollView *scrollView = (NSScrollView *)_scrollView;
-    scrollView.automaticallyAdjustsContentInsets = NO;
-    scrollView.contentInsets = NSEdgeInsetsZero;
     _gridContainer.frame = CGRectMake(overflow, 0, _totalTableWidth, _totalTableHeight);
+  } else if (_totalTableWidth > 0 && _totalTableHeight > 0) {
+    _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
   }
 #endif
 }

--- a/packages/react-native-enriched-markdown/ios/views/TableContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/TableContainerView.m
@@ -580,11 +580,26 @@
     _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
   }
 #else
-  // TODO: Implement horizontalOverflow support for macOS (NSScrollView contentInsets).
-  // For NSScrollView+documentView, the scrollable content area is determined by
-  // the documentView's frame. No contentSize property to set.
+  CGFloat overflow = MAX(self.config.tableHorizontalOverflow, 0);
+  CGFloat containerWidth = self.bounds.size.width;
+  CGFloat originalWidth = containerWidth - overflow * 2;
+  BOOL needsEdgeToEdge = (overflow > 0 && _totalTableWidth > originalWidth);
+
   if (_totalTableWidth > 0 && _totalTableHeight > 0) {
     _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
+  }
+
+  if (needsEdgeToEdge) {
+    NSEdgeInsets inset = NSEdgeInsetsMake(0, overflow, 0, overflow);
+    NSScrollView *scrollView = (NSScrollView *)_scrollView;
+    scrollView.automaticallyAdjustsContentInsets = NO;
+    scrollView.contentInsets = inset;
+    [scrollView.contentView scrollToPoint:NSMakePoint(-overflow, 0)];
+  } else if (overflow > 0) {
+    NSScrollView *scrollView = (NSScrollView *)_scrollView;
+    scrollView.automaticallyAdjustsContentInsets = NO;
+    scrollView.contentInsets = NSEdgeInsetsZero;
+    _gridContainer.frame = CGRectMake(overflow, 0, _totalTableWidth, _totalTableHeight);
   }
 #endif
 }

--- a/packages/react-native-enriched-markdown/ios/views/TableContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/TableContainerView.m
@@ -554,10 +554,33 @@
   [super layoutSubviews];
   _scrollView.frame = self.bounds;
 #if !TARGET_OS_OSX
-  _scrollView.contentSize = CGSizeMake(MAX(_totalTableWidth, self.bounds.size.width), _totalTableHeight);
-  _scrollView.scrollEnabled = (_totalTableWidth > self.bounds.size.width);
-  _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
+  CGFloat overflow = MAX(self.config.tableHorizontalOverflow, 0);
+  CGFloat containerWidth = self.bounds.size.width;
+  CGFloat originalWidth = containerWidth - overflow * 2;
+  BOOL needsEdgeToEdge = (overflow > 0 && _totalTableWidth > originalWidth);
+
+  if (needsEdgeToEdge) {
+    UIEdgeInsets inset = UIEdgeInsetsMake(0, overflow, 0, overflow);
+    if (!UIEdgeInsetsEqualToEdgeInsets(_scrollView.contentInset, inset)) {
+      _scrollView.contentInset = inset;
+      _scrollView.contentOffset = CGPointMake(-overflow, 0);
+    }
+    _scrollView.contentSize = CGSizeMake(_totalTableWidth, _totalTableHeight);
+    _scrollView.scrollEnabled = YES;
+    _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
+  } else if (overflow > 0) {
+    _scrollView.contentInset = UIEdgeInsetsZero;
+    _scrollView.contentSize = CGSizeMake(containerWidth, _totalTableHeight);
+    _scrollView.scrollEnabled = NO;
+    _gridContainer.frame = CGRectMake(overflow, 0, _totalTableWidth, _totalTableHeight);
+  } else {
+    _scrollView.contentInset = UIEdgeInsetsZero;
+    _scrollView.contentSize = CGSizeMake(MAX(_totalTableWidth, containerWidth), _totalTableHeight);
+    _scrollView.scrollEnabled = (_totalTableWidth > containerWidth);
+    _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
+  }
 #else
+  // TODO: Implement horizontalOverflow support for macOS (NSScrollView contentInsets).
   // For NSScrollView+documentView, the scrollable content area is determined by
   // the documentView's frame. No contentSize property to set.
   if (_totalTableWidth > 0 && _totalTableHeight > 0) {

--- a/packages/react-native-enriched-markdown/ios/views/TableContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/TableContainerView.m
@@ -554,44 +554,35 @@
   [super layoutSubviews];
   _scrollView.frame = self.bounds;
 #if !TARGET_OS_OSX
-  CGFloat overflow = MAX(self.config.tableHorizontalOverflow, 0);
+  CGFloat overhang = MAX(self.config.tableHorizontalOverflow, 0);
   CGFloat containerWidth = self.bounds.size.width;
-  CGFloat originalWidth = containerWidth - overflow * 2;
-  BOOL needsEdgeToEdge = (overflow > 0 && _totalTableWidth > originalWidth);
+  BOOL tableOverflows = (overhang > 0 && _totalTableWidth > containerWidth);
 
-  if (needsEdgeToEdge && _totalTableWidth > containerWidth) {
-    UIEdgeInsets inset = UIEdgeInsetsMake(0, overflow, 0, overflow);
+  if (tableOverflows) {
+    UIEdgeInsets inset = UIEdgeInsetsMake(0, overhang, 0, overhang);
     if (!UIEdgeInsetsEqualToEdgeInsets(_scrollView.contentInset, inset)) {
       _scrollView.contentInset = inset;
-      _scrollView.contentOffset = CGPointMake(-overflow, 0);
+      _scrollView.contentOffset = CGPointMake(-overhang, 0);
     }
     _scrollView.contentSize = CGSizeMake(_totalTableWidth, _totalTableHeight);
     _scrollView.scrollEnabled = YES;
     _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
-  } else if (overflow > 0) {
-    _scrollView.contentInset = UIEdgeInsetsZero;
-    _scrollView.contentOffset = CGPointZero;
-    _scrollView.contentSize = CGSizeMake(containerWidth, _totalTableHeight);
-    _scrollView.scrollEnabled = NO;
-    _gridContainer.frame = CGRectMake(overflow, 0, _totalTableWidth, _totalTableHeight);
   } else {
     _scrollView.contentInset = UIEdgeInsetsZero;
     _scrollView.contentOffset = CGPointZero;
     _scrollView.contentSize = CGSizeMake(MAX(_totalTableWidth, containerWidth), _totalTableHeight);
     _scrollView.scrollEnabled = (_totalTableWidth > containerWidth);
-    _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
+    _gridContainer.frame = CGRectMake(overhang, 0, _totalTableWidth, _totalTableHeight);
   }
 #else
-  CGFloat overflow = MAX(self.config.tableHorizontalOverflow, 0);
+  CGFloat overhang = MAX(self.config.tableHorizontalOverflow, 0);
   CGFloat containerWidth = self.bounds.size.width;
-  BOOL needsEdgeToEdge = (overflow > 0 && _totalTableWidth > containerWidth);
+  BOOL tableOverflows = (overhang > 0 && _totalTableWidth > containerWidth);
 
-  if (needsEdgeToEdge) {
+  if (tableOverflows) {
     _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
-  } else if (overflow > 0) {
-    _gridContainer.frame = CGRectMake(overflow, 0, _totalTableWidth, _totalTableHeight);
   } else if (_totalTableWidth > 0 && _totalTableHeight > 0) {
-    _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
+    _gridContainer.frame = CGRectMake(overhang, 0, _totalTableWidth, _totalTableHeight);
   }
 #endif
 }

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
@@ -121,6 +121,7 @@ interface TableStyleInternal extends BaseBlockStyleInternal {
   borderRadius: CodegenTypes.Float;
   cellPaddingHorizontal: CodegenTypes.Float;
   cellPaddingVertical: CodegenTypes.Float;
+  horizontalOverflow: CodegenTypes.Float;
 }
 
 interface TaskListStyleInternal {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
@@ -121,6 +121,7 @@ interface TableStyleInternal extends BaseBlockStyleInternal {
   borderRadius: CodegenTypes.Float;
   cellPaddingHorizontal: CodegenTypes.Float;
   cellPaddingVertical: CodegenTypes.Float;
+  horizontalOverflow: CodegenTypes.Float;
 }
 
 interface TaskListStyleInternal {

--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.ts
@@ -187,6 +187,7 @@ const DEFAULT_NORMALIZED_STYLE = Object.freeze({
     borderRadius: 6,
     cellPaddingHorizontal: 12,
     cellPaddingVertical: 8,
+    horizontalOverflow: 0,
   },
   math: {
     fontSize: 20,

--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.web.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.web.ts
@@ -171,6 +171,7 @@ const DEFAULT_NORMALIZED_STYLE: MarkdownStyleInternal = Object.freeze({
     borderRadius: 6,
     cellPaddingHorizontal: 12,
     cellPaddingVertical: 8,
+    horizontalOverflow: 0,
   },
   math: {
     fontSize: 20,

--- a/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
@@ -135,6 +135,7 @@ interface TableStyle extends BaseBlockStyle {
   borderRadius?: number;
   cellPaddingHorizontal?: number;
   cellPaddingVertical?: number;
+  horizontalOverflow?: number;
 }
 
 interface TaskListStyle {

--- a/packages/react-native-enriched-markdown/src/types/MarkdownStyleInternal.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownStyleInternal.ts
@@ -120,6 +120,7 @@ interface TableStyleInternal extends BaseBlockStyleInternal {
   borderRadius: number;
   cellPaddingHorizontal: number;
   cellPaddingVertical: number;
+  horizontalOverflow: number;
 }
 
 interface TaskListStyleInternal {


### PR DESCRIPTION
### What/Why?
When set, scrollable tables extend beyond the markdown container by the specified amount on each side, allowing wide tables to reach screen edges instead of appearing clipped. Users set the value to match their parent's horizontal padding.

- iOS: uses contentInset on the scroll view for proper alignment
- Android: uses scroll view padding with clipToPadding
- macOS: uses NSScrollView contentInsets
- Web: not supported — React Native Web sets `overflow: hidden` on all Views, preventing children from extending beyond parent bounds. Desktop browsers already handle horizontal table scrolling well via `overflowX: auto`.
- Negative values are clamped to 0
- No effect on tables that fit within the container

### Testing
<!-- How to test changed code? What testing has been done? -->


#### Screenshots

| iOS before | iOS after |
| - | - |
| <video src="https://github.com/user-attachments/assets/f3aa5863-c770-4eb8-a3aa-37098bfceb98" width=300 /> | <video src="https://github.com/user-attachments/assets/f74d1c53-9430-4ccc-80ee-a206917417d2" width=300 /> |

| Android before | Android after |
| - | - |
| <video src="https://github.com/user-attachments/assets/0fa27881-d487-4fcb-b6cb-ac373edd2a18" width=300 /> | <video src="https://github.com/user-attachments/assets/2b6daaa1-6bc6-4f82-89ac-45f8e46d3912" width=300 /> |

Closes: #378 

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)