### PR TITLE
feat: centering of entire tables

### DIFF
--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/Table.stories.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/Table.stories.tsx
@@ -5,6 +5,7 @@ import {
   fontFamilyControl,
   fontWeightControl,
   githubFlavorArgTypes,
+  tableAlignControl,
   tableStyledDefaults,
   type TableStyleControls,
   numberControl,
@@ -26,6 +27,11 @@ const WIDE_MARKDOWN = `| Product | Category | Q1 Revenue | Q2 Revenue | Q3 Reven
 | Widget Pro | Hardware | $12,400 | $15,200 | $14,800 | $18,100 | $60,500 |
 | Cloud Suite | Software | $8,900 | $9,300 | $11,700 | $12,000 | $41,900 |
 | Support Plan | Services | $4,200 | $4,500 | $4,800 | $5,100 | $18,600 |`;
+
+const NARROW_MARKDOWN = `| Item | Qty |
+| --- | --- |
+| Apples | 3 |
+| Pears | 7 |`;
 
 const argTypes = {
   ...githubFlavorArgTypes('Tables require flavor="github" (GFM).'),
@@ -99,6 +105,7 @@ const argTypes = {
     max: 48,
     step: 2,
   }),
+  align: tableAlignControl('markdownStyle.table.align'),
 };
 
 export default storyMeta('Block', 'Table');
