### PR TITLE
Revert "fix(iOS): replace racy RaTeXFFI modulemap-strip script with an explicit-modules opt-out"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: '26.6'
+          xcode-version: '26.3'
 
       - name: Reset build folder and pods
         run: rm -rf apps/react-native-example/build apps/react-native-example/ios/Pods apps/react-native-example/ios/Podfile.lock

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -61,18 +61,6 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES'
   }
 
-  if enable_math
-    # Xcode materializes the RaTeX binary target's module.modulemap into BOTH
-    # the platform-wide products dir and this pod's own build dir, and both are
-    # on this target's search paths. Xcode 26's default explicit-modules
-    # dependency scanner hard-errors on the duplicate ("redefinition of module
-    # 'RaTeXFFI'"); stripping the modulemap from a script phase races the
-    # scanner (loses on Xcode 26.3, happens to win on 26.6). Implicit modules
-    # tolerate the duplicate definition, so opt this target out of explicit
-    # modules instead of patching build products mid-build.
-    pod_xcconfig['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'
-  end
-
   # Detect Apple Silicon on the host running `pod install`. `sysctl hw.optional.arm64`
   # reports the real hardware even under a Rosetta-translated Ruby, unlike `uname -m`.
   apple_silicon = `sysctl -n hw.optional.arm64 2>/dev/null`.strip == '1'
@@ -93,13 +81,22 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = pod_xcconfig
 
   if enable_math
-    # NOTE: the RaTeXFFI duplicate-modulemap problem is handled via
-    # SWIFT_ENABLE_EXPLICIT_MODULES=NO in pod_xcconfig above. The previous
-    # approach (a before_compile script sed-stripping the duplicate out of the
-    # platform products dir) mutated a build product mid-build and raced the
-    # explicit-modules dependency scanner: on Xcode 26.3 the scanner reads the
-    # modulemap before the script phase's edit and the build fails anyway.
+    # React Native's spm_dependency generates a module.modulemap at
+    # ${BUILT_PRODUCTS_DIR}/include/ that re-declares RaTeXFFI, but the RaTeX
+    # XCFramework already ships its own definition. Strip the duplicate to
+    # prevent "redefinition of module 'RaTeXFFI'" during compilation.
     s.script_phases = [
+      {
+        name: 'Fix RaTeXFFI Module Redefinition',
+        script: <<~'SCRIPT',
+          # The shared module.modulemap lives in the platform build-products dir,
+          # one level above the per-target BUILT_PRODUCTS_DIR that CocoaPods sets.
+          MODULEMAP="${BUILT_PRODUCTS_DIR}/../include/module.modulemap"
+          [ -f "$MODULEMAP" ] || exit 0
+          sed -i '' -E '/^(framework )?module RaTeXFFI /,/^\}/d' "$MODULEMAP"
+        SCRIPT
+        execution_position: :before_compile
+      },
       {
         name: 'Dedupe RaTeX XCFramework Signature',
         script: <<~'SCRIPT',


### PR DESCRIPTION
Reverts #546 — the modulemap-strip script it removed turns out to still be required on Xcode 26.3.