### PR TITLE
feat(ios): add custom font support to markdown theme

### DIFF
--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/FontHelpers.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/FontHelpers.swift
@@ -2,25 +2,11 @@ import UIKit
 
 enum FontHelpers {
     static func ensureBold(_ font: UIFont?) -> UIFont? {
-        guard let font else { return nil }
-        let traits = font.fontDescriptor.symbolicTraits
-        guard !traits.contains(.traitBold) else { return font }
-
-        guard let descriptor = font.fontDescriptor.withSymbolicTraits(traits.union(.traitBold)) else {
-            return font
-        }
-        return UIFont(descriptor: descriptor, size: 0)
+        applyTrait(to: font, bold: true, italic: false)
     }
 
     static func ensureItalic(_ font: UIFont?) -> UIFont? {
-        guard let font else { return nil }
-        let traits = font.fontDescriptor.symbolicTraits
-        guard !traits.contains(.traitItalic) else { return font }
-
-        guard let descriptor = font.fontDescriptor.withSymbolicTraits(traits.union(.traitItalic)) else {
-            return font
-        }
-        return UIFont(descriptor: descriptor, size: 0)
+        applyTrait(to: font, bold: false, italic: true)
     }
 
     static func cachedFont(from blockStyle: BlockStyle?) -> UIFont? {
@@ -38,7 +24,124 @@ enum FontHelpers {
             )
         }
 
-        let weight: UIFont.Weight = font.fontDescriptor.symbolicTraits.contains(.traitBold) ? .bold : .regular
+        let weight: UIFont.Weight = hasBoldTrait(font) ? .bold : .regular
         return UIFont.monospacedSystemFont(ofSize: font.pointSize, weight: weight)
+    }
+
+    private static func applyTrait(to font: UIFont?, bold: Bool, italic: Bool) -> UIFont? {
+        guard let font else { return nil }
+
+        let wantsBold = bold || hasBoldTrait(font)
+        let wantsItalic = italic || hasItalicTrait(font)
+
+        if wantsBold == hasBoldTrait(font), wantsItalic == hasItalicTrait(font) {
+            return font
+        }
+
+        if let variant = resolveFamilyVariant(from: font, bold: wantsBold, italic: wantsItalic) {
+            return variant
+        }
+
+        if let synthesized = fontByAddingSymbolicTraits(to: font, bold: wantsBold, italic: wantsItalic) {
+            return synthesized
+        }
+
+        if wantsItalic, !hasItalicTrait(font), wantsBold {
+            if let italicFace = resolveFamilyVariant(from: font, bold: false, italic: true) {
+                return italicFace
+            }
+        }
+
+        if wantsBold, !hasBoldTrait(font), !wantsItalic,
+           let boldFace = resolveFamilyVariant(from: font, bold: true, italic: false) {
+            return boldFace
+        }
+
+        return font
+    }
+
+    private static func resolveFamilyVariant(from font: UIFont, bold: Bool, italic: Bool) -> UIFont? {
+        let size = font.pointSize
+        let faceNames = UIFont.fontNames(forFamilyName: font.familyName)
+        guard !faceNames.isEmpty else { return nil }
+
+        var bestMatch: UIFont?
+        var bestScore = Int.min
+
+        for name in faceNames {
+            guard let candidate = UIFont(name: name, size: size) else { continue }
+            guard matchesTraits(candidate, bold: bold, italic: italic) else { continue }
+
+            let score = traitMatchScore(candidate, bold: bold, italic: italic)
+            if score > bestScore {
+                bestScore = score
+                bestMatch = candidate
+            }
+        }
+
+        return bestMatch
+    }
+
+    private static func matchesTraits(_ font: UIFont, bold: Bool, italic: Bool) -> Bool {
+        if bold != hasBoldTrait(font) { return false }
+        if italic != hasItalicTrait(font) { return false }
+        return true
+    }
+
+    private static func traitMatchScore(_ font: UIFont, bold: Bool, italic: Bool) -> Int {
+        var score = 0
+        let traits = font.fontDescriptor.symbolicTraits
+        if bold, traits.contains(.traitBold) { score += 2 }
+        if italic, traits.contains(.traitItalic) { score += 2 }
+        if !bold, !traits.contains(.traitBold) { score += 1 }
+        if !italic, !traits.contains(.traitItalic) { score += 1 }
+        return score
+    }
+
+    private static func fontByAddingSymbolicTraits(to font: UIFont, bold: Bool, italic: Bool) -> UIFont? {
+        var targetTraits = font.fontDescriptor.symbolicTraits
+        if bold { targetTraits.insert(.traitBold) }
+        if italic { targetTraits.insert(.traitItalic) }
+
+        guard let descriptor = font.fontDescriptor.withSymbolicTraits(targetTraits) else {
+            return nil
+        }
+
+        let synthesized = UIFont(descriptor: descriptor, size: font.pointSize)
+
+        if bold, !hasBoldTrait(synthesized) { return nil }
+        if italic, !hasItalicTrait(synthesized) { return nil }
+
+        return synthesized
+    }
+
+    static func hasBoldTrait(_ font: UIFont) -> Bool {
+        if font.fontDescriptor.symbolicTraits.contains(.traitBold) {
+            return true
+        }
+        if let weight = fontWeight(of: font), weight >= UIFont.Weight.semibold.rawValue {
+            return true
+        }
+        return false
+    }
+
+    static func hasItalicTrait(_ font: UIFont) -> Bool {
+        if font.fontDescriptor.symbolicTraits.contains(.traitItalic) {
+            return true
+        }
+        if let slant = fontSlant(of: font), slant > 0 {
+            return true
+        }
+        return false
+    }
+
+    private static func fontWeight(of font: UIFont) -> CGFloat? {
+        let traits = font.fontDescriptor.object(forKey: .traits) as? [UIFontDescriptor.TraitKey: Any]
+        return traits?[.weight] as? CGFloat
+    }
+
+    private static func fontSlant(of font: UIFont) -> CGFloat? {
+        let traits = font.fontDescriptor.object(forKey: .traits) as? [UIFontDescriptor.TraitKey: Any]
+        return traits?[.slant] as? CGFloat
     }
 }

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/Elements/CodeBlock.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/Elements/CodeBlock.swift
@@ -28,6 +28,19 @@ public struct CodeBlock: MarkdownThemeContent {
         return copy
     }
 
