### PR TITLE
feat: support saving original image

### DIFF
--- a/packages/react-native-enriched-markdown/ios/attachments/ENRMImageAttachment.m
+++ b/packages/react-native-enriched-markdown/ios/attachments/ENRMImageAttachment.m
@@ -29,6 +29,7 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
 @property (nonatomic, weak) ENRMPlatformTextView *textView;
 @property (nonatomic, strong) RCTUIImage *originalImage;
 @property (nonatomic, strong) RCTUIImage *loadedImage;
+@property (nonatomic, strong) RCTUIImage *placeholderImage;
 @property (nonatomic, copy) NSString *lastProcessedKey;
 
 @end
@@ -138,7 +139,7 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
     [self processAndApplyImage:self.originalImage withTargetWidth:imageBounds.size.width];
   }
 
-  return self.loadedImage ?: self.image;
+  return self.loadedImage ?: self.placeholderImage;
 }
 
 - (void)handleLoadedImage:(RCTUIImage *)image
@@ -147,6 +148,8 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
     return;
 
   self.originalImage = image;
+  // UIKit reads the plain image property for save/drag/copy — it must hold the original
+  self.image = image;
   CGFloat targetWidth = self.isInline ? self.cachedHeight : self.bounds.size.width;
 
   // Defer processing if we don't have valid bounds yet (common for non-inline block images)
@@ -172,8 +175,6 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
 
   if (cachedProcessed) {
     self.loadedImage = cachedProcessed;
-    if (self.isInline)
-      self.image = cachedProcessed;
     [self refreshDisplay];
     return;
   }
@@ -198,10 +199,7 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
     dispatch_async(dispatch_get_main_queue(), ^{
       strongSelf.loadedImage = processedImage;
       if (strongSelf.isInline) {
-        strongSelf.image = processedImage;
         strongSelf.bounds = CGRectMake(0, 0, strongSelf.cachedHeight, strongSelf.cachedHeight);
-      } else {
-        strongSelf.image = image; // Keep original for layout references
       }
       [strongSelf refreshDisplay];
     });
@@ -284,7 +282,7 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
   CGFloat size = self.cachedHeight;
   self.bounds = CGRectMake(0, 0, size, size);
   RCTUIGraphicsImageRenderer *renderer = [[RCTUIGraphicsImageRenderer alloc] initWithSize:CGSizeMake(1, 1)];
-  self.image = [renderer imageWithActions:^(RCTUIGraphicsImageRendererContext *ctx){}];
+  self.placeholderImage = [renderer imageWithActions:^(RCTUIGraphicsImageRendererContext *ctx){}];
 }
 
 - (NSRange)findAttachmentRangeInText:(NSAttributedString *)attributedString

--- a/packages/react-native-enriched-markdown/ios/attachments/ENRMImageAttachment.m
+++ b/packages/react-native-enriched-markdown/ios/attachments/ENRMImageAttachment.m
@@ -147,6 +147,12 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
   if (!image)
     return;
 
+  // The downloader completes synchronously on cache hits, which can happen on the render queue
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), ^{ [self handleLoadedImage:image]; });
+    return;
+  }
+
   self.originalImage = image;
   // UIKit reads the plain image property for save/drag/copy — it must hold the original
   self.image = image;


### PR DESCRIPTION
### What/Why?
Closes #380 

Long-pressing an image in `EnrichedMarkdownText` and tapping **Save to Photos** saved the processed render instead of the source image. Instrumentation of `ENRMImageAttachment` showed that UIKit's attachment context menu, save action, and drag session all read the plain `NSTextAttachment.image` property (`_attachmentHasImage:`, `_imageFromAttachment:`, `_defaultMenuForInteractableItem`), which we populated with:

- **inline images**: the scaled, border-radius-clipped bitmap - saved image was tiny and clipped,
- **block images re-created via the processed-image cache**: a stale 1×1 placeholder - saved image was a blank pixel.

The fix separates the two roles the `image` property was playing:

 - `image` now always holds the **original downloaded image** - set as soon as the download completes, on both the fresh-process and cache-hit paths. This is what UIKit serves to Save to Photos, Copy Image, drag-and-drop, and RTFD copy/paste.
- The processed (scaled + border-radius) bitmap lives only in `loadedImage`, returned from `imageForBounds:` for display - so on-screen rendering is unchanged.
- The 1×1 loading placeholder moved to its own `placeholderImage` property. Before an image finishes loading, `image` is nil, so the system no longer offers image actions that would save a blank pixel.

### Testing

In the example app (iOS simulator), with logging on the attachment accessors:

1. Long-press a **block image** - Save to Photos => saved image is the full-resolution original (`800×207` instead of the clipped `341×200` render).
2. Long-press an **inline image** → Save to Photos → original `80×73` instead of the processed `20×20` thumbnail.
3. Re-add an image so the attachment is rebuilt from the processed-image cache → long-press save still gets the original (previously a blank 1×1 placeholder).
4. Verified display is unchanged: `imageForBounds:` still returns the processed bitmap for drawing (sizing and border radius intact), and the drag preview still shows the rendered view.

#### Screenshots
*Note the cut corners*

| | Before | After |
| -- | -- | -- |
| Image after saving | <img width="300" alt="image" src="https://github.com/user-attachments/assets/7a434cdb-dfcc-42d0-af3b-3c6726568480" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/5b4b1c3c-5ede-4f70-872d-2808c27d9d76" /> |

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

