### PR TITLE
chore: update homepage url in package.json

### DIFF
--- a/packages/react-native-enriched-markdown/package.json
+++ b/packages/react-native-enriched-markdown/package.json
@@ -64,7 +64,7 @@
   "bugs": {
     "url": "https://github.com/software-mansion/react-native-enriched-markdown/issues"
   },
-  "homepage": "https://github.com/software-mansion/react-native-enriched-markdown#readme",
+  "homepage": "https://enriched.swmansion.com/markdown",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },


### PR DESCRIPTION
Updates the package `homepage` field to point to the hosted documentation site instead of the GitHub README.

Analogous to software-mansion/react-native-enriched-html#711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)