### PR TITLE
fix(iOS): replace racy RaTeXFFI modulemap-strip script with an explicit-modules opt-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: '26.3'
+          xcode-version: '26.6'
 
       - name: Reset build folder and pods
         run: rm -rf apps/react-native-example/build apps/react-native-example/ios/Pods apps/react-native-example/ios/Podfile.lock

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -61,6 +61,18 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES'
   }
 
+  if enable_math
+    # Xcode materializes the RaTeX binary target's module.modulemap into BOTH
+    # the platform-wide products dir and this pod's own build dir, and both are
+    # on this target's search paths. Xcode 26's default explicit-modules
+    # dependency scanner hard-errors on the duplicate ("redefinition of module
+    # 'RaTeXFFI'"); stripping the modulemap from a script phase races the
+    # scanner (loses on Xcode 26.3, happens to win on 26.6). Implicit modules
+    # tolerate the duplicate definition, so opt this target out of explicit
+    # modules instead of patching build products mid-build.
+    pod_xcconfig['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'
+  end
+
   # Detect Apple Silicon on the host running `pod install`. `sysctl hw.optional.arm64`
   # reports the real hardware even under a Rosetta-translated Ruby, unlike `uname -m`.
   apple_silicon = `sysctl -n hw.optional.arm64 2>/dev/null`.strip == '1'
@@ -81,22 +93,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = pod_xcconfig
 
   if enable_math
-    # React Native's spm_dependency generates a module.modulemap at
-    # ${BUILT_PRODUCTS_DIR}/include/ that re-declares RaTeXFFI, but the RaTeX
-    # XCFramework already ships its own definition. Strip the duplicate to
-    # prevent "redefinition of module 'RaTeXFFI'" during compilation.
+    # NOTE: the RaTeXFFI duplicate-modulemap problem is handled via
+    # SWIFT_ENABLE_EXPLICIT_MODULES=NO in pod_xcconfig above. The previous
+    # approach (a before_compile script sed-stripping the duplicate out of the
+    # platform products dir) mutated a build product mid-build and raced the
+    # explicit-modules dependency scanner: on Xcode 26.3 the scanner reads the
+    # modulemap before the script phase's edit and the build fails anyway.
     s.script_phases = [
-      {
-        name: 'Fix RaTeXFFI Module Redefinition',
-        script: <<~'SCRIPT',
-          # The shared module.modulemap lives in the platform build-products dir,
-          # one level above the per-target BUILT_PRODUCTS_DIR that CocoaPods sets.
-          MODULEMAP="${BUILT_PRODUCTS_DIR}/../include/module.modulemap"
-          [ -f "$MODULEMAP" ] || exit 0
-          sed -i '' -E '/^(framework )?module RaTeXFFI /,/^\}/d' "$MODULEMAP"
-        SCRIPT
-        execution_position: :before_compile
-      },
       {
         name: 'Dedupe RaTeX XCFramework Signature',
         script: <<~'SCRIPT',


### PR DESCRIPTION
# fix(iOS): replace racy RaTeXFFI modulemap-strip script with an explicit-modules opt-out

## Summary

The `[ios] react-native-enriched-markdown` job in react-native-community/nightly-tests went red against `react-native@0.88.0-nightly-20260717` ([run](https://github.com/react-native-community/nightly-tests/actions/runs/29559977839/job/87820207092)):

```
error: Clang dependency scanner failure:
  …/Debug-iphonesimulator/include/module.modulemap:1:8: error: redefinition of module 'RaTeXFFI'
  …/Debug-iphonesimulator/ReactNativeEnrichedMarkdown/include/module.modulemap:1:8: note: previously defined here
```

### What's going on

Xcode materializes the RaTeX binary target's xcframework into **both** the platform-wide products dir and the pod's own build dir — two identical `module.modulemap`s defining `RaTeXFFI`, both on the pod target's search paths. That duplication has always existed; the existing `Fix RaTeXFFI Module Redefinition` script phase sed-strips the platform-wide copy `before_compile`.

Two things changed:

1. React Native's VFS-overlay removal (the prebuilt/SwiftPM stack, first shipped in `0.88.0-nightly-20260717`) removed the `-ivfsoverlay` flag that had been disqualifying this pod target from Xcode 26's default **explicit modules** mode. The target now builds with `-explicit-module-build`, whose dependency scanner loads every reachable module map eagerly and hard-errors on the duplicate — where classic implicit modules tolerate it (verified: an implicit-modules compile against both duplicate maps prints the diagnostic but exits 0).
2. The script-phase approach **races the scanner**: it mutates a build product mid-build. On Xcode 26.3 (what CI runs) the scanner reads the modulemap before the script's edit lands and the build fails even though the script ran; on 26.6 the script happens to win and the build passes. A workaround whose correctness depends on undocumented scan scheduling isn't stable across Xcode releases.

### The fix

Set `SWIFT_ENABLE_EXPLICIT_MODULES = NO` in the pod's `pod_target_xcconfig` when math is enabled, and drop the now-redundant strip script (the signature-dedup phase stays). Under implicit modules the duplicate definition is benign — no build products need patching at all.

This is declarative (no mid-build mutation, no race), works on every RN version, and takes effect at `pod install` time.

Related: react-native side ships the same opt-out for every `spm_dependency` consumer in https://github.com/react/react-native/pull/57589 — but this library shouldn't need to wait for an RN release, and dropping the racy script is worthwhile regardless.

## Test plan

Fresh RN app on `react-native@0.88.0-nightly-20260717-b33de750b` + `react-native-enriched-markdown@0.8.0-nightly-20260716` with the prebuilt-core flags CI uses (`RCT_USE_RN_DEP=1 RCT_USE_PREBUILT_RNCORE=1`), Xcode 26.6, **stock** React Native `spm.rb` (i.e. without the RN-side fix), this podspec swapped into `node_modules`:

- `pod install`: `SWIFT_ENABLE_EXPLICIT_MODULES = NO` lands on both configurations of the pod target; the strip phase is gone from the generated project.
- Build: the pod target's `SwiftDriver` invocation no longer contains `-explicit-module-build`; **BUILD SUCCEEDED** with both duplicate `module.modulemap` copies deliberately present.