+    public func fontFamily(_ name: String, size: CGFloat) -> Self {
+        var copy = self
+        copy.fontSpec = .custom(name: name, size: size)
+        return copy
+    }
+
+    public func fontSize(_ size: CGFloat, weight: Font.Weight = .regular) -> Self {
+        var copy = self
+        copy.fontSpec = .system(size: size, weight: .regular, design: .monospaced)
+        copy.fontWeight = weight
+        return copy
+    }
+
     public func foregroundStyle(_ color: Color) -> Self {
         var copy = self
         copy.foregroundColorSpec = ThemeColorModifiers.spec(from: color)

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/MarkdownThemeElement.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/MarkdownThemeElement.swift
@@ -15,13 +15,36 @@ public protocol MarkdownThemeElement: MarkdownThemeContent {
 public extension MarkdownThemeElement {
     func font(_ font: Font) -> Self {
         var copy = self
-        copy.fontSpec = ThemeResolver.font(from: font, traitCollection: .current)
+        let resolved = ThemeResolver.resolveFont(from: font, traitCollection: .current)
+        copy.fontSpec = resolved.spec
+        if let design = resolved.design {
+            copy.fontDesign = design
+        }
+        return copy
+    }
+
+    func fontFamily(_ name: String, size: CGFloat) -> Self {
+        var copy = self
+        copy.fontSpec = .custom(name: name, size: size)
+        return copy
+    }
+
+    func fontSize(_ size: CGFloat, weight: Font.Weight = .regular) -> Self {
+        var copy = self
+        copy.fontSpec = .system(size: size, weight: .regular, design: .default)
+        copy.fontWeight = weight
         return copy
     }
 
     func bold() -> Self {
         var copy = self
         copy.fontWeight = .bold
+        return copy
+    }
+
+    func fontDesign(_ design: Font.Design) -> Self {
+        var copy = self
+        copy.fontDesign = design
         return copy
     }
 

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/ThemeResolver.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/ThemeResolver.swift
@@ -1,21 +1,36 @@
+import CoreText
 import SwiftUI
 import UIKit
 
 public enum ThemeFontSpec: Equatable, Sendable {
     case textStyle(UIFont.TextStyle)
     case system(size: CGFloat, weight: UIFont.Weight, design: UIFontDescriptor.SystemDesign)
+    case custom(name: String, size: CGFloat)
 
     func resolve(traitCollection: UITraitCollection) -> UIFont {
         switch self {
+        case let .custom(name, size):
+            if let font = ThemeResolver.loadCustomFont(named: name, size: size) {
+                return font
+            }
+            return UIFont.systemFont(ofSize: size, weight: ThemeResolver.inferredWeight(from: name))
         case let .textStyle(style):
             return UIFont.preferredFont(forTextStyle: style, compatibleWith: traitCollection)
         case let .system(size, weight, design):
-            let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body, compatibleWith: traitCollection)
-                .withDesign(design)?
-                .addingAttributes([
-                    .traits: [UIFontDescriptor.TraitKey.weight: weight]
-                ]) ?? UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body, compatibleWith: traitCollection)
-            return UIFont(descriptor: descriptor, size: size)
+            switch design {
+            case .default:
+                return UIFont.systemFont(ofSize: size, weight: weight)
+            case .monospaced:
+                return UIFont.monospacedSystemFont(ofSize: size, weight: weight)
+            case .serif, .rounded:
+                let base = UIFont.systemFont(ofSize: size, weight: weight)
+                guard let descriptor = base.fontDescriptor.withDesign(design) else {
+                    return base
+                }
+                return UIFont(descriptor: descriptor, size: size)
+            default:
+                return UIFont.systemFont(ofSize: size, weight: weight)
+            }
         }
     }
 }
@@ -51,20 +66,137 @@ public enum ThemeColorSpec: Equatable, Sendable {
 }
 
 enum ThemeResolver {
+    struct ResolvedFont {
+        var spec: ThemeFontSpec?
+        var design: Font.Design?
+    }
+
+    private static let contentSizeCategories: [DynamicTypeSize: UIContentSizeCategory] = [
+        .xSmall: .extraSmall,
+        .small: .small,
+        .medium: .medium,
+        .large: .large,
+        .xLarge: .extraLarge,
+        .xxLarge: .extraExtraLarge,
+        .xxxLarge: .extraExtraExtraLarge,
+        .accessibility1: .accessibilityMedium,
+        .accessibility2: .accessibilityLarge,
+        .accessibility3: .accessibilityExtraLarge,
+        .accessibility4: .accessibilityExtraExtraLarge,
+        .accessibility5: .accessibilityExtraExtraExtraLarge
+    ]
+
+    private static let directTextStyleMappings: [(Font, UIFont.TextStyle)] = [
+        (.body, .body),
+        (.callout, .callout),
+        (.caption, .caption1),
+        (.caption2, .caption2),
+        (.footnote, .footnote),
+        (.headline, .headline),
+        (.subheadline, .subheadline),
+        (.title, .title1),
+        (.title2, .title2),
+        (.title3, .title3),
+        (.largeTitle, .largeTitle)
+    ]
+
+    private static let systemTextStylePairs: [(Font.TextStyle, UIFont.TextStyle)] = [
+        (.largeTitle, .largeTitle),
+        (.title, .title1),
+        (.title2, .title2),
+        (.title3, .title3),
+        (.headline, .headline),
+        (.subheadline, .subheadline),
+        (.body, .body),
+        (.callout, .callout),
+        (.footnote, .footnote),
+        (.caption, .caption1),
+        (.caption2, .caption2)
+    ]
+
+    static func traitCollection(
+        colorScheme: ColorScheme,
+        dynamicTypeSize: DynamicTypeSize
+    ) -> UITraitCollection {
+        let interfaceStyle: UIUserInterfaceStyle = colorScheme == .dark ? .dark : .light
+        let overrides = UITraitCollection(traitsFrom: [
+            UITraitCollection(userInterfaceStyle: interfaceStyle),
+            UITraitCollection(preferredContentSizeCategory: uiContentSizeCategory(from: dynamicTypeSize))
+        ])
+        return UITraitCollection(traitsFrom: [UITraitCollection.current, overrides])
+    }
+
+    private static func uiContentSizeCategory(from size: DynamicTypeSize) -> UIContentSizeCategory {
+        contentSizeCategories[size] ?? .large
+    }
+
+    private static var registeredBundleFontNames = Set<String>()
+
+    static func loadCustomFont(named name: String, size: CGFloat) -> UIFont? {
+        if let font = UIFont(name: name, size: size) {
+            return font
+        }
+        registerBundledFontIfNeeded(named: name)
+        return UIFont(name: name, size: size)
+    }
+
+    private static func registerBundledFontIfNeeded(named name: String) {
+        guard !registeredBundleFontNames.contains(name) else { return }
+        registeredBundleFontNames.insert(name)
+
+        let url =
+            Bundle.main.url(forResource: name, withExtension: "ttf", subdirectory: "Fonts")
+            ?? Bundle.main.url(forResource: name, withExtension: "ttf")
+            ?? Bundle.main.url(forResource: name, withExtension: "otf", subdirectory: "Fonts")
+            ?? Bundle.main.url(forResource: name, withExtension: "otf")
+        guard let url else { return }
+
+        CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+    }
+
+    static func inferredWeight(from fontName: String) -> UIFont.Weight {
+        let lower = fontName.lowercased()
+        if lower.contains("semibold") { return .semibold }
+        if lower.contains("bold") { return .bold }
+        if lower.contains("medium") { return .medium }
+        if lower.contains("light") { return .light }
+        if lower.contains("thin") { return .thin }
+        if lower.contains("black") { return .black }
+        if lower.contains("heavy") { return .heavy }
+        return .regular
+    }
+
     static func font(from font: Font, traitCollection: UITraitCollection) -> ThemeFontSpec {
-        // Map common SwiftUI text styles to UIFont.TextStyle
-        if font == .body { return .textStyle(.body) }
-        if font == .callout { return .textStyle(.callout) }
-        if font == .caption { return .textStyle(.caption1) }
-        if font == .caption2 { return .textStyle(.caption2) }
-        if font == .footnote { return .textStyle(.footnote) }
-        if font == .headline { return .textStyle(.headline) }
-        if font == .subheadline { return .textStyle(.subheadline) }
-        if font == .title { return .textStyle(.title1) }
-        if font == .title2 { return .textStyle(.title2) }
-        if font == .title3 { return .textStyle(.title3) }
-        if font == .largeTitle { return .textStyle(.largeTitle) }
-        return .textStyle(.body)
+        resolveFont(from: font, traitCollection: traitCollection).spec ?? .textStyle(.body)
+    }
+
+    static func resolveFont(from font: Font, traitCollection: UITraitCollection) -> ResolvedFont {
+        if let resolved = resolveSystemFont(from: font) {
+            return resolved
+        }
+        if let resolved = resolveDirectTextStyle(from: font) {
+            return resolved
+        }
+        return ResolvedFont(spec: .textStyle(.body), design: nil)
+    }
+
+    private static func resolveSystemFont(from font: Font) -> ResolvedFont? {
+        for design in [Font.Design.default, .monospaced, .serif, .rounded] {
+            for (swiftStyle, uiStyle) in systemTextStylePairs where font == Font.system(swiftStyle, design: design) {
+                return ResolvedFont(
+                    spec: .textStyle(uiStyle),
+                    design: design == .default ? nil : design
+                )
+            }
+        }
+        return nil
+    }
+
+    private static func resolveDirectTextStyle(from font: Font) -> ResolvedFont? {
+        for (swiftFont, uiStyle) in directTextStyleMappings where font == swiftFont {
+            return ResolvedFont(spec: .textStyle(uiStyle), design: nil)
+        }
+        return nil
     }
 
     static func color(from color: Color, traitCollection: UITraitCollection) -> ThemeColorSpec {
@@ -80,6 +212,13 @@ enum ThemeResolver {
         traitCollection: UITraitCollection
     ) -> UIFont? {
         guard let spec else { return base }
+        if case .custom = spec {
+            return applyWeightToCustomFont(
+                spec.resolve(traitCollection: traitCollection),
+                weight: weight
+            )
+        }
+
         var font = spec.resolve(traitCollection: traitCollection)
 
         if let weight {
@@ -89,12 +228,22 @@ enum ThemeResolver {
 
         if let design {
             let uiDesign = uiFontDesign(from: design)
-            if let descriptor = font.fontDescriptor.withDesign(uiDesign) {
+            if uiDesign == .monospaced {
+                let uiWeight = weight.map(uiFontWeight(from:)) ?? .regular
+                font = UIFont.monospacedSystemFont(ofSize: font.pointSize, weight: uiWeight)
+            } else if let descriptor = font.fontDescriptor.withDesign(uiDesign) {
                 font = UIFont(descriptor: descriptor, size: font.pointSize)
             }
         }
 
         return font
+    }
+
+    private static func applyWeightToCustomFont(_ font: UIFont, weight: Font.Weight?) -> UIFont {
+        guard let weight else { return font }
+        let uiWeight = uiFontWeight(from: weight)
+        guard uiWeight >= .semibold else { return font }
+        return FontHelpers.ensureBold(font) ?? font
     }
 
     private static func uiFontWeight(from weight: Font.Weight) -> UIFont.Weight {

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/RendererTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/RendererTests.swift
@@ -77,13 +77,79 @@ final class RendererTests: XCTestCase {
         result.enumerateAttribute(.font, in: NSRange(location: 0, length: result.length)) { value, range, _ in
             guard let font = value as? UIFont else { return }
             if result.string[range] == "both" {
-                let traits = font.fontDescriptor.symbolicTraits
-                XCTAssertTrue(traits.contains(.traitBold))
-                XCTAssertTrue(traits.contains(.traitItalic))
+                XCTAssertTrue(Self.fontHasBoldAndItalic(font))
                 foundBoth = true
             }
         }
         XCTAssertTrue(foundBoth)
+    }
+
+
+    private static func fontHasBoldAndItalic(_ font: UIFont) -> Bool {
+        FontHelpers.hasBoldTrait(font) && FontHelpers.hasItalicTrait(font)
+    }
+
+
+    private static var registeredMontserratFonts = false
+
+
+    private static func registerMontserratFontsIfNeeded() {
+        guard !registeredMontserratFonts else { return }
+        registeredMontserratFonts = true
+
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fontsDir = repoRoot
+            .appendingPathComponent("apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Resources/Fonts")
+
+        for name in ["Montserrat-Regular", "Montserrat-Bold", "Montserrat-Italic", "Montserrat-BoldItalic"] {
+            let url = fontsDir.appendingPathComponent("\(name).ttf")
+            CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+        }
+    }
+
+
+    func testBoldAndItalicCombinedInCustomFontListItem() {
+        Self.registerMontserratFontsIfNeeded()
+
+        var themedConfig = config!
+        var theme = MarkdownTheme {
+            List().fontFamily("Montserrat-Regular", size: 16)
+            Strong().foregroundStyle(Color(red: 17 / 255, green: 24 / 255, blue: 39 / 255))
+            Emphasis().foregroundStyle(Color(red: 75 / 255, green: 85 / 255, blue: 99 / 255))
+        }
+        theme.apply(to: &themedConfig, traitCollection: .current)
+
+        let result = MarkdownRenderer.render(
+            "- Natural water filtration and ***flood prevention***",
+            config: themedConfig
+        )
+
+        var foundItalic = false
+        result.enumerateAttributes(in: NSRange(location: 0, length: result.length)) { attrs, range, _ in
+            let substring = (result.string as NSString).substring(with: range)
+            guard substring.contains("flood prevention") else { return }
+            guard let font = attrs[.font] as? UIFont else { return }
+
+            XCTAssertEqual(font.fontName, "Montserrat-BoldItalic")
+            foundItalic = true
+        }
+        XCTAssertTrue(foundItalic)
+    }
+
+
+    func testBoldAndItalicCombinedUsesItalicFaceForCustomBoldFont() {
+        Self.registerMontserratFontsIfNeeded()
+        guard let bold = UIFont(name: "Montserrat-Bold", size: 16) else {
+            XCTFail("Montserrat-Bold not available")
+            return
+        }
+
+        XCTAssertEqual(FontHelpers.ensureItalic(bold)?.fontName, "Montserrat-BoldItalic")
     }
 
 
@@ -190,6 +256,30 @@ final class RendererTests: XCTestCase {
         let font = attributes[.font] as? UIFont
         XCTAssertNotNil(font)
         XCTAssertTrue(font!.fontDescriptor.symbolicTraits.contains(.traitBold))
+    }
+
+
+    func testCustomThemeHeadingUsesBoldFontFamily() {
+        var themedConfig = config!
+        var theme = MarkdownTheme {
+            Heading(1).fontFamily("Helvetica-Bold", size: 30)
+            Heading(2).fontFamily("Helvetica-Bold", size: 24)
+        }
+        theme.apply(to: &themedConfig, traitCollection: .current)
+
+        let result = MarkdownRenderer.render("# Title\n\n## Subtitle", config: themedConfig)
+
+        var foundBoldHeading = false
+        result.enumerateAttribute(.font, in: NSRange(location: 0, length: result.length)) { value, range, _ in
+            guard let font = value as? UIFont else { return }
+            let text = (result.string as NSString).substring(with: range)
+            guard text == "Title" || text == "Subtitle" else { return }
+            XCTAssertTrue(
+                font.fontDescriptor.symbolicTraits.contains(.traitBold) || font.fontName.localizedCaseInsensitiveContains("bold")
+            )
+            foundBoldHeading = true
+        }
+        XCTAssertTrue(foundBoldHeading)
     }
 
 

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/ThemeResolverTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/ThemeResolverTests.swift
@@ -1,0 +1,59 @@
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+final class ThemeResolverTests: XCTestCase {
+    func testCustomFontSpecResolvesRegisteredFont() {
+        let spec = ThemeFontSpec.custom(name: "Helvetica", size: 16)
+        let font = spec.resolve(traitCollection: .current)
+        XCTAssertEqual(font.pointSize, 16)
+        XCTAssertEqual(font.familyName, "Helvetica")
+    }
+
+    func testCustomFontSpecFallsBackToSystemFont() {
+        let spec = ThemeFontSpec.custom(name: "NonexistentFontFace-12345", size: 18)
+        let font = spec.resolve(traitCollection: .current)
+        XCTAssertEqual(font.pointSize, 18)
+    }
+
+    func testCustomFontFallbackInfersBoldWeightFromName() {
+        let spec = ThemeFontSpec.custom(name: "MissingMontserrat-Bold", size: 30)
+        let font = spec.resolve(traitCollection: .current)
+        XCTAssertEqual(font.pointSize, 30)
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.traitBold))
+    }
+
+    func testSystemFontSpecUsesRegularWeightAtExplicitSize() {
+        let spec = ThemeFontSpec.system(size: 30, weight: .regular, design: .default)
+        let font = spec.resolve(traitCollection: .current)
+        XCTAssertEqual(font.pointSize, 30)
+        XCTAssertFalse(font.fontDescriptor.symbolicTraits.contains(.traitBold))
+    }
+
+    func testApplyFontResolvesBoldFamilyFaceForCustomSpec() {
+        let font = ThemeResolver.applyFont(
+            spec: .custom(name: "Helvetica", size: 20),
+            weight: .bold,
+            design: .monospaced,
+            to: nil,
+            traitCollection: .current
+        )
+        XCTAssertEqual(font?.pointSize, 20)
+        XCTAssertEqual(font?.familyName, "Helvetica")
+        XCTAssertTrue(font?.fontDescriptor.symbolicTraits.contains(.traitBold) ?? false)
+        // `.fontDesign` does not rewrite a custom PostScript face into a system design.
+        XCTAssertFalse(font?.fontDescriptor.symbolicTraits.contains(.traitMonoSpace) ?? true)
+    }
+
+    func testApplyFontKeepsCustomFaceWhenWeightIsRegular() {
+        let font = ThemeResolver.applyFont(
+            spec: .custom(name: "Helvetica", size: 20),
+            weight: .regular,
+            design: nil,
+            to: nil,
+            traitCollection: .current
+        )
+        XCTAssertEqual(font?.familyName, "Helvetica")
+        XCTAssertFalse(font?.fontDescriptor.symbolicTraits.contains(.traitBold) ?? true)
+    }
+}


### PR DESCRIPTION
Resolve bold, italic, and bold-italic via named font faces when trait synthesis fails.

### What/Why?
Ads custom font support. There are 2 cases:
- The dev uses a system font. For bold/italic/whatever ios can synthesise the font and all is good.
- The dev uses a custom font. Normally in swift ui user would sent a specific ttf and for example for bold font would use "Monteserrat-Bold.ttf". This works, but what if user sets Monteserrat and then adds .bold()? Normally on swift ui it would use a regular Monteserrat. I found this confusing, so Enriched at least tries to find Monteserrat-Bold.ttf.  



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

