### PR TITLE
feat: custom image request headers

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -288,6 +288,29 @@ Controls how spoiler text (`||hidden text||`) is displayed before being revealed
 
 Both modes support tap-to-reveal.
 
+### `imageRequestHeaders`
+
+HTTP headers attached to remote image requests, e.g. a `Referer` required by CDN hotlink protection or an `Authorization` token.
+
+| Type                     | Default Value | Platform |
+| ------------------------ | ------------- | -------- |
+| `Record<string, string>` | -             | Both     |
+
+Headers participate in image cache identity, so the same URL requested with different headers is fetched and cached separately — see [Image Caching](./IMAGE_CACHING.md).
+
+> **Web**: Not supported — browsers don't allow custom headers on `<img>` requests.
+
+**Example:**
+
+```tsx
+<EnrichedMarkdownText
+  markdown={markdown}
+  imageRequestHeaders={{
+    Referer: 'https://example.com',
+  }}
+/>
+```
+
 ### `contextMenuItems`
 
 Custom items to add to the text selection context menu. Items appear before the system actions (Copy, etc.). Items with `visible: false` are hidden from the menu.

--- a/docs/IMAGE_CACHING.md
+++ b/docs/IMAGE_CACHING.md
@@ -16,6 +16,12 @@ The library uses a three-tier caching strategy on both platforms:
 - **Processed cache** stores scaled and clipped variants keyed by URL + dimensions + border radius, so repeated layouts with the same geometry skip all image processing.
 - **Disk cache** persists raw HTTP responses across app launches, respecting standard HTTP cache headers.
 
+## Request Headers
+
+When `imageRequestHeaders` is set, the headers become part of the cache identity for both memory tiers and for request deduplication: the same URL requested with different headers is fetched and cached separately, and changing the prop re-fetches the images.
+
+One caveat: the disk cache is managed by the HTTP stack (OkHttp / `NSURLCache`) and keys responses by URL alone. A response fetched with one set of headers can be served from disk for a request with different headers, subject to standard HTTP caching semantics (`Cache-Control`, `Vary`).
+
 ## Request Deduplication
 
 When multiple components request the same image URL simultaneously (e.g. during a re-render), only one network request is made. All pending callbacks are coalesced and dispatched together once the download completes.

--- a/packages/android-enriched-markdown/README.md
+++ b/packages/android-enriched-markdown/README.md
@@ -134,6 +134,7 @@ fun EnrichedMarkdownText(
   modifier: Modifier = Modifier,
   style: MarkdownStyle = MarkdownTheme.style,
   selectable: Boolean = true,
+  imageRequestHeaders: Map<String, String> = emptyMap(),
   onLinkPress: ((String) -> Unit)? = null,
   onLinkLongPress: ((String) -> Unit)? = null,
 )
@@ -144,6 +145,7 @@ fun EnrichedMarkdownText(
 | `markdown` | Markdown source string |
 | `style` | Per-instance style override |
 | `selectable` | Enable text selection |
+| `imageRequestHeaders` | HTTP headers attached to remote image requests (e.g. `Referer`) |
 | `onLinkPress` | Called when a link is tapped |
 | `onLinkLongPress` | Called when a link is long-pressed |
 

--- a/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/EnrichedMarkdownText.kt
+++ b/packages/android-enriched-markdown/compose/src/main/java/com/swmansion/enriched/markdown/compose/EnrichedMarkdownText.kt
@@ -31,6 +31,7 @@ fun EnrichedMarkdownText(
   modifier: Modifier = Modifier,
   style: MarkdownStyle = MarkdownTheme.style,
   selectable: Boolean = true,
+  imageRequestHeaders: Map<String, String> = emptyMap(),
   onLinkPress: ((String) -> Unit)? = null,
   onLinkLongPress: ((String) -> Unit)? = null,
 ) {
@@ -63,6 +64,7 @@ fun EnrichedMarkdownText(
         setOnLinkLongPressCallback { url -> onLinkLongPressState?.invoke(url) }
         setMarkdownStyle(styleConfig)
         setIsSelectable(selectable)
+        setImageRequestHeaders(imageRequestHeaders)
         setMarkdownContent(markdown)
       }
     },
@@ -71,6 +73,7 @@ fun EnrichedMarkdownText(
       view.setOnLinkLongPressCallback { url -> onLinkLongPressState?.invoke(url) }
       view.setMarkdownStyle(styleConfig)
       view.setIsSelectable(selectable)
+      view.setImageRequestHeaders(imageRequestHeaders)
       view.setMarkdownContent(markdown)
     },
     onReset = { view -> view.prepareForViewReuse() },

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -47,6 +47,7 @@ class EnrichedMarkdownText
       private set
 
     private var pendingStyledText: CharSequence? = null
+    private var imageRequestHeaders: Map<String, String> = emptyMap()
     private var selectionColor: Int? = null
     private var selectionHandleColor: Int? = null
     private var isSelectable = true
@@ -73,6 +74,18 @@ class EnrichedMarkdownText
       if (markdownStyle == style) return
       markdownStyle = style
       updateJustificationMode(style)
+      scheduleRenderIfNeeded()
+    }
+
+    /**
+     * Sets HTTP headers attached to remote image requests, e.g. a `Referer`
+     * required by CDN hotlink protection or an `Authorization` token.
+     * Headers participate in image cache identity, so the same URL requested
+     * with different headers is fetched and cached separately.
+     */
+    fun setImageRequestHeaders(headers: Map<String, String>) {
+      if (imageRequestHeaders == headers) return
+      imageRequestHeaders = headers
       scheduleRenderIfNeeded()
     }
 
@@ -185,7 +198,7 @@ class EnrichedMarkdownText
 
           if (renderId != currentRenderId) return@submit
 
