### PR TITLE
fix: preserve Select All (and other system items) in the selection edit menu

### DIFF
--- a/packages/react-native-enriched-markdown/ios/utils/EditMenuUtils.m
+++ b/packages/react-native-enriched-markdown/ios/utils/EditMenuUtils.m
@@ -49,11 +49,32 @@ static UIAction *_Nullable createCopyImageURLAction(NSArray<NSString *> *imageUR
 
 static UIMenu *createEnhancedStandardEditMenu(UIMenu *originalMenu, UIAction *copyAction)
 {
+  // Preserve the system menu's children, swapping only the standard Copy command
+  // for our enhanced version. Dropping the other items would remove Select All,
+  // which on iOS 16+ is the only way to start a selection from the long-press
+  // edit menu of a non-editable text view.
+  NSMutableArray<UIMenuElement *> *children = [NSMutableArray arrayWithCapacity:originalMenu.children.count];
+  BOOL replacedCopy = NO;
+
+  for (UIMenuElement *element in originalMenu.children) {
+    if (!replacedCopy && [element isKindOfClass:[UICommand class]] &&
+        ((UICommand *)element).action == @selector(copy:)) {
+      [children addObject:copyAction];
+      replacedCopy = YES;
+      continue;
+    }
+    [children addObject:element];
+  }
+
+  if (!replacedCopy) {
+    [children insertObject:copyAction atIndex:0];
+  }
+
   return [UIMenu menuWithTitle:originalMenu.title
                          image:originalMenu.image
                     identifier:originalMenu.identifier
                        options:originalMenu.options
-                      children:@[ copyAction ]];
+                      children:children];
 }
 
 static void addOptionalAction(NSMutableArray<UIMenuElement *> *array, UIAction *_Nullable action)

--- a/packages/react-native-enriched-markdown/ios/utils/EditMenuUtils.m
+++ b/packages/react-native-enriched-markdown/ios/utils/EditMenuUtils.m
@@ -47,12 +47,12 @@ static UIAction *_Nullable createCopyImageURLAction(NSArray<NSString *> *imageUR
                            handler:^(__kindof UIAction *action) { copyStringToPasteboard(urlsToCopy); }];
 }
 
+/// Rebuilds the standard-edit menu with the system Copy swapped for the enhanced
+/// copy action. All other system items are kept — dropping them would remove
+/// Select All, which on iOS 16+ is the only way to start a selection from the
+/// long-press menu of a non-editable text view.
 static UIMenu *createEnhancedStandardEditMenu(UIMenu *originalMenu, UIAction *copyAction)
 {
-  // Preserve the system menu's children, swapping only the standard Copy command
-  // for our enhanced version. Dropping the other items would remove Select All,
-  // which on iOS 16+ is the only way to start a selection from the long-press
-  // edit menu of a non-editable text view.
   NSMutableArray<UIMenuElement *> *children = [NSMutableArray arrayWithCapacity:originalMenu.children.count];
   BOOL replacedCopy = NO;
 


### PR DESCRIPTION
### What/Why?

On iOS 16+, long-pressing plain text in a non-editable, selectable `EnrichedMarkdownText` presents the edit menu **without** starting a selection — and **Select All** is the only path from that menu into a text selection.

`createEnhancedStandardEditMenu` in `ios/utils/EditMenuUtils.m` rebuilds the system standard-edit menu (`com.apple.menu.standard-edit`) with `children:@[ copyAction ]`, which silently discards every other system item in that menu — most notably Select All. As a result, the menu shows only Copy / Copy as Markdown, and a selection can never be started from the long-press menu.

**Repro:** render `<EnrichedMarkdownText markdown="Some plain text" />` (default `selectable`), long-press the text on iOS 16+ → the menu offers only Copy / Copy as Markdown; Select All is missing, so there is no way to begin selecting text from there.

**Fix:** keep the original menu's `children` in order and swap only the system Copy item for the library's enhanced copy action. The system Copy is identified as a `UICommand` whose action is `copy:`. If no Copy item is found, the enhanced copy action is prepended (the previous behavior as a fallback). The function signature is unchanged and the macOS path (`EditMenuUtils+macOS.m`) is untouched. All other suggested actions outside the standard-edit menu already passed through unchanged; this only stops the standard-edit menu's own children from being dropped.

### Testing

- `yarn lint`, `yarn typecheck` pass; `ios/utils/EditMenuUtils.m` is clean under `clang-format --Werror` with the repo's `.clang-format`.
- I was not able to build the iOS example app in my environment, so this was not exercised on a simulator — the change is a minimal, self-contained rework of `createEnhancedStandardEditMenu` and would benefit from a quick manual check: long-press plain text (no selection) → Select All appears and starts a selection; with an existing selection → the enhanced Copy still replaces the system Copy and Copy as Markdown still appears.

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android <!-- no Android changes -->
- [ ] Updated documentation/README if applicable <!-- behavior fix, no API change -->
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