@@ -116,6 +123,27 @@ export const Default: TextStory<TableStyleControls> = {
       <EnrichedMarkdownTextStory
         title="Table"
         description="GFM tables. Use the controls to tune markdownStyle.table."
+        {...rest}
+        style={{ table: toTableStyle(controls) }}
+      />
+    );
+  },
+};
+
+export const Centered: TextStory<TableStyleControls> = {
+  args: {
+    markdown: NARROW_MARKDOWN,
+    flavor: 'github',
+    ...tableStyledDefaults,
+    align: 'center',
+  },
+  argTypes,
+  render: (args) => {
+    const { controls, rest } = splitStyleControls(args, tableStyledDefaults);
+    return (
+      <EnrichedMarkdownTextStory
+        title="Table Alignment"
+        description="markdownStyle.table.align positions tables that are narrower than the container. Tables that overflow and scroll ignore it and start at the table's beginning."
         {...rest}
         style={{ table: toTableStyle(controls) }}
       />

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/Table.stories.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/Table.stories.tsx
@@ -105,7 +105,9 @@ const argTypes = {
     max: 48,
     step: 2,
   }),
-  align: tableAlignControl('markdownStyle.table.align'),
+  align: tableAlignControl(
+    "markdownStyle.table.align ('' = unset, legacy full-width table on web)"
+  ),
 };
 
 export default storyMeta('Block', 'Table');

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookMarkdownStyles.ts
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookMarkdownStyles.ts
@@ -1,5 +1,6 @@
 type TextAlign = 'auto' | 'left' | 'right' | 'center' | 'justify';
 type MathTextAlign = 'left' | 'center' | 'right';
+type TableAlign = 'left' | 'center' | 'right';
 
 export type ParagraphStyleControls = {
   fontSize: number;
@@ -178,6 +179,7 @@ export type TableStyleControls = {
   cellPaddingHorizontal: number;
   cellPaddingVertical: number;
   horizontalOverflow: number;
+  align: TableAlign;
 };
 
 export const tableStyledDefaults: TableStyleControls = {
@@ -199,6 +201,7 @@ export const tableStyledDefaults: TableStyleControls = {
   cellPaddingHorizontal: 12,
   cellPaddingVertical: 8,
   horizontalOverflow: 0,
+  align: 'left',
 };
 
 export type TaskListStyleControls = {
@@ -546,6 +549,20 @@ export function textAlignControl(description: string) {
 export function mathTextAlignControl(description: string) {
   return {
     options: [...MATH_TEXT_ALIGN_OPTIONS],
+    control: { type: 'select' as const },
+    description,
+  };
+}
+
+const TABLE_ALIGN_OPTIONS = [
+  'left',
+  'center',
+  'right',
+] as const satisfies readonly TableAlign[];
+
+export function tableAlignControl(description: string) {
+  return {
+    options: [...TABLE_ALIGN_OPTIONS],
     control: { type: 'select' as const },
     description,
   };

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookMarkdownStyles.ts
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookMarkdownStyles.ts
@@ -179,7 +179,7 @@ export type TableStyleControls = {
   cellPaddingHorizontal: number;
   cellPaddingVertical: number;
   horizontalOverflow: number;
-  align: TableAlign;
+  align: TableAlign | '';
 };
 
 export const tableStyledDefaults: TableStyleControls = {
@@ -201,7 +201,7 @@ export const tableStyledDefaults: TableStyleControls = {
   cellPaddingHorizontal: 12,
   cellPaddingVertical: 8,
   horizontalOverflow: 0,
-  align: 'left',
+  align: '',
 };
 
 export type TaskListStyleControls = {
@@ -555,10 +555,11 @@ export function mathTextAlignControl(description: string) {
 }
 
 const TABLE_ALIGN_OPTIONS = [
+  '',
   'left',
   'center',
   'right',
-] as const satisfies readonly TableAlign[];
+] as const satisfies readonly (TableAlign | '')[];
 
 export function tableAlignControl(description: string) {
   return {

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookStyleBuilders.ts
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookStyleBuilders.ts
@@ -177,6 +177,7 @@ export function toTableStyle(
     cellPaddingHorizontal: controls.cellPaddingHorizontal,
     cellPaddingVertical: controls.cellPaddingVertical,
     horizontalOverflow: controls.horizontalOverflow,
+    align: controls.align,
   };
 }
 

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookStyleBuilders.ts
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookStyleBuilders.ts
@@ -177,7 +177,7 @@ export function toTableStyle(
     cellPaddingHorizontal: controls.cellPaddingHorizontal,
     cellPaddingVertical: controls.cellPaddingVertical,
     horizontalOverflow: controls.horizontalOverflow,
-    align: controls.align,
+    ...(controls.align ? { align: controls.align } : {}),
   };
 }
 

--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -434,7 +434,7 @@ Table styles only apply when `flavor="github"` is set. Tables inherit the base b
 | `cellPaddingHorizontal` | `number` | Horizontal padding inside cells |
 | `cellPaddingVertical` | `number` | Vertical padding inside cells |
 | `horizontalOverflow` | `number` | When set, scrollable tables extend beyond the markdown container by this amount on each side (edge-to-edge / "bleed" layout). Set to the parent's horizontal padding to make wide tables reach the screen edges. Has no effect on tables that fit within the container width. iOS, Android, and macOS only. Default: `0` |
-| `align` | `'left' \| 'center' \| 'right'` | Horizontal alignment of the whole table when it is narrower than the container. Tables that overflow and scroll ignore it — scrolling always starts at the table's beginning. On web, setting it also makes the table shrink to fit its content instead of filling the container width. Default: left-aligned |
+| `align` | `'left' \| 'center' \| 'right'` | Horizontal alignment of the whole table when it is narrower than the container. Tables that overflow and scroll ignore it — scrolling always starts at the table's beginning. On web, setting any value (including `'left'`) also makes the table shrink to fit its content instead of filling the container width. Default: unset — legacy start-aligned placement (full-width table on web) |
 
 ### Task List-specific
 

--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -434,6 +434,7 @@ Table styles only apply when `flavor="github"` is set. Tables inherit the base b
 | `cellPaddingHorizontal` | `number` | Horizontal padding inside cells |
 | `cellPaddingVertical` | `number` | Vertical padding inside cells |
 | `horizontalOverflow` | `number` | When set, scrollable tables extend beyond the markdown container by this amount on each side (edge-to-edge / "bleed" layout). Set to the parent's horizontal padding to make wide tables reach the screen edges. Has no effect on tables that fit within the container width. iOS, Android, and macOS only. Default: `0` |
+| `align` | `'left' \| 'center' \| 'right'` | Horizontal alignment of the whole table when it is narrower than the container. Tables that overflow and scroll ignore it — scrolling always starts at the table's beginning. On web, setting it also makes the table shrink to fit its content instead of filling the container width. Default: left-aligned |
 
 ### Task List-specific
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/TableStyle.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/TableStyle.kt
@@ -21,6 +21,7 @@ data class TableStyle(
   val cellPaddingHorizontal: Float,
   val cellPaddingVertical: Float,
   val horizontalOverflow: Float,
+  val align: String,
 ) : BaseBlockStyle {
   companion object {
     fun fromReadableMap(
@@ -46,6 +47,7 @@ data class TableStyle(
       val cellPaddingHorizontal = parser.toPixelFromDIP(map.getDouble("cellPaddingHorizontal").toFloat())
       val cellPaddingVertical = parser.toPixelFromDIP(map.getDouble("cellPaddingVertical").toFloat())
       val horizontalOverflow = parser.toPixelFromDIP(map.getDouble("horizontalOverflow").toFloat())
+      val align = parser.parseString(map, "align")
 
       return TableStyle(
         fontSize = fontSize,
@@ -66,6 +68,7 @@ data class TableStyle(
         cellPaddingHorizontal = cellPaddingHorizontal,
         cellPaddingVertical = cellPaddingVertical,
         horizontalOverflow = horizontalOverflow,
+        align = align,
       )
     }
   }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/TableContainerView.kt
@@ -338,6 +338,21 @@ class TableContainerView(
 
     scrollView.layout(0, 0, viewWidth, bottom - top)
 
+    gridContainer.translationX =
+      if (tableStyle.align.isNotEmpty() && !tableOverflows) {
+        val freeSpace = max(contentWidth - totalTableWidth, 0f)
+        val desiredLeft =
+          overhang +
+            when (tableStyle.align) {
+              "center" -> freeSpace / 2f
+              "right" -> freeSpace
+              else -> 0f
+            }
+        desiredLeft - gridContainer.left
+      } else {
+        0f
+      }
+
     if (isRtl) {
       val effectiveWidth = if (tableOverflows) contentWidth.toFloat() else viewWidth.toFloat()
       if (totalTableWidth > effectiveWidth) {

--- a/packages/react-native-enriched-markdown/ios/styles/StyleConfig.h
+++ b/packages/react-native-enriched-markdown/ios/styles/StyleConfig.h
@@ -358,6 +358,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setTableCellPaddingVertical:(CGFloat)newValue;
 - (CGFloat)tableHorizontalOverflow;
 - (void)setTableHorizontalOverflow:(CGFloat)newValue;
+- (NSString *)tableAlign;
+- (void)setTableAlign:(NSString *)newValue;
 // Task list checkbox properties
 - (RCTUIColor *)taskListCheckedColor;
 - (void)setTaskListCheckedColor:(RCTUIColor *)newValue;

--- a/packages/react-native-enriched-markdown/ios/styles/StyleConfig.mm
+++ b/packages/react-native-enriched-markdown/ios/styles/StyleConfig.mm
@@ -213,6 +213,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   CGFloat _tableCellPaddingHorizontal;
   CGFloat _tableCellPaddingVertical;
   CGFloat _tableHorizontalOverflow;
+  NSString *_tableAlign;
   // Task list checkbox
   RCTUIColor *_taskListCheckedColor;
   RCTUIColor *_taskListBorderColor;
@@ -478,6 +479,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   copy->_tableCellPaddingHorizontal = _tableCellPaddingHorizontal;
   copy->_tableCellPaddingVertical = _tableCellPaddingVertical;
   copy->_tableHorizontalOverflow = _tableHorizontalOverflow;
+  copy->_tableAlign = [_tableAlign copy];
   copy->_taskListCheckedColor = [_taskListCheckedColor copy];
   copy->_taskListBorderColor = [_taskListBorderColor copy];
   copy->_taskListCheckboxSize = _taskListCheckboxSize;
@@ -2332,6 +2334,16 @@ static const CGFloat kDefaultMinGap = 4.0;
 - (void)setTableHorizontalOverflow:(CGFloat)newValue
 {
   _tableHorizontalOverflow = newValue;
+}
+
+- (NSString *)tableAlign
+{
+  return _tableAlign ?: @"";
+}
+
+- (void)setTableAlign:(NSString *)newValue
+{
+  _tableAlign = newValue;
 }
 
 // Task list

--- a/packages/react-native-enriched-markdown/ios/utils/StylePropsUtils.h
+++ b/packages/react-native-enriched-markdown/ios/utils/StylePropsUtils.h
@@ -1011,6 +1011,11 @@ BOOL applyMarkdownStyleToConfig(StyleConfig *config, const MarkdownStyle &newSty
     changed = YES;
   }
 
+  if (newStyle.table.align != oldStyle.table.align) {
+    [config setTableAlign:@(newStyle.table.align.c_str())];
+    changed = YES;
+  }
+
   // ── Task List ───────────────────────────────────────────────────────────────
 
   if (newStyle.taskList.checkedColor != oldStyle.taskList.checkedColor) {

--- a/packages/react-native-enriched-markdown/ios/views/TableContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/TableContainerView.m
@@ -549,6 +549,18 @@
   return _totalTableHeight;
 }
 
+- (CGFloat)alignOffsetForFreeSpace:(CGFloat)freeSpace
+{
+  if (freeSpace <= 0)
+    return 0;
+  NSString *align = self.config.tableAlign;
+  if ([align isEqualToString:@"center"])
+    return freeSpace / 2;
+  if ([align isEqualToString:@"right"])
+    return freeSpace;
+  return 0;
+}
+
 - (void)layoutSubviews
 {
   [super layoutSubviews];
@@ -568,11 +580,12 @@
     _scrollView.scrollEnabled = YES;
     _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
   } else {
+    CGFloat alignOffset = [self alignOffsetForFreeSpace:containerWidth - overhang * 2 - _totalTableWidth];
     _scrollView.contentInset = UIEdgeInsetsZero;
     _scrollView.contentOffset = CGPointZero;
     _scrollView.contentSize = CGSizeMake(MAX(_totalTableWidth, containerWidth), _totalTableHeight);
     _scrollView.scrollEnabled = (_totalTableWidth > containerWidth);
-    _gridContainer.frame = CGRectMake(overhang, 0, _totalTableWidth, _totalTableHeight);
+    _gridContainer.frame = CGRectMake(overhang + alignOffset, 0, _totalTableWidth, _totalTableHeight);
   }
 #else
   CGFloat overhang = MAX(self.config.tableHorizontalOverflow, 0);
@@ -582,7 +595,8 @@
   if (tableOverflows) {
     _gridContainer.frame = CGRectMake(0, 0, _totalTableWidth, _totalTableHeight);
   } else if (_totalTableWidth > 0 && _totalTableHeight > 0) {
-    _gridContainer.frame = CGRectMake(overhang, 0, _totalTableWidth, _totalTableHeight);
+    CGFloat alignOffset = [self alignOffsetForFreeSpace:containerWidth - overhang * 2 - _totalTableWidth];
+    _gridContainer.frame = CGRectMake(overhang + alignOffset, 0, _totalTableWidth, _totalTableHeight);
   }
 #endif
 }

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
@@ -125,6 +125,7 @@ interface TableStyleInternal extends BaseBlockStyleInternal {
   cellPaddingHorizontal: CodegenTypes.Float;
   cellPaddingVertical: CodegenTypes.Float;
   horizontalOverflow: CodegenTypes.Float;
+  align: string;
 }
 
 interface TaskListStyleInternal {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
@@ -126,6 +126,7 @@ interface TableStyleInternal extends BaseBlockStyleInternal {
   cellPaddingHorizontal: CodegenTypes.Float;
   cellPaddingVertical: CodegenTypes.Float;
   horizontalOverflow: CodegenTypes.Float;
+  align: string;
 }
 
 interface TaskListStyleInternal {

--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.ts
@@ -196,6 +196,7 @@ const DEFAULT_NORMALIZED_STYLE = Object.freeze({
     cellPaddingHorizontal: 12,
     cellPaddingVertical: 8,
     horizontalOverflow: 0,
+    align: '' as const,
   },
   math: {
     fontSize: 20,

--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.web.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.web.ts
@@ -180,6 +180,7 @@ const DEFAULT_NORMALIZED_STYLE: MarkdownStyleInternal = Object.freeze({
     cellPaddingHorizontal: 12,
     cellPaddingVertical: 8,
     horizontalOverflow: 0,
+    align: '' as const,
   },
   math: {
     fontSize: 20,

--- a/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
@@ -161,7 +161,10 @@ interface TableStyle extends BaseBlockStyle {
   /**
    * Horizontal alignment of the whole table within the container. Only applies
    * when the table is narrower than the container; tables that overflow and
-   * scroll always start at the table's beginning. Default: left-aligned.
+   * scroll always start at the table's beginning. When unset, tables keep the
+   * legacy start-aligned placement. On web, setting any value (including
+   * 'left') also makes the table shrink to fit its content instead of filling
+   * the container width.
    */
   align?: 'left' | 'center' | 'right';
 }

--- a/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
@@ -158,6 +158,12 @@ interface TableStyle extends BaseBlockStyle {
   cellPaddingHorizontal?: number;
   cellPaddingVertical?: number;
   horizontalOverflow?: number;
+  /**
+   * Horizontal alignment of the whole table within the container. Only applies
+   * when the table is narrower than the container; tables that overflow and
+   * scroll always start at the table's beginning. Default: left-aligned.
+   */
+  align?: 'left' | 'center' | 'right';
 }
 
 interface TaskListStyle {

--- a/packages/react-native-enriched-markdown/src/types/MarkdownStyleInternal.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownStyleInternal.ts
@@ -6,6 +6,9 @@ export type BlockTextAlign = 'auto' | 'left' | 'right' | 'center' | 'justify';
 // Mirrors the public fontStyle values; empty string means "inherit / no override".
 export type EmphasisFontStyle = 'normal' | 'italic' | 'oblique' | '';
 
+// empty string means "no table alignment set" (legacy start-aligned placement).
+export type TableAlign = 'left' | 'center' | 'right' | '';
+
 // empty string means "legacy sizing" (fill width, no resize-mode handling).
 // resolves to 'cover' when maxHeight/aspectRatio is present.
 export type ImageResizeMode =
@@ -134,6 +137,7 @@ interface TableStyleInternal extends BaseBlockStyleInternal {
   cellPaddingHorizontal: number;
   cellPaddingVertical: number;
   horizontalOverflow: number;
+  align: TableAlign;
 }
 
 interface TaskListStyleInternal {

--- a/packages/react-native-enriched-markdown/src/web/styles.ts
+++ b/packages/react-native-enriched-markdown/src/web/styles.ts
@@ -446,11 +446,20 @@ export function tableBodyRowStyle(
 
 function tableWrapperStyle(style: MarkdownStyleInternal): CSSProperties {
   const table = style.table;
+  const alignment: CSSProperties = table.align
+    ? {
+        width: 'fit-content',
+        maxWidth: '100%',
+        marginLeft: table.align === 'left' ? 0 : 'auto',
+        marginRight: table.align === 'right' ? 0 : 'auto',
+      }
+    : {};
   return {
     overflowX: 'auto',
     overflowY: 'hidden',
     marginTop: table.marginTop,
     marginBottom: table.marginBottom,
+    ...alignment,
     // borderRadius must live on the wrapper, not the <table> — border-collapse:
     // collapse causes browsers to ignore border-radius on the table element itself.
     borderRadius: table.borderRadius,


### PR DESCRIPTION
### What/Why?

closes #156

Adds a new `markdownStyle.table.align` style prop (`'left' | 'center' | 'right'`) that aligns an **entire table** within the markdown container, complementing the existing per-column cell alignment from GFM syntax.

- Applies only when the table is narrower than the container.
- When the table overflows and scrolls, alignment is ignored and scrolling always starts at the table's beginning (snap to start; RTL keeps its existing snap-to-end behavior).
- When unset, every platform keeps the previous behavior exactly, including Android RTL start-alignment and the web's full-width table

Note: 
Does not apply to tables that does not fit initially but fit with `horizontalOverflow` - this would require a bit of work in regards to cross-platform consistency to clean up.

### Testing
- Created new **Table - centered** story (narrow table) and added "align" controll on all table stories. 
- Verified that table overflow does not break the new logic (and vice versa). 
- Manually verified behaviour in the example app


#### Screenshots

| | iOS | Android |
| - | - | - |
| Default | <img width="300" alt="image" src="https://github.com/user-attachments/assets/440245da-f3ed-496d-a473-8a52d213a94d" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/06e1e9db-16f4-4808-b789-1a406a62c2b4" /> |
| Left | <img width="300" alt="image" src="https://github.com/user-attachments/assets/15b853ad-b568-4c8c-b2b7-8da8d15e8692" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/abd2dffb-a286-4df9-b71e-955e99bc5abd" /> |
| Center | <img width="300" alt="image" src="https://github.com/user-attachments/assets/2a745ce1-7fca-4005-90ff-9b5103b0c38f" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/0d939285-0d77-4cbf-b0ed-a499ce7136d4" /> |
| Right | <img width="300" alt="image" src="https://github.com/user-attachments/assets/363a18e6-e262-4931-90d9-7271be36d2d1" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/edaa6fca-ad6a-447e-8a18-a8969dbb5f37" /> |
| Wide table | <img width="300" alt="image" src="https://github.com/user-attachments/assets/d2af9cc1-8e41-4a5d-ae13-a75d0cc049d9" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/ed27c3e7-2fa9-428b-a21e-15077a1ed08c" /> | 


### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

