### PR TITLE
chore: use macos-latest-xlarge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
             --dry=json | jq -r '.tasks[0].cache.status')
 
           if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=0" >> $GITHUB_ENV
+            echo "turbo_cache_hit=1" >> $GITHUB_ENV
           fi
 
       - name: Restore cocoapods

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
   rn-build-ios:
     needs: changes
     if: needs.changes.outputs.react-native == 'true'
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge
     env:
       TURBO_CACHE_DIR: .turbo/ios
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
             --dry=json | jq -r '.tasks[0].cache.status')
 
           if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> $GITHUB_ENV
+            echo "turbo_cache_hit=0" >> $GITHUB_ENV
           fi
 
       - name: Restore cocoapods

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     s.private_header_files = "ios/**/*.h", "cpp/**/*.{h,hpp}"
     s.source_files = "ios/**/*.{h,m,mm,cpp,swift}", "cpp/md4c/*.{c,h}", "cpp/parser/*.{hpp,cpp}"
   end
-# TEMPORARY COMMENT TO TRIGGER IOS BUILD
+
   # To disable LaTeX math rendering (RaTeX, iOS only), add ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] = '0' to your Podfile.
   # When math is enabled, consumers must use `use_frameworks! :linkage => :dynamic` (required for SPM interop).
   enable_math = ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] != '0'

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     s.private_header_files = "ios/**/*.h", "cpp/**/*.{h,hpp}"
     s.source_files = "ios/**/*.{h,m,mm,cpp,swift}", "cpp/md4c/*.{c,h}", "cpp/parser/*.{hpp,cpp}"
   end
-
+# TEMPORARY COMMENT TO TRIGGER IOS BUILD
   # To disable LaTeX math rendering (RaTeX, iOS only), add ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] = '0' to your Podfile.
   # When math is enabled, consumers must use `use_frameworks! :linkage => :dynamic` (required for SPM interop).
   enable_math = ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] != '0'


### PR DESCRIPTION
### What/Why?

use macos-latest-xlarge
its x1.6 more expensive, but usually finishes tasks x2 faster

> additional 2 commits were introduced to trigger the full uncached build on runners, please remove those "temp commit" and its revert from commit message

### Benchmark

> Note: RNRepo times were calculated with one run, default times are avg of few latest runs from [actions/workflows/ci.yml](https://github.com/software-mansion/react-native-enriched-markdown/actions/workflows/ci.yml) (just building the app times, not whole job. Also not ones that were cached with turbo)

| Default | XLarge | Diff |
|------|---------|------|
| 19:21min | 5:56min | 13:25min (-70%) |

it was more than 3x faster

Sources:
- IOS this pr
  - https://github.com/software-mansion/react-native-enriched-markdown/actions/runs/29488600517?pr=543
- iOS before
  - https://github.com/software-mansion/react-native-enriched-markdown/actions/runs/29428337753
  - https://github.com/software-mansion/react-native-enriched-markdown/actions/runs/29427009925
  - https://github.com/software-mansion/react-native-enriched-markdown/actions/runs/29418636847