-          renderer.configure(style, context)
+          renderer.configure(style, context, imageRequestHeaders)
           val styledText =
             renderer.renderDocument(
               ast,

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/NodeRenderer.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/NodeRenderer.kt
@@ -19,6 +19,7 @@ interface NodeRenderer {
 
 data class RendererConfig(
   val style: StyleConfig,
+  val imageRequestHeaders: Map<String, String> = emptyMap(),
 )
 
 class RendererFactory(
@@ -68,6 +69,7 @@ class RendererFactory(
       styleConfig = config.style,
       isInline = isInline,
       altText = altText,
+      requestHeaders = config.imageRequestHeaders,
     )
 
   private val textRenderer = TextRenderer()

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/Renderer.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/Renderer.kt
@@ -12,6 +12,7 @@ class Renderer {
   private var cachedFactory: RendererFactory? = null
   private var cachedStyle: StyleConfig? = null
   private var cachedContext: Context? = null
+  private var cachedImageRequestHeaders: Map<String, String> = emptyMap()
 
   private val collectedImageSpans = mutableListOf<ImageSpan>()
   private var lastElementMarginBottom: Float = 0f
@@ -19,14 +20,16 @@ class Renderer {
   fun configure(
     style: StyleConfig,
     context: Context,
+    imageRequestHeaders: Map<String, String> = emptyMap(),
   ) {
-    if (cachedStyle === style && cachedContext === context) return
+    if (cachedStyle === style && cachedContext === context && cachedImageRequestHeaders == imageRequestHeaders) return
 
     cachedStyle = style
     cachedContext = context
+    cachedImageRequestHeaders = imageRequestHeaders
     cachedFactory =
       RendererFactory(
-        RendererConfig(style),
+        RendererConfig(style, imageRequestHeaders),
         context,
       ) { span -> reportImageSpan(span) }
   }

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/ImageSpan.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/ImageSpan.kt
@@ -31,6 +31,7 @@ class ImageSpan(
   styleConfig: StyleConfig,
   val isInline: Boolean = false,
   val altText: String = "",
+  private val requestHeaders: Map<String, String> = emptyMap(),
 ) : AndroidImageSpan(
     Color.TRANSPARENT.toDrawable(),
     imageUrl,
@@ -40,6 +41,7 @@ class ImageSpan(
   private var loadedDrawable: Drawable? = null
   private val height: Int = if (isInline) styleConfig.inlineImageStyle.size.toInt() else styleConfig.imageStyle.height.toInt()
   private val borderRadiusPx: Int = (styleConfig.imageStyle.borderRadius * context.resources.displayMetrics.density).toInt()
+  private val requestKey: String = ImageCache.requestKey(imageUrl, requestHeaders)
 
   private var cachedWidth: Int = 0
   private var viewRef: WeakReference<TextView>? = null
@@ -51,7 +53,7 @@ class ImageSpan(
 
   private fun loadImage() {
     if (imageUrl.startsWith("http")) {
-      ImageDownloader.download(context, imageUrl) { bitmap ->
+      ImageDownloader.download(context, imageUrl, requestHeaders) { bitmap ->
         if (bitmap != null) {
           sourceDrawable = bitmap.toDrawable(context.resources)
           wrapAndAssignDrawable()
@@ -83,7 +85,7 @@ class ImageSpan(
         available.coerceAtLeast(0)
       }
 
-    val cachedBitmap = ImageCache.getProcessed(imageUrl, targetWidth, height, borderRadiusPx)
+    val cachedBitmap = ImageCache.getProcessed(requestKey, targetWidth, height, borderRadiusPx)
     if (cachedBitmap != null) {
       loadedDrawable =
         cachedBitmap.toDrawable(context.resources).apply {
@@ -97,7 +99,7 @@ class ImageSpan(
           targetHeight = height,
           borderRadius = borderRadiusPx,
           isBlockImage = !isInline,
-          cacheKey = CacheKey(imageUrl, targetWidth, height, borderRadiusPx),
+          cacheKey = CacheKey(requestKey, targetWidth, height, borderRadiusPx),
         )
     }
     requestReflow()

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageCache.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageCache.kt
@@ -10,6 +10,21 @@ object ImageCache {
   private val originalCache = bitmapLruCache(ORIGINAL_CACHE_SIZE)
   private val processedCache = bitmapLruCache(PROCESSED_CACHE_SIZE)
 
+  /**
+   * Cache identity for a remote image request. Returns the URL itself when no
+   * headers are set; otherwise appends the sorted header pairs, so the same
+   * URL fetched with different headers is cached and deduplicated separately.
+   */
+  fun requestKey(
+    url: String,
+    headers: Map<String, String>,
+  ): String {
+    if (headers.isEmpty()) return url
+    return headers.entries
+      .sortedBy { it.key }
+      .joinToString(separator = "", prefix = url) { "|${it.key}:${it.value}" }
+  }
+
   fun getOriginal(url: String): Bitmap? = originalCache.get(url)
 
   fun putOriginal(

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageCache.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageCache.kt
@@ -2,6 +2,7 @@ package com.swmansion.enriched.markdown.utils.text
 
 import android.graphics.Bitmap
 import android.util.LruCache
+import java.security.MessageDigest
 
 object ImageCache {
   private const val ORIGINAL_CACHE_SIZE = 20 * 1024 * 1024
@@ -12,17 +13,21 @@ object ImageCache {
 
   /**
    * Cache identity for a remote image request. Returns the URL itself when no
-   * headers are set; otherwise appends the sorted header pairs, so the same
-   * URL fetched with different headers is cached and deduplicated separately.
+   * headers are set; otherwise appends a SHA-256 digest of the sorted header
+   * pairs, so the same URL fetched with different headers is cached and
+   * deduplicated separately without embedding header values in the key.
    */
   fun requestKey(
     url: String,
     headers: Map<String, String>,
   ): String {
     if (headers.isEmpty()) return url
-    return headers.entries
-      .sortedBy { it.key }
-      .joinToString(separator = "", prefix = url) { "|${it.key}:${it.value}" }
+    val joined =
+      headers.entries
+        .sortedBy { it.key }
+        .joinToString(separator = "\n") { "${it.key}:${it.value}" }
+    val digest = MessageDigest.getInstance("SHA-256").digest(joined.toByteArray())
+    return url + "|" + digest.joinToString(separator = "") { "%02x".format(it) }
   }
 
   fun getOriginal(url: String): Bitmap? = originalCache.get(url)

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageDownloader.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageDownloader.kt
@@ -50,23 +50,31 @@ object ImageDownloader {
   fun download(
     context: Context,
     url: String,
+    headers: Map<String, String> = emptyMap(),
     callback: (Bitmap?) -> Unit,
   ) {
-    ImageCache.getOriginal(url)?.let {
+    val requestKey = ImageCache.requestKey(url, headers)
+
+    ImageCache.getOriginal(requestKey)?.let {
       callback(it)
       return
     }
 
     synchronized(inFlight) {
-      val existing = inFlight[url]
+      val existing = inFlight[requestKey]
       if (existing != null) {
         existing.add(callback)
         return
       }
-      inFlight[url] = mutableListOf(callback)
+      inFlight[requestKey] = mutableListOf(callback)
     }
 
-    val request = Request.Builder().url(url).build()
+    val request =
+      Request
+        .Builder()
+        .url(url)
+        .apply { headers.forEach { (name, value) -> addHeader(name, value) } }
+        .build()
     getClient(context).newCall(request).enqueue(
       object : Callback {
         override fun onResponse(
@@ -87,8 +95,8 @@ object ImageDownloader {
               }
             }
 
-          bitmap?.let { ImageCache.putOriginal(url, it) }
-          dispatchCallbacks(url, bitmap)
+          bitmap?.let { ImageCache.putOriginal(requestKey, it) }
+          dispatchCallbacks(requestKey, bitmap)
         }
 
         override fun onFailure(
@@ -96,7 +104,7 @@ object ImageDownloader {
           e: IOException,
         ) {
           Log.e(TAG, "Failed to download image: $url", e)
-          dispatchCallbacks(url, null)
+          dispatchCallbacks(requestKey, null)
         }
       },
     )
@@ -145,10 +153,10 @@ object ImageDownloader {
   }
 
   private fun dispatchCallbacks(
-    url: String,
+    requestKey: String,
     bitmap: Bitmap?,
   ) {
-    val callbacks = synchronized(inFlight) { inFlight.remove(url) } ?: return
+    val callbacks = synchronized(inFlight) { inFlight.remove(requestKey) } ?: return
     mainHandler.post {
       callbacks.forEach { it(bitmap) }
     }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -79,6 +79,7 @@ class EnrichedMarkdown
     private var allowFontScaling: Boolean = true
     private var maxFontSizeMultiplier: Float = 0f
     private var allowTrailingMargin: Boolean = false
+    private var imageRequestHeaders: Map<String, String> = emptyMap()
     private var selectable: Boolean = true
     private var selectionColor: Int? = null
     private var selectionHandleColor: Int? = null
@@ -109,10 +110,19 @@ class EnrichedMarkdown
     fun setMarkdownStyle(style: ReadableMap?) {
       markdownStyleMap = style
       val newConfig = style?.let { StyleConfig(it, context, allowFontScaling, maxFontSizeMultiplier) }
+      newConfig?.imageRequestHeaders = imageRequestHeaders
       if (markdownStyle == newConfig) return
       markdownStyle = newConfig
       dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
       dirtyFlags += DirtyFlag.FORCE_HEIGHT
+      renderPending = true
+    }
+
+    fun setImageRequestHeaders(headers: Map<String, String>) {
+      if (imageRequestHeaders == headers) return
+      imageRequestHeaders = headers
+      markdownStyle?.imageRequestHeaders = headers
+      dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
       renderPending = true
     }
 
@@ -292,7 +302,10 @@ class EnrichedMarkdown
 
     private fun recreateStyleConfig() {
       markdownStyleMap?.let {
-        markdownStyle = StyleConfig(it, context, allowFontScaling, maxFontSizeMultiplier)
+        markdownStyle =
+          StyleConfig(it, context, allowFontScaling, maxFontSizeMultiplier).also { config ->
+            config.imageRequestHeaders = imageRequestHeaders
+          }
       }
     }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -20,6 +20,7 @@ import com.swmansion.enriched.markdown.utils.common.emitTaskListItemPress
 import com.swmansion.enriched.markdown.utils.common.markdownEventTypeConstants
 import com.swmansion.enriched.markdown.utils.common.parseAccessibilityLabels
 import com.swmansion.enriched.markdown.utils.common.parseContextMenuItems
+import com.swmansion.enriched.markdown.utils.common.parseImageRequestHeaders
 import com.swmansion.enriched.markdown.utils.common.parseMd4cFlags
 import com.swmansion.enriched.markdown.utils.common.parseSelectionMenuConfig
 import com.swmansion.enriched.markdown.utils.text.interaction.TaskListToggleUtils
@@ -213,6 +214,15 @@ class EnrichedMarkdownManager :
   ) {
     if (view == null) return
     view.setContextMenuItems(parseContextMenuItems(value))
+  }
+
+  @ReactProp(name = "imageRequestHeaders")
+  override fun setImageRequestHeaders(
+    view: EnrichedMarkdown?,
+    value: ReadableArray?,
+  ) {
+    if (view == null) return
+    view.setImageRequestHeaders(parseImageRequestHeaders(value))
   }
 
   @ReactProp(name = "selectionMenuConfig")

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -78,6 +78,7 @@ class EnrichedMarkdownText
     private var allowFontScaling: Boolean = true
     private var maxFontSizeMultiplier: Float = 0f
     private var allowTrailingMargin: Boolean = false
+    private var imageRequestHeaders: Map<String, String> = emptyMap()
 
     private var streamingAnimation: Boolean = false
     private var previousTextLength: Int = 0
@@ -116,10 +117,18 @@ class EnrichedMarkdownText
       // Register font scaling settings when style is set (view should have ID by now)
       updateMeasurementStoreFontScaling()
       val newStyle = style?.let { StyleConfig(it, context, allowFontScaling, maxFontSizeMultiplier) }
+      newStyle?.imageRequestHeaders = imageRequestHeaders
       if (markdownStyle == newStyle) return
       markdownStyle = newStyle
       updateJustificationMode(newStyle)
       scheduleRender()
+    }
+
+    fun setImageRequestHeaders(headers: Map<String, String>) {
+      if (imageRequestHeaders == headers) return
+      imageRequestHeaders = headers
+      markdownStyle?.imageRequestHeaders = headers
+      scheduleRenderIfNeeded()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -189,7 +198,10 @@ class EnrichedMarkdownText
 
     private fun recreateStyleConfig() {
       markdownStyleMap?.let { styleMap ->
-        markdownStyle = StyleConfig(styleMap, context, allowFontScaling, maxFontSizeMultiplier)
+        markdownStyle =
+          StyleConfig(styleMap, context, allowFontScaling, maxFontSizeMultiplier).also {
+            it.imageRequestHeaders = imageRequestHeaders
+          }
         updateJustificationMode(markdownStyle)
       }
     }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -19,6 +19,7 @@ import com.swmansion.enriched.markdown.utils.common.emitTaskListItemPress
 import com.swmansion.enriched.markdown.utils.common.markdownEventTypeConstants
 import com.swmansion.enriched.markdown.utils.common.parseAccessibilityLabels
 import com.swmansion.enriched.markdown.utils.common.parseContextMenuItems
+import com.swmansion.enriched.markdown.utils.common.parseImageRequestHeaders
 import com.swmansion.enriched.markdown.utils.common.parseMd4cFlags
 import com.swmansion.enriched.markdown.utils.common.parseSelectionMenuConfig
 import com.swmansion.enriched.markdown.utils.text.interaction.TaskListTapUtils
@@ -211,6 +212,15 @@ class EnrichedMarkdownTextManager :
   ) {
     if (view == null) return
     view.setContextMenuItems(parseContextMenuItems(value))
+  }
+
+  @ReactProp(name = "imageRequestHeaders")
+  override fun setImageRequestHeaders(
+    view: EnrichedMarkdownText?,
+    value: ReadableArray?,
+  ) {
+    if (view == null) return
+    view.setImageRequestHeaders(parseImageRequestHeaders(value))
   }
 
   @ReactProp(name = "selectionMenuConfig")

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -239,6 +239,7 @@ object MeasurementStore {
     val styleMap = props.getMapOrNull("markdownStyle")
     val md4cFlagsMap = props.getMapOrNull("md4cFlags")
     val allowTrailingMargin = props.getBooleanOrDefault("allowTrailingMargin", false)
+    val imageRequestHeaders = parseImageRequestHeaders(props.getArrayOrNull("imageRequestHeaders"))
     var result = markdown.hashCode()
     result = 31 * result + (styleMap?.hashCode() ?: 0)
     result = 31 * result + (md4cFlagsMap?.hashCode() ?: 0)
@@ -246,6 +247,7 @@ object MeasurementStore {
     result = 31 * result + allowFontScaling.hashCode()
     result = 31 * result + maxFontSizeMultiplier.toBits()
     result = 31 * result + allowTrailingMargin.hashCode()
+    result = 31 * result + imageRequestHeaders.hashCode()
     return result
   }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -24,9 +24,11 @@ import com.swmansion.enriched.markdown.utils.common.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.utils.common.RenderedSegment
 import com.swmansion.enriched.markdown.utils.common.StreamingMarkdownFilter
 import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
+import com.swmansion.enriched.markdown.utils.common.getArrayOrNull
 import com.swmansion.enriched.markdown.utils.common.getBooleanOrDefault
 import com.swmansion.enriched.markdown.utils.common.getMapOrNull
 import com.swmansion.enriched.markdown.utils.common.getStringOrDefault
+import com.swmansion.enriched.markdown.utils.common.parseImageRequestHeaders
 import com.swmansion.enriched.markdown.utils.common.splitASTIntoSegments
 import com.swmansion.enriched.markdown.utils.text.extensions.replaceMathSpansWithPlaceholders
 import com.swmansion.enriched.markdown.views.TableContainerView
@@ -298,7 +300,9 @@ object MeasurementStore {
     val propsHash = computePropsHash(props, allowFontScaling, fontScale, maxFontSizeMultiplier)
 
     // 2. Render & Measure
-    val spannable = tryRenderMarkdown(markdown, styleMap, context, md4cFlags, allowFontScaling, maxFontSizeMultiplier)
+    val imageRequestHeaders = parseImageRequestHeaders(props.getArrayOrNull("imageRequestHeaders"))
+    val spannable =
+      tryRenderMarkdown(markdown, styleMap, context, md4cFlags, allowFontScaling, maxFontSizeMultiplier, imageRequestHeaders)
     spannable?.replaceMathSpansWithPlaceholders(context)
     val textToMeasure = spannable ?: markdown
     val (size, _) = measureWithLayout(width, textToMeasure, measurePaint, id)
@@ -382,6 +386,7 @@ object MeasurementStore {
           ?: return YogaMeasureOutput.make(PixelUtil.toDIPFromPixel(width), 0f)
 
       val style = StyleConfig(styleMap, context, allowFontScaling, maxFontSizeMultiplier)
+      style.imageRequestHeaders = parseImageRequestHeaders(props.getArrayOrNull("imageRequestHeaders"))
       val segments = splitASTIntoSegments(ast)
       val renderedSegments = MarkdownSegmentRenderer.render(segments, style, context, null, null)
 
@@ -496,12 +501,14 @@ object MeasurementStore {
     md4cFlags: Md4cFlags,
     allowFontScaling: Boolean,
     maxFontSizeMultiplier: Float,
+    imageRequestHeaders: Map<String, String> = emptyMap(),
   ): SpannableString? {
     if (styleMap == null) return null
 
     return try {
       val ast = Parser.shared.parseMarkdown(markdown, md4cFlags) ?: return null
       val style = StyleConfig(styleMap, context, allowFontScaling, maxFontSizeMultiplier)
+      style.imageRequestHeaders = imageRequestHeaders
       measureRenderer.configure(style, context)
       measureRenderer.renderDocument(ast, null)
     } catch (e: Exception) {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/ImageSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/ImageSpan.kt
@@ -40,6 +40,8 @@ class ImageSpan(
   private var loadedDrawable: Drawable? = null
   private val height: Int = if (isInline) styleConfig.inlineImageStyle.size.toInt() else styleConfig.imageStyle.height.toInt()
   private val borderRadiusPx: Int = (styleConfig.imageStyle.borderRadius * context.resources.displayMetrics.density).toInt()
+  private val requestHeaders: Map<String, String> = styleConfig.imageRequestHeaders
+  private val requestKey: String = ImageCache.requestKey(imageUrl, requestHeaders)
 
   private var cachedWidth: Int = 0
   private var viewRef: WeakReference<TextView>? = null
@@ -51,7 +53,7 @@ class ImageSpan(
 
   private fun loadImage() {
     if (imageUrl.startsWith("http")) {
-      ImageDownloader.download(context, imageUrl) { bitmap ->
+      ImageDownloader.download(context, imageUrl, requestHeaders) { bitmap ->
         if (bitmap != null) {
           sourceDrawable = bitmap.toDrawable(context.resources)
           wrapAndAssignDrawable()
@@ -83,7 +85,7 @@ class ImageSpan(
         available.coerceAtLeast(0)
       }
 
-    val cachedBitmap = ImageCache.getProcessed(imageUrl, targetWidth, height, borderRadiusPx)
+    val cachedBitmap = ImageCache.getProcessed(requestKey, targetWidth, height, borderRadiusPx)
     if (cachedBitmap != null) {
       loadedDrawable =
         cachedBitmap.toDrawable(context.resources).apply {
@@ -97,7 +99,7 @@ class ImageSpan(
           targetHeight = height,
           borderRadius = borderRadiusPx,
           isBlockImage = !isInline,
-          cacheKey = CacheKey(imageUrl, targetWidth, height, borderRadiusPx),
+          cacheKey = CacheKey(requestKey, targetWidth, height, borderRadiusPx),
         )
     }
     requestReflow()

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/StyleConfig.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/StyleConfig.kt
@@ -166,6 +166,8 @@ class StyleConfig(
     ImageStyle.fromReadableMap(map, styleParser)
   }
 
+  var imageRequestHeaders: Map<String, String> = emptyMap()
+
   val inlineImageStyle: InlineImageStyle by lazy {
     val map =
       requireNotNull(style.getMap("inlineImage")) {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/StyleConfig.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/StyleConfig.kt
@@ -339,7 +339,8 @@ class StyleConfig(
       spoilerStyle == other.spoilerStyle &&
       superscriptStyle == other.superscriptStyle &&
       subscriptStyle == other.subscriptStyle &&
-      highlightStyle == other.highlightStyle
+      highlightStyle == other.highlightStyle &&
+      imageRequestHeaders == other.imageRequestHeaders
   }
 
   override fun hashCode(): Int {
@@ -366,6 +367,7 @@ class StyleConfig(
     result = 31 * result + superscriptStyle.hashCode()
     result = 31 * result + subscriptStyle.hashCode()
     result = 31 * result + highlightStyle.hashCode()
+    result = 31 * result + imageRequestHeaders.hashCode()
     return result
   }
 }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MarkdownViewManagerUtils.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MarkdownViewManagerUtils.kt
@@ -92,6 +92,15 @@ fun parseMd4cFlags(flags: ReadableMap?): Md4cFlags =
 fun parseContextMenuItems(value: ReadableArray?): List<String> =
   (0 until (value?.size() ?: 0)).mapNotNull { value?.getMap(it)?.getString("text") }
 
+fun parseImageRequestHeaders(value: ReadableArray?): Map<String, String> =
+  (0 until (value?.size() ?: 0))
+    .mapNotNull { index ->
+      val header = value?.getMap(index) ?: return@mapNotNull null
+      val name = header.getString("name") ?: return@mapNotNull null
+      val headerValue = header.getString("value") ?: return@mapNotNull null
+      name to headerValue
+    }.toMap()
+
 fun parseSelectionMenuConfig(value: ReadableMap?): SelectionMenuConfig {
   if (value == null) return SelectionMenuConfig()
   return SelectionMenuConfig(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/ReadableMapExtensions.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/ReadableMapExtensions.kt
@@ -1,5 +1,6 @@
 package com.swmansion.enriched.markdown.utils.common
 
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 
 fun ReadableMap?.getBooleanOrDefault(
@@ -18,3 +19,5 @@ fun ReadableMap?.getStringOrDefault(
 ): String = if (this?.hasKey(key) == true) getString(key) ?: default else default
 
 fun ReadableMap?.getMapOrNull(key: String): ReadableMap? = if (this?.hasKey(key) == true) getMap(key) else null
+
+fun ReadableMap?.getArrayOrNull(key: String): ReadableArray? = if (this?.hasKey(key) == true) getArray(key) else null

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageCache.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageCache.kt
@@ -10,6 +10,21 @@ object ImageCache {
   private val originalCache = bitmapLruCache(ORIGINAL_CACHE_SIZE)
   private val processedCache = bitmapLruCache(PROCESSED_CACHE_SIZE)
 
+  /**
+   * Cache identity for a remote image request. Returns the URL itself when no
+   * headers are set; otherwise appends the sorted header pairs, so the same
+   * URL fetched with different headers is cached and deduplicated separately.
+   */
+  fun requestKey(
+    url: String,
+    headers: Map<String, String>,
+  ): String {
+    if (headers.isEmpty()) return url
+    return headers.entries
+      .sortedBy { it.key }
+      .joinToString(separator = "", prefix = url) { "|${it.key}:${it.value}" }
+  }
+
   fun getOriginal(url: String): Bitmap? = originalCache.get(url)
 
   fun putOriginal(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageCache.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageCache.kt
@@ -2,6 +2,7 @@ package com.swmansion.enriched.markdown.utils.text
 
 import android.graphics.Bitmap
 import android.util.LruCache
+import java.security.MessageDigest
 
 object ImageCache {
   private const val ORIGINAL_CACHE_SIZE = 20 * 1024 * 1024
@@ -12,17 +13,21 @@ object ImageCache {
 
   /**
    * Cache identity for a remote image request. Returns the URL itself when no
-   * headers are set; otherwise appends the sorted header pairs, so the same
-   * URL fetched with different headers is cached and deduplicated separately.
+   * headers are set; otherwise appends a SHA-256 digest of the sorted header
+   * pairs, so the same URL fetched with different headers is cached and
+   * deduplicated separately without embedding header values in the key.
    */
   fun requestKey(
     url: String,
     headers: Map<String, String>,
   ): String {
     if (headers.isEmpty()) return url
-    return headers.entries
-      .sortedBy { it.key }
-      .joinToString(separator = "", prefix = url) { "|${it.key}:${it.value}" }
+    val joined =
+      headers.entries
+        .sortedBy { it.key }
+        .joinToString(separator = "\n") { "${it.key}:${it.value}" }
+    val digest = MessageDigest.getInstance("SHA-256").digest(joined.toByteArray())
+    return url + "|" + digest.joinToString(separator = "") { "%02x".format(it) }
   }
 
   fun getOriginal(url: String): Bitmap? = originalCache.get(url)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageDownloader.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/ImageDownloader.kt
@@ -50,23 +50,31 @@ object ImageDownloader {
   fun download(
     context: Context,
     url: String,
+    headers: Map<String, String> = emptyMap(),
     callback: (Bitmap?) -> Unit,
   ) {
-    ImageCache.getOriginal(url)?.let {
+    val requestKey = ImageCache.requestKey(url, headers)
+
+    ImageCache.getOriginal(requestKey)?.let {
       callback(it)
       return
     }
 
     synchronized(inFlight) {
-      val existing = inFlight[url]
+      val existing = inFlight[requestKey]
       if (existing != null) {
         existing.add(callback)
         return
       }
-      inFlight[url] = mutableListOf(callback)
+      inFlight[requestKey] = mutableListOf(callback)
     }
 
-    val request = Request.Builder().url(url).build()
+    val request =
+      Request
+        .Builder()
+        .url(url)
+        .apply { headers.forEach { (name, value) -> addHeader(name, value) } }
+        .build()
     getClient(context).newCall(request).enqueue(
       object : Callback {
         override fun onResponse(
@@ -87,8 +95,8 @@ object ImageDownloader {
               }
             }
 
-          bitmap?.let { ImageCache.putOriginal(url, it) }
-          dispatchCallbacks(url, bitmap)
+          bitmap?.let { ImageCache.putOriginal(requestKey, it) }
+          dispatchCallbacks(requestKey, bitmap)
         }
 
         override fun onFailure(
@@ -96,7 +104,7 @@ object ImageDownloader {
           e: IOException,
         ) {
           Log.e(TAG, "Failed to download image: $url", e)
-          dispatchCallbacks(url, null)
+          dispatchCallbacks(requestKey, null)
         }
       },
     )
@@ -145,10 +153,10 @@ object ImageDownloader {
   }
 
   private fun dispatchCallbacks(
-    url: String,
+    requestKey: String,
     bitmap: Bitmap?,
   ) {
-    val callbacks = synchronized(inFlight) { inFlight.remove(url) } ?: return
+    val callbacks = synchronized(inFlight) { inFlight.remove(requestKey) } ?: return
     mainHandler.post {
       callbacks.forEach { it(bitmap) }
     }

--- a/packages/react-native-enriched-markdown/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
+++ b/packages/react-native-enriched-markdown/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
@@ -15,6 +15,12 @@ inline folly::dynamic toDynamic(const EnrichedMarkdownTextProps &props) {
   serializedProps["allowTrailingMargin"] = props.allowTrailingMargin;
   serializedProps["streamingAnimation"] = props.streamingAnimation;
 
+  folly::dynamic imageRequestHeaders = folly::dynamic::array();
+  for (const auto &header : props.imageRequestHeaders) {
+    imageRequestHeaders.push_back(toDynamic(header));
+  }
+  serializedProps["imageRequestHeaders"] = std::move(imageRequestHeaders);
+
   return serializedProps;
 }
 
@@ -25,6 +31,12 @@ inline folly::dynamic toDynamic(const EnrichedMarkdownProps &props) {
   serializedProps["md4cFlags"] = toDynamic(props.md4cFlags);
   serializedProps["allowTrailingMargin"] = props.allowTrailingMargin;
   serializedProps["streamingAnimation"] = props.streamingAnimation;
+
+  folly::dynamic imageRequestHeaders = folly::dynamic::array();
+  for (const auto &header : props.imageRequestHeaders) {
+    imageRequestHeaders.push_back(toDynamic(header));
+  }
+  serializedProps["imageRequestHeaders"] = std::move(imageRequestHeaders);
 
   return serializedProps;
 }

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -10,6 +10,7 @@
 #import "ENRMTextViewSetup.h"
 #import "ENRMUIKit.h"
 #import "EditMenuUtils.h"
+#import "ImageRequestHeaderUtils.h"
 
 #import "ENRMFeatureFlags.h"
 
@@ -746,6 +747,15 @@ static char kENRMSegmentFadeAnimatorKey;
   if (applyMarkdownStyleToConfig(_config, newViewProps.markdownStyle, oldViewProps.markdownStyle)) {
     [ENRMImageAttachment clearAttachmentRegistry];
     _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
+    if (!markdownChanged) {
+      _dirtyFlags |= ENRMDirtyRecreateSegments;
+    }
+  }
+
+  if (ENRMImageRequestHeadersChanged(oldViewProps.imageRequestHeaders, newViewProps.imageRequestHeaders)) {
+    [_config setImageRequestHeaders:ENRMImageRequestHeadersFromProps(newViewProps.imageRequestHeaders)];
+    [ENRMImageAttachment clearAttachmentRegistry];
+    _dirtyFlags |= ENRMDirtyRender;
     if (!markdownChanged) {
       _dirtyFlags |= ENRMDirtyRecreateSegments;
     }

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -754,7 +754,6 @@ static char kENRMSegmentFadeAnimatorKey;
 
   if (ENRMImageRequestHeadersChanged(oldViewProps.imageRequestHeaders, newViewProps.imageRequestHeaders)) {
     [_config setImageRequestHeaders:ENRMImageRequestHeadersFromProps(newViewProps.imageRequestHeaders)];
-    [ENRMImageAttachment clearAttachmentRegistry];
     _dirtyFlags |= ENRMDirtyRender;
     if (!markdownChanged) {
       _dirtyFlags |= ENRMDirtyRecreateSegments;

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -462,7 +462,6 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
 
   if (ENRMImageRequestHeadersChanged(oldViewProps.imageRequestHeaders, newViewProps.imageRequestHeaders)) {
     [_config setImageRequestHeaders:ENRMImageRequestHeadersFromProps(newViewProps.imageRequestHeaders)];
-    [ENRMImageAttachment clearAttachmentRegistry];
     _dirtyFlags |= ENRMDirtyRender;
   }
 

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -17,6 +17,7 @@
 #import "FontScaleObserver.h"
 #import "FontUtils.h"
 #import "HeightUpdateUtils.h"
+#import "ImageRequestHeaderUtils.h"
 #import "LinkTapUtils.h"
 #import "MarkdownASTNode.h"
 #import "MarkdownAccessibilityElementBuilder.h"
@@ -456,6 +457,12 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   if (applyMarkdownStyleToConfig(_config, newViewProps.markdownStyle, oldViewProps.markdownStyle)) {
     [ENRMImageAttachment clearAttachmentRegistry];
     _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
+  }
+
+  if (ENRMImageRequestHeadersChanged(oldViewProps.imageRequestHeaders, newViewProps.imageRequestHeaders)) {
+    [_config setImageRequestHeaders:ENRMImageRequestHeadersFromProps(newViewProps.imageRequestHeaders)];
+    [ENRMImageAttachment clearAttachmentRegistry];
     _dirtyFlags |= ENRMDirtyRender;
   }
 

--- a/packages/react-native-enriched-markdown/ios/attachments/ENRMImageAttachment.m
+++ b/packages/react-native-enriched-markdown/ios/attachments/ENRMImageAttachment.m
@@ -22,6 +22,8 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
 @interface ENRMImageAttachment ()
 
 @property (nonatomic, copy) NSString *imageURL;
+@property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *requestHeaders;
+@property (nonatomic, copy) NSString *cacheKey;
 @property (nonatomic, assign) BOOL isInline;
 @property (nonatomic, assign) CGFloat cachedHeight;
 @property (nonatomic, assign) CGFloat cachedBorderRadius;
@@ -66,7 +68,8 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
 
 + (instancetype)attachmentForURL:(NSString *)imageURL config:(StyleConfig *)config isInline:(BOOL)isInline
 {
-  NSString *key = [NSString stringWithFormat:@"%@_%d", imageURL, isInline];
+  NSString *key =
+      [NSString stringWithFormat:@"%@_%d", ENRMImageCacheKey(imageURL, [config imageRequestHeaders]), isInline];
   ENRMImageAttachment *existing = [[self attachmentRegistry] objectForKey:key];
   if (existing && existing.loadedImage) {
     return existing;
@@ -86,6 +89,8 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
   self = [super init];
   if (self) {
     _imageURL = imageURL;
+    _requestHeaders = [[config imageRequestHeaders] copy];
+    _cacheKey = ENRMImageCacheKey(imageURL, _requestHeaders);
     _isInline = isInline;
 
     _cachedHeight = isInline ? [config inlineImageSize] : [config imageHeight];
@@ -162,7 +167,7 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
   if (targetWidth <= 0)
     return;
 
-  NSString *processedKey = CACHE_KEY_PROCESSED(self.imageURL, targetWidth, self.cachedHeight, self.cachedBorderRadius);
+  NSString *processedKey = CACHE_KEY_PROCESSED(self.cacheKey, targetWidth, self.cachedHeight, self.cachedBorderRadius);
 
   if ([processedKey isEqualToString:self.lastProcessedKey])
     return;
@@ -251,6 +256,7 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
 
   __weak typeof(self) weakSelf = self;
   [[ENRMImageDownloader shared] downloadURL:self.imageURL
+                                    headers:self.requestHeaders
                                  completion:^(RCTUIImage *image) { [weakSelf handleLoadedImage:image]; }];
 }
 

--- a/packages/react-native-enriched-markdown/ios/styles/StyleConfig.h
+++ b/packages/react-native-enriched-markdown/ios/styles/StyleConfig.h
@@ -214,6 +214,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setImageMarginTop:(CGFloat)newValue;
 - (CGFloat)imageMarginBottom;
 - (void)setImageMarginBottom:(CGFloat)newValue;
+- (nullable NSDictionary<NSString *, NSString *> *)imageRequestHeaders;
+- (void)setImageRequestHeaders:(nullable NSDictionary<NSString *, NSString *> *)newValue;
 // Inline image properties
 - (CGFloat)inlineImageSize;
 - (void)setInlineImageSize:(CGFloat)newValue;

--- a/packages/react-native-enriched-markdown/ios/styles/StyleConfig.mm
+++ b/packages/react-native-enriched-markdown/ios/styles/StyleConfig.mm
@@ -137,6 +137,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   CGFloat _imageBorderRadius;
   CGFloat _imageMarginTop;
   CGFloat _imageMarginBottom;
+  NSDictionary<NSString *, NSString *> *_imageRequestHeaders;
   // Inline image properties
   CGFloat _inlineImageSize;
   // Blockquote properties
@@ -409,6 +410,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   copy->_imageBorderRadius = _imageBorderRadius;
   copy->_imageMarginTop = _imageMarginTop;
   copy->_imageMarginBottom = _imageMarginBottom;
+  copy->_imageRequestHeaders = [_imageRequestHeaders copy];
   copy->_inlineImageSize = _inlineImageSize;
   copy->_blockquoteFontSize = _blockquoteFontSize;
   copy->_blockquoteFontFamily = [_blockquoteFontFamily copy];
@@ -1531,6 +1533,16 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
 - (void)setImageMarginBottom:(CGFloat)newValue
 {
   _imageMarginBottom = newValue;
+}
+
+- (NSDictionary<NSString *, NSString *> *)imageRequestHeaders
+{
+  return _imageRequestHeaders;
+}
+
+- (void)setImageRequestHeaders:(NSDictionary<NSString *, NSString *> *)newValue
+{
+  _imageRequestHeaders = [newValue copy];
 }
 
 - (CGFloat)inlineImageSize

--- a/packages/react-native-enriched-markdown/ios/utils/ENRMImageDownloader.h
+++ b/packages/react-native-enriched-markdown/ios/utils/ENRMImageDownloader.h
@@ -5,11 +5,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^ENRMImageDownloadCompletion)(RCTUIImage *_Nullable image);
 
+/**
+ * Cache identity for a remote image request. Returns the URL itself when no
+ * headers are set; otherwise appends a signature built from the sorted
+ * header pairs, so the same URL fetched with different headers is cached
+ * and deduplicated separately.
+ */
+NSString *ENRMImageCacheKey(NSString *url, NSDictionary<NSString *, NSString *> *_Nullable headers);
+
 @interface ENRMImageDownloader : NSObject
 
 + (instancetype)shared;
 
-- (void)downloadURL:(NSString *)url completion:(ENRMImageDownloadCompletion)completion;
+- (void)downloadURL:(NSString *)url
+            headers:(nullable NSDictionary<NSString *, NSString *> *)headers
+         completion:(ENRMImageDownloadCompletion)completion;
 
 @end
 

--- a/packages/react-native-enriched-markdown/ios/utils/ENRMImageDownloader.h
+++ b/packages/react-native-enriched-markdown/ios/utils/ENRMImageDownloader.h
@@ -7,9 +7,9 @@ typedef void (^ENRMImageDownloadCompletion)(RCTUIImage *_Nullable image);
 
 /**
  * Cache identity for a remote image request. Returns the URL itself when no
- * headers are set; otherwise appends a signature built from the sorted
- * header pairs, so the same URL fetched with different headers is cached
- * and deduplicated separately.
+ * headers are set; otherwise appends a SHA-256 digest of the sorted header
+ * pairs, so the same URL fetched with different headers is cached and
+ * deduplicated separately without embedding header values in the key.
  */
 NSString *ENRMImageCacheKey(NSString *url, NSDictionary<NSString *, NSString *> *_Nullable headers);
 

--- a/packages/react-native-enriched-markdown/ios/utils/ENRMImageDownloader.m
+++ b/packages/react-native-enriched-markdown/ios/utils/ENRMImageDownloader.m
@@ -1,5 +1,6 @@
 #import "ENRMImageDownloader.h"
 #import "ENRMImageAttachment.h"
+#import <CommonCrypto/CommonDigest.h>
 #include <TargetConditionals.h>
 
 static const NSUInteger kDiskCacheMemoryCapacity = 10 * 1024 * 1024;
@@ -19,11 +20,18 @@ NSString *ENRMImageCacheKey(NSString *url, NSDictionary<NSString *, NSString *> 
     return url;
   }
   NSArray<NSString *> *names = [headers.allKeys sortedArrayUsingSelector:@selector(compare:)];
-  NSMutableString *key = [NSMutableString stringWithString:url];
+  NSMutableString *joined = [NSMutableString string];
   for (NSString *name in names) {
-    [key appendFormat:@"|%@:%@", name, headers[name]];
+    [joined appendFormat:@"%@:%@\n", name, headers[name]];
   }
-  return [key copy];
+  NSData *data = [joined dataUsingEncoding:NSUTF8StringEncoding];
+  unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
+  NSMutableString *hash = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+  for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+    [hash appendFormat:@"%02x", digest[i]];
+  }
+  return [NSString stringWithFormat:@"%@|%@", url, hash];
 }
 
 @implementation ENRMImageDownloader {

--- a/packages/react-native-enriched-markdown/ios/utils/ENRMImageDownloader.m
+++ b/packages/react-native-enriched-markdown/ios/utils/ENRMImageDownloader.m
@@ -13,6 +13,19 @@ static inline NSUInteger ENRMImageByteCost(RCTUIImage *image)
   return CGImageGetBytesPerRow(cgImage) * CGImageGetHeight(cgImage);
 }
 
+NSString *ENRMImageCacheKey(NSString *url, NSDictionary<NSString *, NSString *> *headers)
+{
+  if (headers.count == 0) {
+    return url;
+  }
+  NSArray<NSString *> *names = [headers.allKeys sortedArrayUsingSelector:@selector(compare:)];
+  NSMutableString *key = [NSMutableString stringWithString:url];
+  for (NSString *name in names) {
+    [key appendFormat:@"|%@:%@", name, headers[name]];
+  }
+  return [key copy];
+}
+
 @implementation ENRMImageDownloader {
   NSURLSession *_session;
   NSMutableDictionary<NSString *, NSMutableArray<ENRMImageDownloadCompletion> *> *_inFlightRequests;
@@ -43,56 +56,67 @@ static inline NSUInteger ENRMImageByteCost(RCTUIImage *image)
   return self;
 }
 
-- (void)downloadURL:(NSString *)url completion:(ENRMImageDownloadCompletion)completion
+- (void)downloadURL:(NSString *)url
+            headers:(NSDictionary<NSString *, NSString *> *)headers
+         completion:(ENRMImageDownloadCompletion)completion
 {
   if (url.length == 0) {
     completion(nil);
     return;
   }
 
-  RCTUIImage *cached = [[ENRMImageAttachment originalImageCache] objectForKey:url];
+  NSString *cacheKey = ENRMImageCacheKey(url, headers);
+
+  RCTUIImage *cached = [[ENRMImageAttachment originalImageCache] objectForKey:cacheKey];
   if (cached) {
     completion(cached);
     return;
   }
 
   @synchronized(_inFlightRequests) {
-    NSMutableArray *existing = _inFlightRequests[url];
+    NSMutableArray *existing = _inFlightRequests[cacheKey];
     if (existing) {
       [existing addObject:completion];
       return;
     }
-    _inFlightRequests[url] = [NSMutableArray arrayWithObject:completion];
+    _inFlightRequests[cacheKey] = [NSMutableArray arrayWithObject:completion];
   }
 
   NSURL *nsURL = [NSURL URLWithString:url];
   if (!nsURL) {
-    [self dispatchCallbacksForURL:url image:nil];
+    [self dispatchCallbacksForKey:cacheKey image:nil];
     return;
   }
 
-  [[_session dataTaskWithURL:nsURL
-           completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:nsURL];
+  [headers enumerateKeysAndObjectsUsingBlock:^(NSString *name, NSString *value, BOOL *stop) {
+    [request setValue:value forHTTPHeaderField:name];
+  }];
+
+  [[_session dataTaskWithRequest:request
+               completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
 #if !TARGET_OS_OSX
-             RCTUIImage *image = (data && !error) ? [RCTUIImage imageWithData:data] : nil;
+                 RCTUIImage *image = (data && !error) ? [RCTUIImage imageWithData:data] : nil;
 #else
         RCTUIImage *image = (data && !error) ? [[RCTUIImage alloc] initWithData:data] : nil;
 #endif
 
-             if (image) {
-               [[ENRMImageAttachment originalImageCache] setObject:image forKey:url cost:ENRMImageByteCost(image)];
-             }
+                 if (image) {
+                   [[ENRMImageAttachment originalImageCache] setObject:image
+                                                                forKey:cacheKey
+                                                                  cost:ENRMImageByteCost(image)];
+                 }
 
-             [self dispatchCallbacksForURL:url image:image];
-           }] resume];
+                 [self dispatchCallbacksForKey:cacheKey image:image];
+               }] resume];
 }
 
-- (void)dispatchCallbacksForURL:(NSString *)url image:(RCTUIImage *_Nullable)image
+- (void)dispatchCallbacksForKey:(NSString *)cacheKey image:(RCTUIImage *_Nullable)image
 {
   NSArray<ENRMImageDownloadCompletion> *callbacks;
   @synchronized(_inFlightRequests) {
-    callbacks = [_inFlightRequests[url] copy];
-    [_inFlightRequests removeObjectForKey:url];
+    callbacks = [_inFlightRequests[cacheKey] copy];
+    [_inFlightRequests removeObjectForKey:cacheKey];
   }
 
   if (!callbacks)

--- a/packages/react-native-enriched-markdown/ios/utils/ENRMImageDownloader.m
+++ b/packages/react-native-enriched-markdown/ios/utils/ENRMImageDownloader.m
@@ -20,10 +20,11 @@ NSString *ENRMImageCacheKey(NSString *url, NSDictionary<NSString *, NSString *> 
     return url;
   }
   NSArray<NSString *> *names = [headers.allKeys sortedArrayUsingSelector:@selector(compare:)];
-  NSMutableString *joined = [NSMutableString string];
+  NSMutableArray<NSString *> *pairs = [NSMutableArray arrayWithCapacity:names.count];
   for (NSString *name in names) {
-    [joined appendFormat:@"%@:%@\n", name, headers[name]];
+    [pairs addObject:[NSString stringWithFormat:@"%@:%@", name, headers[name]]];
   }
+  NSString *joined = [pairs componentsJoinedByString:@"\n"];
   NSData *data = [joined dataUsingEncoding:NSUTF8StringEncoding];
   unsigned char digest[CC_SHA256_DIGEST_LENGTH];
   CC_SHA256(data.bytes, (CC_LONG)data.length, digest);

--- a/packages/react-native-enriched-markdown/ios/utils/ImageRequestHeaderUtils.h
+++ b/packages/react-native-enriched-markdown/ios/utils/ImageRequestHeaderUtils.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+#include <vector>
+
+template <typename T>
+static bool ENRMImageRequestHeadersChanged(const std::vector<T> &oldHeaders, const std::vector<T> &newHeaders)
+{
+  if (newHeaders.size() != oldHeaders.size()) {
+    return true;
+  }
+  for (size_t i = 0; i < newHeaders.size(); i++) {
+    if (newHeaders[i].name != oldHeaders[i].name || newHeaders[i].value != oldHeaders[i].value) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename T>
+static NSDictionary<NSString *, NSString *> *_Nullable ENRMImageRequestHeadersFromProps(const std::vector<T> &headers)
+{
+  if (headers.empty()) {
+    return nil;
+  }
+  NSMutableDictionary<NSString *, NSString *> *result = [NSMutableDictionary dictionaryWithCapacity:headers.size()];
+  for (const auto &header : headers) {
+    result[@(header.name.c_str())] = @(header.value.c_str());
+  }
+  return [result copy];
+}
+
+#endif

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
@@ -227,6 +227,11 @@ export interface ContextMenuItemConfig {
   icon?: string;
 }
 
+export interface ImageRequestHeaderInternal {
+  name: string;
+  value: string;
+}
+
 export interface SelectionMenuConfig {
   copyAsMarkdown: boolean;
   copyImageUrl: boolean;
@@ -426,6 +431,10 @@ export interface NativeProps extends ViewProps {
    * Custom items to show in the text selection context menu.
    */
   contextMenuItems?: ReadonlyArray<Readonly<ContextMenuItemConfig>>;
+  /**
+   * HTTP headers attached to remote image requests, as name/value pairs.
+   */
+  imageRequestHeaders?: ReadonlyArray<Readonly<ImageRequestHeaderInternal>>;
   /**
    * Built-in items to show in the text selection context menu.
    */

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
@@ -227,6 +227,11 @@ export interface ContextMenuItemConfig {
   icon?: string;
 }
 
+export interface ImageRequestHeaderInternal {
+  name: string;
+  value: string;
+}
+
 export interface SelectionMenuConfig {
   copyAsMarkdown: boolean;
   copyImageUrl: boolean;
@@ -425,6 +430,10 @@ export interface NativeProps extends ViewProps {
    * Custom items to show in the text selection context menu.
    */
   contextMenuItems?: ReadonlyArray<Readonly<ContextMenuItemConfig>>;
+  /**
+   * HTTP headers attached to remote image requests, as name/value pairs.
+   */
+  imageRequestHeaders?: ReadonlyArray<Readonly<ImageRequestHeaderInternal>>;
   /**
    * Built-in items to show in the text selection context menu.
    */

--- a/packages/react-native-enriched-markdown/src/native/EnrichedMarkdownText.tsx
+++ b/packages/react-native-enriched-markdown/src/native/EnrichedMarkdownText.tsx
@@ -121,6 +121,7 @@ export const EnrichedMarkdownText = ({
   streamingConfig,
   spoilerOverlay = 'particles',
   contextMenuItems,
+  imageRequestHeaders,
   selectionMenuConfig,
   accessibilityLabels,
   selectionColor,
@@ -170,6 +171,16 @@ export const EnrichedMarkdownText = ({
         ?.filter((item) => item.visible !== false)
         .map((item) => ({ text: item.text, icon: item.icon })),
     [contextMenuItems]
+  );
+
+  const nativeImageRequestHeaders = useMemo(
+    () =>
+      imageRequestHeaders
+        ? Object.entries(imageRequestHeaders)
+            .map(([name, value]) => ({ name, value }))
+            .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+        : undefined,
+    [imageRequestHeaders]
   );
 
   const handleContextMenuItemPress = useCallback(
@@ -280,6 +291,7 @@ export const EnrichedMarkdownText = ({
     spoilerOverlay,
     style: containerStyle,
     contextMenuItems: nativeContextMenuItems,
+    imageRequestHeaders: nativeImageRequestHeaders,
     selectionMenuConfig: normalizedSelectionMenuConfig,
     accessibilityLabels: resolvedAccessibilityLabels,
     onContextMenuItemPress: handleContextMenuItemPress,

--- a/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
@@ -255,6 +255,18 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    */
   contextMenuItems?: ContextMenuItem[];
   /**
+   * HTTP headers to attach to remote image requests, e.g. a `Referer`
+   * required by CDN hotlink protection or an `Authorization` token.
+   *
+   * Headers participate in image cache identity, so the same URL requested
+   * with different headers is fetched and cached separately.
+   *
+   * Not supported on web — browsers don't allow custom headers on `<img>`
+   * requests.
+   * @platform ios, android
+   */
+  imageRequestHeaders?: Record<string, string>;
+  /**
    * Controls the built-in items added to the native text selection menu and
    * lets you localize their labels. Custom app-provided actions are controlled
    * separately with `contextMenuItems`.


### PR DESCRIPTION
### What/Why?

Closes #369

Adds an `imageRequestHeaders` prop to `EnrichedMarkdownText` that attaches custom HTTP headers to remote image requests. Some Markdown image URLs are protected by CDN / hotlink protection and require a `Referer` (or `Authorization`) header to load - previously images were downloaded internally with no way to pass headers, so those images silently failed to render.

```tsx
<EnrichedMarkdownText
  markdown={markdown}
  imageRequestHeaders={{ Referer: 'https://example.com' }}
/>
```

#### Implementation notes

- Headers are per-view, not global: the downloaders are process-wide singletons, so headers travel per-request (view -> `StyleConfig` ->`ImageSpan`/`ENRMImageAttachment` -> downloader) instead of being stored on the singleton - two views with different headers would cause race condition if done otherwise.
- Cache: headers participate in the memory cache keys, in-flight request dedup, and the attachment registry key (iOS), so the same URL fetched with different headers is **cached separately.** The HTTP disk caches (OkHttp / `NSURLCache`) remain URL-keyed.
- Android measurement pass: the C++ measure-props serialization (`conversions.h toDynamic`) only forwards a curated subset of props; `imageRequestHeaders` is now included. Without this, the Fabric measurement render fired a duplicate header-less request per image.
- **Standalone Android package**: `EnrichedMarkdownText.setImageRequestHeaders(Map<String, String>)` on the view and an `imageRequestHeaders` parameter on the Compose wrapper. Threaded through `Renderer.configure` → `RendererConfig` → `ImageSpan` (no `StyleConfig` mutation, since standalone configs are user-owned and shareable across views).
- **Web not supported** - browsers don't allow custom headers on `<img>` requests; documented on the prop.

### Testing

Manual verification against a local mock server:

<details>
<summary> Run this node server </summary>

```js
/**
 * Mock CDN for testing `imageRequestHeaders`.
 *
 * Always responds 200 OK with a generated PNG:
 *   - GET /referer-image.png  → green if `Referer: https://example.com`, red otherwise
 *   - GET /auth-image.png     → green if `Authorization: Bearer secret-token`, red otherwise
 *
 * Responses are sent with `Cache-Control: no-store` so the URL-keyed disk
 * caches (OkHttp / NSURLCache) don't mask header changes between test runs.
 *
 * Run:  node scripts/mock-cdn-server.js
 * URLs: iOS simulator      http://localhost:3001/referer-image.png
 *       Android emulator   http://10.0.2.2:3001/referer-image.png
 *       Physical device    http://<your-lan-ip>:3001/referer-image.png
 */
const http = require('http');
const zlib = require('zlib');

const PORT = 3001;

const CRC_TABLE = Array.from({ length: 256 }, (_, n) => {
  let c = n;
  for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
  return c >>> 0;
});

function crc32(buf) {
  let c = 0xffffffff;
  for (const byte of buf) c = CRC_TABLE[(c ^ byte) & 0xff] ^ (c >>> 8);
  return (c ^ 0xffffffff) >>> 0;
}

function chunk(type, data) {
  const length = Buffer.alloc(4);
  length.writeUInt32BE(data.length);
  const body = Buffer.concat([Buffer.from(type, 'ascii'), data]);
  const crc = Buffer.alloc(4);
  crc.writeUInt32BE(crc32(body));
  return Buffer.concat([length, body, crc]);
}

function solidPng(width, height, [r, g, b]) {
  const ihdr = Buffer.alloc(13);
  ihdr.writeUInt32BE(width, 0);
  ihdr.writeUInt32BE(height, 4);
  ihdr[8] = 8; // bit depth
  ihdr[9] = 2; // color type: RGB
  const row = Buffer.concat([Buffer.from([0]), Buffer.alloc(width * 3)]);
  for (let x = 0; x < width; x++) row.set([r, g, b], 1 + x * 3);
  const raw = Buffer.concat(Array.from({ length: height }, () => row));
  return Buffer.concat([
    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
    chunk('IHDR', ihdr),
    chunk('IDAT', zlib.deflateSync(raw)),
    chunk('IEND', Buffer.alloc(0)),
  ]);
}

const GREEN = solidPng(400, 200, [46, 160, 67]);
const RED = solidPng(400, 200, [218, 54, 51]);

const ROUTES = {
  '/referer-image.png': (req) => req.headers.referer === 'https://example.com',
  '/auth-image.png': (req) => req.headers.authorization === 'Bearer secret-token',
};

http
  .createServer((req, res) => {
    const check = ROUTES[req.url];
    if (!check) {
      res.writeHead(404).end('Not found');
      return;
    }
    const ok = check(req);
    console.log(
      `${new Date().toISOString()} GET ${req.url} → ${ok ? 'GREEN (header ok)' : 'RED (header missing/wrong)'}`,
      `| Referer: ${req.headers.referer ?? '-'} | Authorization: ${req.headers.authorization ?? '-'}`
    );
    res
      .writeHead(200, {
        'Content-Type': 'image/png',
        'Cache-Control': 'no-store',
      })
      .end(ok ? GREEN : RED);
  })
  .listen(PORT, () => console.log(`Mock CDN running on http://localhost:${PORT}`));
```
</details>

The server always returns 200 with a **green** image when the expected header is present and a **red** one otherwise, and logs the received
headers per request — so both the rendered result and the actual wire traffic are verifiable. Routes cover `Referer` and `Authorization`
shapes. Responses are `Cache-Control: no-store` so disk caches don't mask header changes between runs.

Verified:

- **iOS (RN)**: green image with the prop set.
- **Android (RN, both flavors)**: green image; server log confirms a single request carrying `Referer: https://example.com` (measurement +
display renders coalesce via in-flight dedup after the `conversions.h` fix).
- **Android (standalone, Compose)**: green image, single request with the header.

### Screenshots

| | No Header | Wrong Header | Correct Header |
| -- | -- | -- | -- |
| Android | <img width="300" alt="image" src="https://github.com/user-attachments/assets/7da30d4e-bb1d-4d43-a714-317d17d362cd" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/1c666524-9125-43e0-82c8-0d1c187bfb2b" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/1f3eda3c-2975-4e3b-b253-a786787f055e" /> |
| Android (native) | <img width="300" alt="image" src="https://github.com/user-attachments/assets/04c8f9fc-6099-45de-b7f5-c118f0d0bf30" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/d9462d95-c1e0-4546-9fe1-bc6998912067" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/193d517a-838e-44fe-abe7-83103958e2b9" /> |
| IOS | <img width="300" alt="image" src="https://github.com/user-attachments/assets/85e9663a-1171-4177-827d-32ba8e79510e" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/b7339066-bfa6-4c3e-9a55-066cadf0f347" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/c3fac051-ae08-4a2d-b97a-9468c5748c05" /> |

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)