### PR TITLE
feat(ios): add image rendering, theme, and attachments

### DIFF
--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Attachments/MarkdownImageAttachment.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Attachments/MarkdownImageAttachment.swift
@@ -1,0 +1,250 @@
+import UIKit
+
+final class MarkdownImageAttachment: NSTextAttachment {
+    static let originalImageCache: NSCache<NSString, UIImage> = {
+        let cache = NSCache<NSString, UIImage>()
+        cache.countLimit = 50
+        cache.totalCostLimit = 20 * 1024 * 1024
+        return cache
+    }()
+
+    private static let processedImageCache = NSCache<NSString, UIImage>()
+    private static let registry = NSMapTable<NSString, MarkdownImageAttachment>.strongToWeakObjects()
+
+    let imageURL: String
+    let isInline: Bool
+    let cachedHeight: CGFloat
+    let cachedBorderRadius: CGFloat
+
+    private var originalImage: UIImage?
+    private var loadedImage: UIImage?
+    private weak var textContainer: NSTextContainer?
+    private var lastProcessedKey: String?
+
+    static func attachment(
+        for url: String,
+        config: MarkdownStyleConfig,
+        isInline: Bool,
+        altText: String
+    ) -> MarkdownImageAttachment {
+        let key = "\(url)_\(isInline)" as NSString
+        if let existing = registry.object(forKey: key), existing.loadedImage != nil {
+            return existing
+        }
+
+        let attachment = MarkdownImageAttachment(
+            url: url,
+            config: config,
+            isInline: isInline,
+            altText: altText
+        )
+        registry.setObject(attachment, forKey: key)
+        return attachment
+    }
+
+    private init(url: String, config: MarkdownStyleConfig, isInline: Bool, altText: String) {
+        imageURL = url
+        self.isInline = isInline
+        cachedHeight = isInline
+            ? (config.inlineImage.size ?? 20)
+            : (config.image.height ?? 200)
+        cachedBorderRadius = config.image.borderRadius ?? 0
+        super.init(data: nil, ofType: nil)
+        accessibilityLabel = altText.isEmpty ? nil : altText
+        setupPlaceholder()
+        startDownloadingImage()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func attachmentBounds(
+        for textContainer: NSTextContainer?,
+        proposedLineFragment lineFragmentRect: CGRect,
+        glyphPosition position: CGPoint,
+        characterIndex charIndex: Int
+    ) -> CGRect {
+        self.textContainer = textContainer
+        let height = cachedHeight
+        let width = isInline ? height : (lineFragmentRect.width > 0 ? lineFragmentRect.width : height)
+
+        if isInline {
+            var appliedFont: UIFont?
+            if let textStorage = textStorage(from: textContainer),
+               charIndex >= 0,
+               charIndex < textStorage.length {
+                appliedFont = textStorage.attribute(.font, at: charIndex, effectiveRange: nil) as? UIFont
+            }
+
+            let verticalOffset: CGFloat
+            if let appliedFont {
+                verticalOffset = (appliedFont.capHeight - height) / 2
+            } else {
+                verticalOffset = (lineFragmentRect.height - height) / 2
+            }
+            return CGRect(x: 0, y: verticalOffset, width: width, height: height)
+        }
+
+        return CGRect(x: 0, y: 0, width: width, height: height)
+    }
+
+    override func image(
+        forBounds imageBounds: CGRect,
+        textContainer: NSTextContainer?,
+        characterIndex charIndex: Int
+    ) -> UIImage? {
+        self.textContainer = textContainer
+
+        if let originalImage, imageBounds.width > 0 {
+            bounds = imageBounds
+            processAndApplyImage(originalImage, targetWidth: imageBounds.width)
+        }
+
+        return loadedImage ?? image
+    }
+
+    private func setupPlaceholder() {
+        bounds = CGRect(x: 0, y: 0, width: cachedHeight, height: cachedHeight)
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1))
+        image = renderer.image { context in
+            UIColor.systemGray5.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+        }
+    }
+
+    private func startDownloadingImage() {
+        guard !imageURL.isEmpty else { return }
+        ImageDownloader.shared.download(url: imageURL) { [weak self] image in
+            self?.handleLoadedImage(image)
+        }
+    }
+
+    private func handleLoadedImage(_ image: UIImage?) {
+        guard let image else { return }
+        originalImage = image
+        let targetWidth = isInline ? cachedHeight : bounds.width
+        if !isInline, targetWidth <= 0 {
+            return
+        }
+        processAndApplyImage(image, targetWidth: targetWidth)
+    }
+
+    private func processAndApplyImage(_ image: UIImage, targetWidth: CGFloat) {
+        guard targetWidth > 0 else { return }
+
+        let processedKey = "\(imageURL)_w\(targetWidth)_h\(cachedHeight)_r\(cachedBorderRadius)"
+        if processedKey == lastProcessedKey { return }
+        lastProcessedKey = processedKey
+
+        if let cached = Self.processedImageCache.object(forKey: processedKey as NSString) {
+            loadedImage = cached
+            if isInline {
+                self.image = cached
+            }
+            refreshDisplay()
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
+            let processed = self.createScaledImage(
+                image,
+                targetWidth: targetWidth,
+                targetHeight: self.cachedHeight,
+                borderRadius: self.cachedBorderRadius
+            )
+
+            if let processed {
+                Self.processedImageCache.setObject(processed, forKey: processedKey as NSString)
+            }
+
+            DispatchQueue.main.async {
+                self.loadedImage = processed
+                if self.isInline {
+                    self.image = processed
+                    self.bounds = CGRect(x: 0, y: 0, width: self.cachedHeight, height: self.cachedHeight)
+                } else {
+                    self.image = image
+                }
+                self.refreshDisplay()
+            }
+        }
+    }
+
+    private func createScaledImage(
+        _ image: UIImage,
+        targetWidth: CGFloat,
+        targetHeight: CGFloat,
+        borderRadius: CGFloat
+    ) -> UIImage? {
+        let sourceWidth = image.size.width
+        let sourceHeight = image.size.height
+        guard sourceWidth > 0, sourceHeight > 0 else { return nil }
+
+        let drawingWidth: CGFloat
+        let drawingHeight: CGFloat
+
+        if isInline {
+            drawingWidth = targetWidth
+            drawingHeight = targetHeight
+        } else {
+            let aspectRatioScale = targetWidth / sourceWidth
+            drawingWidth = targetWidth
+            drawingHeight = sourceHeight * aspectRatioScale
+        }
+
+        let drawingRect = CGRect(
+            x: (targetWidth - drawingWidth) / 2,
+            y: (targetHeight - drawingHeight) / 2,
+            width: drawingWidth,
+            height: drawingHeight
+        )
+
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: targetWidth, height: targetHeight))
+        return renderer.image { _ in
+            if borderRadius > 0 {
+                let clippingRect = drawingRect.intersection(CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight))
+                UIBezierPath(roundedRect: clippingRect, cornerRadius: borderRadius).addClip()
+            }
+            image.draw(in: drawingRect)
+        }
+    }
+
+    private func refreshDisplay() {
+        guard let textContainer,
+              let textLayoutManager = textContainer.textLayoutManager,
+              let textStorage = textStorage(from: textContainer) else {
+            return
+        }
+
+        let range = findAttachmentRange(in: textStorage)
+        guard range.location != NSNotFound,
+              let contentManager = textLayoutManager.textContentManager,
+              let textRange = TextLayoutHelpers.textRange(range, in: contentManager) else {
+            return
+        }
+
+        textLayoutManager.invalidateRenderingAttributes(for: textRange)
+        textLayoutManager.invalidateLayout(for: textRange)
+    }
+
+    private func textStorage(from textContainer: NSTextContainer?) -> NSTextStorage? {
+        guard let contentStorage = textContainer?.textLayoutManager?.textContentManager as? NSTextContentStorage else {
+            return nil
+        }
+        return contentStorage.textStorage
+    }
+
+    private func findAttachmentRange(in attributedString: NSAttributedString) -> NSRange {
+        var foundRange = NSRange(location: NSNotFound, length: 0)
+        attributedString.enumerateAttribute(.attachment, in: NSRange(location: 0, length: attributedString.length)) { value, range, stop in
+            if (value as AnyObject) === self {
+                foundRange = range
+                stop.pointee = true
+            }
+        }
+        return foundRange
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RenderContext.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RenderContext.swift
@@ -4,6 +4,15 @@ enum BlockType {
     case none
     case paragraph
     case heading
+    case codeBlock
+    case blockquote
+    case orderedList
+    case unorderedList
+}
+
+enum ListType: Int {
+    case unordered = 0
+    case ordered = 1
 }
 
 struct BlockStyle {
@@ -14,18 +23,47 @@ struct BlockStyle {
 
 enum MarkdownAttribute {
     static let inlineCode = NSAttributedString.Key("EnrichedMarkdownInlineCode")
+    static let codeBlock = NSAttributedString.Key("EnrichedMarkdownCodeBlock")
+    static let blockquoteDepth = NSAttributedString.Key("EnrichedMarkdownBlockquoteDepth")
+    static let blockquoteBackgroundColor = NSAttributedString.Key("EnrichedMarkdownBlockquoteBackgroundColor")
+    static let listDepth = NSAttributedString.Key("EnrichedMarkdownListDepth")
+    static let listType = NSAttributedString.Key("EnrichedMarkdownListType")
+    static let listItemNumber = NSAttributedString.Key("EnrichedMarkdownListItemNumber")
 }
 
 final class RenderContext {
     private(set) var currentBlockType: BlockType = .none
     private(set) var currentBlockStyle: BlockStyle?
 
+    var blockquoteDepth = 0
+    var listDepth = 0
+    var listType: ListType = .unordered
+    var listItemNumber = 0
+    var rendersBlockImage = false
+
+    private static let blockSpacerTemplate: NSParagraphStyle = {
+        let style = NSMutableParagraphStyle()
+        style.minimumLineHeight = 1
+        style.maximumLineHeight = 1
+        return style
+    }()
+
     func reset() {
         currentBlockType = .none
         currentBlockStyle = nil
+        blockquoteDepth = 0
+        listDepth = 0
+        listType = .unordered
+        listItemNumber = 0
+        rendersBlockImage = false
     }
 
-    func setBlockStyle(font: UIFont, color: UIColor, blockType: BlockType = .paragraph, headingLevel: Int = 0) {
+    func setBlockStyle(
+        font: UIFont,
+        color: UIColor,
+        blockType: BlockType = .paragraph,
+        headingLevel: Int = 0
+    ) {
         currentBlockType = blockType
         currentBlockStyle = BlockStyle(font: font, color: color, headingLevel: headingLevel)
     }
@@ -47,6 +85,16 @@ final class RenderContext {
             .font: blockStyle.font,
             .foregroundColor: blockStyle.color
         ]
+    }
+
+    func spacerStyle(height: CGFloat, spacing: CGFloat = 0) -> NSMutableParagraphStyle {
+        guard let style = Self.blockSpacerTemplate.mutableCopy() as? NSMutableParagraphStyle else {
+            return NSMutableParagraphStyle()
+        }
+        style.minimumLineHeight = height
+        style.maximumLineHeight = height
+        style.paragraphSpacing = spacing
+        return style
     }
 
     static func shouldPreserveColors(_ attributes: [NSAttributedString.Key: Any]) -> Bool {

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
@@ -47,6 +47,8 @@ final class RendererFactory {
             return LineBreakRenderer()
         case .code:
             return CodeRenderer(factory: self, config: config)
+        case .image:
+            return ImageRenderer(config: config)
         default:
             return childrenOnlyRenderer
         }

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/ImageRenderer.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/ImageRenderer.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+final class ImageRenderer: NodeRenderer {
+    private let config: MarkdownStyleConfig
+
+    init(config: MarkdownStyleConfig) {
+        self.config = config
+    }
+
+    func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
+        guard let url = node.attribute("url"), !url.isEmpty else { return }
+
+        let isInline = !context.rendersBlockImage && isInlineImage(in: output)
+        let altText = extractText(from: node)
+        let attachment = MarkdownImageAttachment.attachment(
+            for: url,
+            config: config,
+            isInline: isInline,
+            altText: altText
+        )
+
+        let imageString = NSAttributedString(attachment: attachment)
+        output.append(imageString)
+    }
+
+    private func isInlineImage(in output: NSAttributedString) -> Bool {
+        guard output.length > 0 else { return false }
+        let lastChar = (output.string as NSString).character(at: output.length - 1)
+        return lastChar != 10 && lastChar != 0x200B
+    }
+
+    private func extractText(from node: MarkdownASTNode) -> String {
+        var buffer = ""
+        appendText(from: node, to: &buffer)
+        return buffer.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func appendText(from node: MarkdownASTNode, to buffer: inout String) {
+        if !node.content.isEmpty {
+            buffer.append(node.content)
+        }
+        for child in node.children {
+            appendText(from: child, to: &buffer)
+        }
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/ParagraphRenderer.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/ParagraphRenderer.swift
@@ -37,6 +37,10 @@ final class ParagraphRenderer: NodeRenderer {
             contentStart += offset
         }
 
+        if isBlockImage {
+            context.rendersBlockImage = true
+        }
+
         if isTopLevel {
             factory.renderChildren(of: node, into: output, context: context)
             context.clearBlockStyle()
@@ -46,6 +50,8 @@ final class ParagraphRenderer: NodeRenderer {
                 ParagraphStyleHelpers.ensureTrailingNewline(in: output)
             }
         }
+
+        context.rendersBlockImage = false
 
         guard output.length > start else { return }
 

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/DefaultMarkdownTheme.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/DefaultMarkdownTheme.swift
@@ -56,6 +56,14 @@ enum DefaultMarkdownTheme {
                 .fontDesign(.monospaced)
                 .foregroundStyle(Semantic.secondary)
                 .background(Semantic.quaternary)
+
+            BlockImage()
+                .height(200)
+                .borderRadius(8)
+                .marginBottom(16)
+
+            InlineImage()
+                .size(20)
         }
     }
 }

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/Elements/Image.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/Elements/Image.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+public struct BlockImage: MarkdownThemeContent {
+    public var height: CGFloat?
+    public var borderRadius: CGFloat?
+    public var marginTop: CGFloat?
+    public var marginBottom: CGFloat?
+
+    public init() {}
+
+    public func height(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.height = value
+        return copy
+    }
+
+    public func borderRadius(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.borderRadius = value
+        return copy
+    }
+
+    public func marginTop(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.marginTop = value
+        return copy
+    }
+
+    public func marginBottom(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.marginBottom = value
+        return copy
+    }
+
+    public func apply(to config: inout MarkdownStyleConfig, traitCollection: UITraitCollection) {
+        if let height { config.image.height = height }
+        if let borderRadius { config.image.borderRadius = borderRadius }
+        if let marginTop { config.image.marginTop = marginTop }
+        if let marginBottom { config.image.marginBottom = marginBottom }
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/Elements/InlineImage.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/Elements/InlineImage.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+public struct InlineImage: MarkdownThemeContent {
+    public var size: CGFloat?
+
+    public init() {}
+
+    public func size(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.size = value
+        return copy
+    }
+
+    public func apply(to config: inout MarkdownStyleConfig, traitCollection: UITraitCollection) {
+        if let size { config.inlineImage.size = size }
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
@@ -42,6 +42,44 @@ public struct ElementStyle: Equatable, Sendable {
     }
 }
 
+public struct ImageStyle: Equatable, Sendable {
+    public var height: CGFloat?
+    public var borderRadius: CGFloat?
+    public var marginTop: CGFloat?
+    public var marginBottom: CGFloat?
+
+    public init(
+        height: CGFloat? = nil,
+        borderRadius: CGFloat? = nil,
+        marginTop: CGFloat? = nil,
+        marginBottom: CGFloat? = nil
+    ) {
+        self.height = height
+        self.borderRadius = borderRadius
+        self.marginTop = marginTop
+        self.marginBottom = marginBottom
+    }
+
+    public mutating func merge(_ other: ImageStyle) {
+        if let height = other.height { self.height = height }
+        if let borderRadius = other.borderRadius { self.borderRadius = borderRadius }
+        if let marginTop = other.marginTop { self.marginTop = marginTop }
+        if let marginBottom = other.marginBottom { self.marginBottom = marginBottom }
+    }
+}
+
+public struct InlineImageStyle: Equatable, Sendable {
+    public var size: CGFloat?
+
+    public init(size: CGFloat? = nil) {
+        self.size = size
+    }
+
+    public mutating func merge(_ other: InlineImageStyle) {
+        if let size = other.size { self.size = size }
+    }
+}
+
 public struct MarkdownStyleConfig: Equatable, Sendable {
     public var paragraph: ElementStyle
     public var heading1: ElementStyle
@@ -54,6 +92,8 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
     public var strong: ElementStyle
     public var emphasis: ElementStyle
     public var code: ElementStyle
+    public var image: ImageStyle
+    public var inlineImage: InlineImageStyle
 
     public init(
         paragraph: ElementStyle = ElementStyle(),
@@ -66,7 +106,9 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         link: ElementStyle = ElementStyle(),
         strong: ElementStyle = ElementStyle(),
         emphasis: ElementStyle = ElementStyle(),
-        code: ElementStyle = ElementStyle()
+        code: ElementStyle = ElementStyle(),
+        image: ImageStyle = ImageStyle(),
+        inlineImage: InlineImageStyle = InlineImageStyle()
     ) {
         self.paragraph = paragraph
         self.heading1 = heading1
@@ -79,6 +121,8 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         self.strong = strong
         self.emphasis = emphasis
         self.code = code
+        self.image = image
+        self.inlineImage = inlineImage
     }
 
     public mutating func merge(_ other: MarkdownStyleConfig) {
@@ -93,6 +137,8 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         strong.merge(other.strong)
         emphasis.merge(other.emphasis)
         code.merge(other.code)
+        image.merge(other.image)
+        inlineImage.merge(other.inlineImage)
     }
 
     public func headingStyle(for level: Int) -> ElementStyle {

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/ImageDownloader.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/ImageDownloader.swift
@@ -1,0 +1,74 @@
+import UIKit
+
+final class ImageDownloader {
+    static let shared = ImageDownloader()
+
+    private let session: URLSession
+    private var inFlightRequests: [String: [(UIImage?) -> Void]] = [:]
+    private let lock = NSLock()
+
+    private init() {
+        let configuration = URLSessionConfiguration.default
+        configuration.urlCache = URLCache(
+            memoryCapacity: 10 * 1024 * 1024,
+            diskCapacity: 100 * 1024 * 1024
+        )
+        configuration.requestCachePolicy = .returnCacheDataElseLoad
+        configuration.timeoutIntervalForRequest = 15
+        configuration.timeoutIntervalForResource = 30
+        session = URLSession(configuration: configuration)
+    }
+
+    func download(url: String, completion: @escaping (UIImage?) -> Void) {
+        guard !url.isEmpty else {
+            completion(nil)
+            return
+        }
+
+        if let cached = MarkdownImageAttachment.originalImageCache.object(forKey: url as NSString) {
+            completion(cached)
+            return
+        }
+
+        lock.lock()
+        if var existing = inFlightRequests[url] {
+            existing.append(completion)
+            inFlightRequests[url] = existing
+            lock.unlock()
+            return
+        }
+        inFlightRequests[url] = [completion]
+        lock.unlock()
+
+        guard let requestURL = URL(string: url) else {
+            dispatchCallbacks(for: url, image: nil)
+            return
+        }
+
+        session.dataTask(with: requestURL) { [weak self] data, _, error in
+            let image = (data != nil && error == nil) ? UIImage(data: data!) : nil
+            if let image {
+                MarkdownImageAttachment.originalImageCache.setObject(
+                    image,
+                    forKey: url as NSString,
+                    cost: Self.byteCost(for: image)
+                )
+            }
+            self?.dispatchCallbacks(for: url, image: image)
+        }.resume()
+    }
+
+    private func dispatchCallbacks(for url: String, image: UIImage?) {
+        lock.lock()
+        let callbacks = inFlightRequests.removeValue(forKey: url) ?? []
+        lock.unlock()
+        DispatchQueue.main.async {
+            callbacks.forEach { $0(image) }
+        }
+    }
+
+    private static func byteCost(for image: UIImage) -> Int {
+        guard let cgImage = image.cgImage else { return 0 }
+        return cgImage.bytesPerRow * cgImage.height
+    }
+}

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/RendererTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/RendererTests.swift
@@ -391,6 +391,66 @@ final class RendererTests: XCTestCase {
         }
         XCTAssertTrue(foundBoldMonospaced)
     }
+
+
+    func testBlockImageInsertsAttachmentWithAltText() {
+        let result = MarkdownRenderer.render("![Mountain](https://example.com/img.png)", config: config)
+
+        var found = false
+        result.enumerateAttribute(.attachment, in: NSRange(location: 0, length: result.length)) { value, _, _ in
+            guard let attachment = value as? MarkdownImageAttachment else { return }
+            XCTAssertEqual(attachment.imageURL, "https://example.com/img.png")
+            XCTAssertFalse(attachment.isInline)
+            XCTAssertEqual(attachment.accessibilityLabel, "Mountain")
+            XCTAssertEqual(attachment.cachedHeight, 200)
+            found = true
+        }
+        XCTAssertTrue(found)
+    }
+
+
+    func testBlockImageAfterParagraphIsNotInline() {
+        let result = MarkdownRenderer.render(
+            "Hello world\n\n![Mountain](https://example.com/img.png)",
+            config: config
+        )
+
+        var foundBlockImage = false
+        result.enumerateAttribute(.attachment, in: NSRange(location: 0, length: result.length)) { value, _, _ in
+            guard let attachment = value as? MarkdownImageAttachment else { return }
+            XCTAssertFalse(attachment.isInline)
+            XCTAssertEqual(attachment.cachedHeight, 200)
+            foundBlockImage = true
+        }
+        XCTAssertTrue(foundBlockImage)
+    }
+
+
+    func testInlineImageUsesInlineSize() {
+        let result = MarkdownRenderer.render("Hello ![icon](https://example.com/icon.png) world", config: config)
+
+        var found = false
+        result.enumerateAttribute(.attachment, in: NSRange(location: 0, length: result.length)) { value, _, _ in
+            guard let attachment = value as? MarkdownImageAttachment else { return }
+            XCTAssertTrue(attachment.isInline)
+            XCTAssertEqual(attachment.cachedHeight, 20)
+            found = true
+        }
+        XCTAssertTrue(found)
+    }
+
+
+    func testImageWithEmptyURLIsSkipped() {
+        let result = MarkdownRenderer.render("![alt]()", config: config)
+
+        var hasAttachment = false
+        result.enumerateAttribute(.attachment, in: NSRange(location: 0, length: result.length)) { value, _, _ in
+            if value != nil {
+                hasAttachment = true
+            }
+        }
+        XCTAssertFalse(hasAttachment)
+    }
 }
 
 private extension String {


### PR DESCRIPTION
Load images asynchronously via NSTextAttachment, support inline and block layout with theme sizing, caching, and block-image margins. Code is taken mostly from RN package (after translating to swift)

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

