### PR TITLE
feat(ios): add block rendering layout infrastructure

### DIFF
--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -7,6 +7,7 @@ public struct EnrichedMarkdownText: View {
     @Environment(\.markdownThemeLayers) private var themeLayers
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.markdownLinkPressHandler) private var onLinkPress
     @StateObject private var renderStore = MarkdownRenderStore()
 
     public init(_ markdown: String) {
@@ -23,7 +24,9 @@ public struct EnrichedMarkdownText: View {
 
     public var body: some View {
         MarkdownTextViewRepresentable(
-            attributedText: renderStore.attributedText
+            attributedText: renderStore.attributedText,
+            styleConfig: styleConfig,
+            onLinkPress: onLinkPress
         )
         .fixedSize(horizontal: false, vertical: true)
         .onAppear {

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Layout/MarkdownViewportDecorator.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Layout/MarkdownViewportDecorator.swift
@@ -1,0 +1,80 @@
+import UIKit
+
+@available(iOS 16.0, *)
+final class MarkdownViewportDecorator {
+    private let decorationView: MarkdownDecorationView
+
+    init(decorationView: MarkdownDecorationView) {
+        self.decorationView = decorationView
+    }
+
+    func updateStyleConfig(_ styleConfig: MarkdownStyleConfig) {}
+
+    func setNeedsDisplay() {
+        decorationView.setNeedsDisplay()
+    }
+
+    func draw(in context: CGContext, textView: UITextView) {
+        guard let textLayoutManager = textView.textLayoutManager,
+              let textContentStorage = textLayoutManager.textContentManager as? NSTextContentStorage,
+              let textStorage = textContentStorage.textStorage,
+              textStorage.length > 0 else {
+            return
+        }
+        let contentManager: NSTextContentManager = textContentStorage
+        _ = visibleCharacterRange(textLayoutManager: textLayoutManager, contentManager: contentManager)
+    }
+
+    private func visibleCharacterRange(
+        textLayoutManager: NSTextLayoutManager,
+        contentManager: NSTextContentManager
+    ) -> NSRange {
+        var range = NSRange(location: 0, length: 0)
+        textLayoutManager.enumerateTextLayoutFragments(
+            from: textLayoutManager.documentRange.location,
+            options: []
+        ) { fragment in
+            guard let fragmentRange = TextLayoutHelpers.nsRange(fragment.rangeInElement, in: contentManager) else {
+                return true
+            }
+            if range.length == 0 {
+                range = fragmentRange
+            } else {
+                let end = max(NSMaxRange(range), NSMaxRange(fragmentRange))
+                range = NSRange(
+                    location: min(range.location, fragmentRange.location),
+                    length: end - min(range.location, fragmentRange.location)
+                )
+            }
+            return true
+        }
+        return range
+    }
+}
+
+@available(iOS 16.0, *)
+final class MarkdownDecorationView: UIView {
+    weak var textView: UITextView?
+    var viewportDecorator: MarkdownViewportDecorator?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+        contentMode = .redraw
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard let context = UIGraphicsGetCurrentContext(),
+              let textView,
+              let viewportDecorator else {
+            return
+        }
+        viewportDecorator.draw(in: context, textView: textView)
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Layout/TextLayoutHelpers.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Layout/TextLayoutHelpers.swift
@@ -1,0 +1,31 @@
+import UIKit
+
+enum TextLayoutHelpers {
+    static func nsRange(_ textRange: NSTextRange, in contentManager: NSTextContentManager) -> NSRange? {
+        let start = contentManager.offset(
+            from: contentManager.documentRange.location,
+            to: textRange.location
+        )
+        let end = contentManager.offset(
+            from: contentManager.documentRange.location,
+            to: textRange.endLocation
+        )
+        guard start != NSNotFound, end != NSNotFound, end >= start else { return nil }
+        return NSRange(location: start, length: end - start)
+    }
+
+    static func textRange(_ range: NSRange, in contentManager: NSTextContentManager) -> NSTextRange? {
+        guard let startLocation = contentManager.location(
+            contentManager.documentRange.location,
+            offsetBy: range.location
+        ),
+        let endLocation = contentManager.location(startLocation, offsetBy: range.length) else {
+            return nil
+        }
+        return NSTextRange(location: startLocation, end: endLocation)
+    }
+
+    static func rangesIntersect(_ lhs: NSRange, _ rhs: NSRange) -> Bool {
+        NSIntersectionRange(lhs, rhs).length > 0
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct MarkdownTextViewRepresentable: UIViewRepresentable {
     let attributedText: NSAttributedString
+    let styleConfig: MarkdownStyleConfig
     let onLinkPress: ((URL) -> Void)?
 
     func makeCoordinator() -> Coordinator {
@@ -12,11 +13,13 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
     func makeUIView(context: Context) -> MarkdownTextView {
         let textView = MarkdownTextView()
         textView.delegate = context.coordinator
+        textView.styleConfig = styleConfig
         return textView
     }
 
     func updateUIView(_ textView: MarkdownTextView, context: Context) {
         context.coordinator.onLinkPress = onLinkPress
+        textView.styleConfig = styleConfig
         textView.setMarkdownAttributedText(attributedText)
     }
 
@@ -50,6 +53,14 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
 }
 
 final class MarkdownTextView: UITextView {
+    var styleConfig: MarkdownStyleConfig = .baseline() {
+        didSet {
+            if #available(iOS 16.0, *) {
+                updateDecorationStyleConfig()
+            }
+        }
+    }
+
     override var intrinsicContentSize: CGSize {
         let width = bounds.width > 0 ? bounds.width : UIView.noIntrinsicMetric
         guard width != UIView.noIntrinsicMetric else {
@@ -79,11 +90,70 @@ final class MarkdownTextView: UITextView {
         dataDetectorTypes = []
         linkTextAttributes = [:]
         setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        if #available(iOS 16.0, *) {
+            setupDecoration()
+        }
     }
 
     func setMarkdownAttributedText(_ attributedText: NSAttributedString) {
         guard !(self.attributedText?.isEqual(to: attributedText) ?? false) else { return }
         self.attributedText = attributedText
         invalidateIntrinsicContentSize()
+        if #available(iOS 16.0, *) {
+            setDecorationNeedsDisplay()
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if #available(iOS 16.0, *) {
+            layoutDecorationView()
+            setDecorationNeedsDisplay()
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+private extension MarkdownTextView {
+    private static var decorationViewKey: UInt8 = 0
+    private static var viewportDecoratorKey: UInt8 = 0
+
+    var decorationView: MarkdownDecorationView {
+        if let view = objc_getAssociatedObject(self, &Self.decorationViewKey) as? MarkdownDecorationView {
+            return view
+        }
+        let view = MarkdownDecorationView()
+        objc_setAssociatedObject(self, &Self.decorationViewKey, view, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return view
+    }
+
+    var viewportDecorator: MarkdownViewportDecorator {
+        if let decorator = objc_getAssociatedObject(self, &Self.viewportDecoratorKey) as? MarkdownViewportDecorator {
+            return decorator
+        }
+        let decorator = MarkdownViewportDecorator(decorationView: decorationView)
+        objc_setAssociatedObject(self, &Self.viewportDecoratorKey, decorator, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return decorator
+    }
+
+    func setupDecoration() {
+        decorationView.textView = self
+        decorationView.viewportDecorator = viewportDecorator
+        viewportDecorator.updateStyleConfig(styleConfig)
+        insertSubview(decorationView, at: 0)
+    }
+
+    func layoutDecorationView() {
+        decorationView.frame = bounds
+    }
+
+    func updateDecorationStyleConfig() {
+        viewportDecorator.updateStyleConfig(styleConfig)
+        decorationView.setNeedsDisplay()
+    }
+
+    func setDecorationNeedsDisplay() {
+        decorationView.setNeedsDisplay()
     }
 }


### PR DESCRIPTION
Introduce TextKit 2 viewport decoration and shared RenderContext/attribute helpers for block-level spacing and layout.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

