### PR TITLE
feat(ios): add EnrichedMarkdownText SwiftUI view

### DIFF
--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/EnrichedMarkdown.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/EnrichedMarkdown.swift
@@ -1,1 +1,3 @@
-public enum EnrichedMarkdown {}
+public enum EnrichedMarkdown {
+    // Namespace for the EnrichedMarkdown library.
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import UIKit
+
+public struct EnrichedMarkdownText: View {
+    private let markdown: String
+
+    @Environment(\.markdownStyleConfig) private var styleConfig
+
+    public init(_ markdown: String) {
+        self.markdown = markdown
+    }
+
+    public var body: some View {
+        MarkdownTextViewRepresentable(
+            attributedText: MarkdownRenderer.render(markdown, config: styleConfig)
+        )
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import UIKit
+
+struct MarkdownTextViewRepresentable: UIViewRepresentable {
+    let attributedText: NSAttributedString
+
+    func makeUIView(context: Context) -> MarkdownTextView {
+        MarkdownTextView()
+    }
+
+    func updateUIView(_ textView: MarkdownTextView, context: Context) {
+        textView.setMarkdownAttributedText(attributedText)
+    }
+
+    @available(iOS 16.0, *)
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: MarkdownTextView, context: Context) -> CGSize? {
+        let width = proposal.width ?? UIScreen.main.bounds.width
+        let size = uiView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+        return CGSize(width: width, height: size.height)
+    }
+}
+
+final class MarkdownTextView: UITextView {
+    override var intrinsicContentSize: CGSize {
+        let width = bounds.width > 0 ? bounds.width : UIView.noIntrinsicMetric
+        guard width != UIView.noIntrinsicMetric else {
+            return CGSize(width: UIView.noIntrinsicMetric, height: UIView.noIntrinsicMetric)
+        }
+        let size = sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+        return CGSize(width: UIView.noIntrinsicMetric, height: size.height)
+    }
+
+    init() {
+        super.init(frame: .zero, textContainer: nil)
+        configure()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configure() {
+        isEditable = false
+        isScrollEnabled = false
+        backgroundColor = .clear
+        textContainerInset = .zero
+        textContainer.lineFragmentPadding = 0
+        setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    }
+
+    func setMarkdownAttributedText(_ attributedText: NSAttributedString) {
+        guard !(self.attributedText?.isEqual(to: attributedText) ?? false) else { return }
+        self.attributedText = attributedText
+        invalidateIntrinsicContentSize()
+    }
+}


### PR DESCRIPTION
Add a TextKit 2 UITextView host and EnrichedMarkdownText view that wires parsing, rendering, and theme config into a SwiftUI-native API.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

