### PR TITLE
feat(ios): add line break rendering

### DIFF
--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
@@ -43,6 +43,8 @@ final class RendererFactory {
             return HeadingRenderer(factory: self, config: config)
         case .link:
             return LinkRenderer(factory: self, config: config)
+        case .lineBreak:
+            return LineBreakRenderer()
         default:
             return childrenOnlyRenderer
         }

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/LineBreakRenderer.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/LineBreakRenderer.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+final class LineBreakRenderer: NodeRenderer {
+    private static let lineSeparator = "\u{2028}"
+
+    func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
+        let lineBreak = NSAttributedString(
+            string: Self.lineSeparator,
+            attributes: context.getTextAttributes()
+        )
+        output.append(lineBreak)
+    }
+}

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/RendererTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/RendererTests.swift
@@ -300,6 +300,21 @@ final class RendererTests: XCTestCase {
 
     A paragraph with a [link](https://example.com) and **bold** nearby.
     """
+
+
+    func testHardLineBreakUsesLineSeparator() {
+        let result = MarkdownRenderer.render("Line one  \nLine two", config: config)
+        XCTAssertTrue(result.string.contains("Line one"))
+        XCTAssertTrue(result.string.contains("Line two"))
+        XCTAssertTrue(result.string.contains("\u{2028}"))
+
+        let separatorRange = (result.string as NSString).range(of: "\u{2028}")
+        XCTAssertNotEqual(separatorRange.location, NSNotFound)
+
+        var effectiveRange = NSRange()
+        let attributes = result.attributes(at: separatorRange.location, effectiveRange: &effectiveRange)
+        XCTAssertNotNil(attributes[.font] as? UIFont)
+    }
 }
 
 private extension String {


### PR DESCRIPTION
Render hard line breaks as U+2028 inside paragraphs so TextKit preserves intra-paragraph breaks without starting new blocks.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

