### PR TITLE
feat: space between list items

### DIFF
--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/Lists.stories.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/Lists.stories.tsx
@@ -108,6 +108,11 @@ const argTypes = {
     max: 48,
     step: 4,
   }),
+  itemSpacing: numberControl('markdownStyle.list.itemSpacing', {
+    min: 0,
+    max: 32,
+    step: 2,
+  }),
 };
 
 function renderList(

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/TaskList.stories.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/TaskList.stories.tsx
@@ -29,8 +29,20 @@ const NESTED_MARKDOWN = `- [x] Buy groceries
   - [ ] Serve
 - [x] Wash dishes`;
 
+type TaskListDemoControls = TaskListStyleControls & { itemSpacing: number };
+
+const taskListDemoDefaults: TaskListDemoControls = {
+  ...taskListStyledDefaults,
+  itemSpacing: 0,
+};
+
 const argTypes = {
   ...githubFlavorArgTypes('Task lists require flavor="github" (GFM).'),
+  itemSpacing: numberControl('markdownStyle.list.itemSpacing', {
+    min: 0,
+    max: 32,
+    step: 2,
+  }),
   checkedColor: {
     control: 'color',
     description: 'markdownStyle.taskList.checkedColor',
@@ -66,15 +78,19 @@ const argTypes = {
 function renderTaskList(
   title: string,
   description: string,
-  args: StoryArgs<TaskListStyleControls>
+  args: StoryArgs<TaskListDemoControls>
 ) {
-  const { controls, rest } = splitStyleControls(args, taskListStyledDefaults);
+  const { controls, rest } = splitStyleControls(args, taskListDemoDefaults);
+  const { itemSpacing, ...taskListControls } = controls;
   return (
     <EnrichedMarkdownTextStory
       title={title}
       description={description}
       {...rest}
-      style={{ taskList: toTaskListStyle(controls) }}
+      style={{
+        taskList: toTaskListStyle(taskListControls),
+        list: { itemSpacing },
+      }}
     />
   );
 }
@@ -83,13 +99,13 @@ const taskListStoryBase = {
   argTypes,
   args: {
     flavor: 'github' as const,
-    ...taskListStyledDefaults,
+    ...taskListDemoDefaults,
   },
 };
 
 export default storyMeta('Block', 'Task List');
 
-export const Default: TextStory<TaskListStyleControls> = {
+export const Default: TextStory<TaskListDemoControls> = {
   ...taskListStoryBase,
   args: {
     ...taskListStoryBase.args,
@@ -103,7 +119,7 @@ export const Default: TextStory<TaskListStyleControls> = {
     ),
 };
 
-export const Nested: TextStory<TaskListStyleControls> = {
+export const Nested: TextStory<TaskListDemoControls> = {
   ...taskListStoryBase,
   args: {
     ...taskListStoryBase.args,

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookMarkdownStyles.ts
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookMarkdownStyles.ts
@@ -258,6 +258,7 @@ export type ListStyleControls = {
   markerFontWeight: string;
   gapWidth: number;
   marginLeft: number;
+  itemSpacing: number;
 };
 
 export const listStyledDefaults: ListStyleControls = {
@@ -275,6 +276,7 @@ export const listStyledDefaults: ListStyleControls = {
   markerFontWeight: '',
   gapWidth: 8,
   marginLeft: 24,
+  itemSpacing: 0,
 };
 
 export type StrongStyleControls = {

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookStyleBuilders.ts
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookStyleBuilders.ts
@@ -228,6 +228,7 @@ export function toListStyle(
       : {}),
     gapWidth: controls.gapWidth,
     marginLeft: controls.marginLeft,
+    itemSpacing: controls.itemSpacing,
   };
 }
 

--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -304,6 +304,7 @@ function App() {
 | `markerFontWeight` | `string` | Number marker font weight |
 | `gapWidth` | `number` | Gap between marker and text |
 | `marginLeft` | `number` | Left margin for nesting |
+| `itemSpacing` | `number` | Vertical spacing between consecutive items, including nested ones (default: `0`) |
 
 ### Code Block-specific
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockStyleContext.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockStyleContext.kt
@@ -44,8 +44,6 @@ class BlockStyleContext {
   var taskItemCount = 0
   var accumulatedIndent = 0
 
-  // Buffer positions where rendered list items start; consumed by the
-  // root-level ListRenderer to insert vertical spacing between items.
   val listItemStarts = mutableListOf<Int>()
 
   private val orderedListItemNumbers = ArrayDeque<Int>()

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockStyleContext.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockStyleContext.kt
@@ -44,6 +44,10 @@ class BlockStyleContext {
   var taskItemCount = 0
   var accumulatedIndent = 0
 
+  // Buffer positions where rendered list items start; consumed by the
+  // root-level ListRenderer to insert vertical spacing between items.
+  val listItemStarts = mutableListOf<Int>()
+
   private val orderedListItemNumbers = ArrayDeque<Int>()
 
   enum class ListType { UNORDERED, ORDERED }
@@ -151,6 +155,7 @@ class BlockStyleContext {
     listItemNumber = 0
     taskItemCount = 0
     accumulatedIndent = 0
+    listItemStarts.clear()
     orderedListItemNumbers.clear()
   }
 }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/ListItemRenderer.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/ListItemRenderer.kt
@@ -76,6 +76,8 @@ class ListItemRenderer(
 
     if (builder.length == start || builder.substring(start).isBlank()) return
 
+    styleContext.listItemStarts.add(start)
+
     if (builder.last() != '\n') {
       builder.append("\n")
     }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/ListRenderer.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/ListRenderer.kt
@@ -2,7 +2,9 @@ package com.swmansion.enriched.markdown.renderer
 
 import android.text.SpannableStringBuilder
 import com.swmansion.enriched.markdown.parser.MarkdownASTNode
+import com.swmansion.enriched.markdown.spans.ListItemSpacingSpan
 import com.swmansion.enriched.markdown.spans.MarginBottomSpan
+import com.swmansion.enriched.markdown.styles.ListStyle
 import com.swmansion.enriched.markdown.utils.text.span.SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE
 import com.swmansion.enriched.markdown.utils.text.span.applyLineHeightSkippingImages
 import com.swmansion.enriched.markdown.utils.text.span.applyMarginTop
@@ -52,7 +54,7 @@ class ListRenderer(
     }
 
     if (builder.length > contentStart) {
-      applyListSpacing(builder, contentStart, entryState.previousDepth, listStyle)
+      applyListSpacing(builder, contentStart, entryState.previousDepth, listStyle, factory.blockStyleContext)
     }
   }
 
@@ -60,20 +62,50 @@ class ListRenderer(
     builder: SpannableStringBuilder,
     start: Int,
     depth: Int,
-    style: com.swmansion.enriched.markdown.styles.BaseBlockStyle,
+    style: ListStyle,
+    styleContext: BlockStyleContext,
   ) {
     // TODO: LineHeightSpan may also clip superscript/subscript glyphs that extend
     // outside the normal line bounds. A similar "skip" strategy as for images may
     // be needed here once super/subscript usage in practice is better understood.
     applyLineHeightSkippingImages(builder, start, builder.length, style.lineHeight)
 
-    // External bottom margin is only handled by the root-level list
+    // Item spacing and external bottom margin are only handled by the root-level list
     if (depth == 0) {
+      applyItemSpacing(builder, start, style.itemSpacing, styleContext)
+
       builder.append("\n")
       builder.setSpan(
         MarginBottomSpan(style.marginBottom),
         builder.length - 1,
         builder.length,
+        SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
+      )
+    }
+  }
+
+  // Inserts the vertical gap between consecutive items (including nested ones)
+  // by spanning the newline that precedes each item start. The first item of
+  // the root list gets no spacing above it.
+  private fun applyItemSpacing(
+    builder: SpannableStringBuilder,
+    start: Int,
+    itemSpacing: Float,
+    styleContext: BlockStyleContext,
+  ) {
+    if (itemSpacing <= 0f) return
+
+    val itemStarts =
+      styleContext.listItemStarts
+        .filter { it in start until builder.length }
+        .distinct()
+        .sorted()
+
+    for (itemStart in itemStarts.drop(1)) {
+      builder.setSpan(
+        ListItemSpacingSpan(itemSpacing),
+        itemStart - 1,
+        itemStart,
         SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
       )
     }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/ListItemSpacingSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/ListItemSpacingSpan.kt
@@ -1,0 +1,35 @@
+package com.swmansion.enriched.markdown.spans
+
+import android.graphics.Paint
+import android.text.Spanned
+import android.text.style.LineHeightSpan
+
+/**
+ * Adds vertical spacing between list items using LineHeightSpan.
+ *
+ * Attached over the newline that separates two items; extends only the line
+ * ending at that newline so the gap appears below the preceding item.
+ *
+ * @param spacing The spacing in pixels to add below the line (0 = no spacing)
+ */
+class ListItemSpacingSpan(
+  val spacing: Float,
+) : LineHeightSpan {
+  override fun chooseHeight(
+    text: CharSequence,
+    start: Int,
+    end: Int,
+    spanstartv: Int,
+    lineHeight: Int,
+    fm: Paint.FontMetricsInt,
+  ) {
+    // chooseHeight runs for every line of the paragraphs this span touches;
+    // only the line terminated by the spanned newline gets the extra space.
+    val spanEnd = (text as? Spanned)?.getSpanEnd(this) ?: return
+    if (end != spanEnd) return
+
+    val spacingPixels = spacing.toInt()
+    fm.descent += spacingPixels
+    fm.bottom += spacingPixels
+  }
+}

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/ListItemSpacingSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/ListItemSpacingSpan.kt
@@ -23,8 +23,6 @@ class ListItemSpacingSpan(
     lineHeight: Int,
     fm: Paint.FontMetricsInt,
   ) {
-    // chooseHeight runs for every line of the paragraphs this span touches;
-    // only the line terminated by the spanned newline gets the extra space.
     val spanEnd = (text as? Spanned)?.getSpanEnd(this) ?: return
     if (end != spanEnd) return
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/ListStyle.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/ListStyle.kt
@@ -17,6 +17,7 @@ data class ListStyle(
   val markerFontWeight: String,
   val gapWidth: Float,
   val marginLeft: Float,
+  val itemSpacing: Float,
 ) : BaseBlockStyle {
   fun effectiveMarkerWidth(naturalWidth: Float): Float = naturalWidth.coerceAtLeast(markerMinWidth)
 
@@ -40,6 +41,7 @@ data class ListStyle(
       val markerFontWeight = parser.parseString(map, "markerFontWeight", "normal")
       val gapWidth = parser.toPixelFromDIP(map.getDouble("gapWidth").toFloat())
       val marginLeft = parser.toPixelFromDIP(map.getDouble("marginLeft").toFloat())
+      val itemSpacing = parser.toPixelFromDIP(map.getDouble("itemSpacing").toFloat().coerceAtLeast(0f))
 
       return ListStyle(
         fontSize,
@@ -56,6 +58,7 @@ data class ListStyle(
         markerFontWeight,
         gapWidth,
         marginLeft,
+        itemSpacing,
       )
     }
   }

--- a/packages/react-native-enriched-markdown/ios/internals/MeasurementCache.h
+++ b/packages/react-native-enriched-markdown/ios/internals/MeasurementCache.h
@@ -116,7 +116,8 @@ template <typename StyleStruct> inline size_t computeStyleFingerprint(const Styl
   hashFields(s.blockquote.borderWidth, s.blockquote.gapWidth);
 
   hashTextLayout(s.list);
-  hashFields(s.list.bulletSize, s.list.markerMinWidth, s.list.markerFontWeight, s.list.gapWidth, s.list.marginLeft);
+  hashFields(s.list.bulletSize, s.list.markerMinWidth, s.list.markerFontWeight, s.list.gapWidth, s.list.marginLeft,
+             s.list.itemSpacing);
 
   // Code & Inlines
   hashFields(s.codeBlock.fontFamily, s.codeBlock.fontSize, s.codeBlock.fontWeight, s.codeBlock.marginTop,

--- a/packages/react-native-enriched-markdown/ios/renderer/ListRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/ListRenderer.m
@@ -6,6 +6,45 @@
 #import "RendererFactory.h"
 #import "StyleConfig.h"
 
+// Inserts the configured vertical gap between consecutive list items (including
+// nested ones) by raising paragraphSpacing on the paragraph preceding each item
+// start. The first item of the root list gets no spacing above it.
+static void applyListItemSpacing(NSMutableAttributedString *output, RenderContext *context, NSUInteger listStart,
+                                 CGFloat itemSpacing)
+{
+  if (itemSpacing <= 0)
+    return;
+
+  NSMutableIndexSet *itemStarts = [NSMutableIndexSet indexSet];
+  for (NSValue *value in context.listItemRanges) {
+    NSUInteger location = [value rangeValue].location;
+    if (location >= listStart && location < output.length) {
+      [itemStarts addIndex:location];
+    }
+  }
+  if (itemStarts.count < 2)
+    return;
+
+  NSString *string = output.string;
+  const NSUInteger firstStart = itemStarts.firstIndex;
+  [itemStarts enumerateIndexesUsingBlock:^(NSUInteger itemStart, BOOL *stop) {
+    if (itemStart == firstStart)
+      return;
+    NSRange prevParagraph = [string paragraphRangeForRange:NSMakeRange(itemStart - 1, 0)];
+    [output enumerateAttribute:NSParagraphStyleAttributeName
+                       inRange:prevParagraph
+                       options:0
+                    usingBlock:^(NSParagraphStyle *style, NSRange range, BOOL *innerStop) {
+                      if (style.paragraphSpacing >= itemSpacing)
+                        return;
+                      NSMutableParagraphStyle *updated =
+                          style ? [style mutableCopy] : [[NSMutableParagraphStyle alloc] init];
+                      updated.paragraphSpacing = itemSpacing;
+                      [output addAttribute:NSParagraphStyleAttributeName value:updated range:range];
+                    }];
+  }];
+}
+
 @implementation ListRenderer {
   BOOL _isOrdered;
 }
@@ -60,6 +99,7 @@
   [_rendererFactory renderChildrenOfNode:node into:output context:context];
 
   if (prevDepth == 0) {
+    applyListItemSpacing(output, context, startLocation, [_config listStyleItemSpacing]);
     // Apply bottom margin for root-level list
     applyBlockSpacingAfter(output, _config.listStyleMarginBottom);
   }

--- a/packages/react-native-enriched-markdown/ios/styles/StyleConfig.h
+++ b/packages/react-native-enriched-markdown/ios/styles/StyleConfig.h
@@ -278,6 +278,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setListStyleGapWidth:(CGFloat)newValue;
 - (CGFloat)listStyleMarginLeft;
 - (void)setListStyleMarginLeft:(CGFloat)newValue;
+- (CGFloat)listStyleItemSpacing;
+- (void)setListStyleItemSpacing:(CGFloat)newValue;
 - (UIFont *)listMarkerFont;
 - (UIFont *)listStyleFont;
 - (CGFloat)effectiveListGapWidth;

--- a/packages/react-native-enriched-markdown/ios/styles/StyleConfig.mm
+++ b/packages/react-native-enriched-markdown/ios/styles/StyleConfig.mm
@@ -171,6 +171,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   NSString *_listStyleMarkerFontWeight;
   CGFloat _listStyleGapWidth;
   CGFloat _listStyleMarginLeft;
+  CGFloat _listStyleItemSpacing;
   ENRMFontSlot *_listMarkerFont;
   ENRMFontSlot *_listStyleFont;
   // Code block properties
@@ -444,6 +445,7 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   copy->_listStyleMarkerFontWeight = [_listStyleMarkerFontWeight copy];
   copy->_listStyleGapWidth = _listStyleGapWidth;
   copy->_listStyleMarginLeft = _listStyleMarginLeft;
+  copy->_listStyleItemSpacing = _listStyleItemSpacing;
   copy->_codeBlockFontSize = _codeBlockFontSize;
   copy->_codeBlockFontFamily = [_codeBlockFontFamily copy];
   copy->_codeBlockFontWeight = [_codeBlockFontWeight copy];
@@ -1873,6 +1875,16 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
 - (void)setListStyleMarginLeft:(CGFloat)newValue
 {
   _listStyleMarginLeft = newValue;
+}
+
+- (CGFloat)listStyleItemSpacing
+{
+  return _listStyleItemSpacing;
+}
+
+- (void)setListStyleItemSpacing:(CGFloat)newValue
+{
+  _listStyleItemSpacing = newValue;
 }
 
 - (UIFont *)listMarkerFont

--- a/packages/react-native-enriched-markdown/ios/utils/StylePropsUtils.h
+++ b/packages/react-native-enriched-markdown/ios/utils/StylePropsUtils.h
@@ -804,6 +804,11 @@ BOOL applyMarkdownStyleToConfig(StyleConfig *config, const MarkdownStyle &newSty
     changed = YES;
   }
 
+  if (newStyle.list.itemSpacing != oldStyle.list.itemSpacing) {
+    [config setListStyleItemSpacing:newStyle.list.itemSpacing];
+    changed = YES;
+  }
+
   // ── Code Block ─────────────────────────────────────────────────────────────
 
   if (newStyle.codeBlock.fontSize != oldStyle.codeBlock.fontSize) {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
@@ -39,6 +39,7 @@ interface ListStyleInternal extends BaseBlockStyleInternal {
   markerFontWeight: string;
   gapWidth: CodegenTypes.Float;
   marginLeft: CodegenTypes.Float;
+  itemSpacing: CodegenTypes.Float;
 }
 
 interface CodeBlockStyleInternal extends BaseBlockStyleInternal {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
@@ -39,6 +39,7 @@ interface ListStyleInternal extends BaseBlockStyleInternal {
   markerFontWeight: string;
   gapWidth: CodegenTypes.Float;
   marginLeft: CodegenTypes.Float;
+  itemSpacing: CodegenTypes.Float;
 }
 
 interface CodeBlockStyleInternal extends BaseBlockStyleInternal {

--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.ts
@@ -122,6 +122,7 @@ const DEFAULT_NORMALIZED_STYLE = Object.freeze({
     markerFontWeight: '500',
     gapWidth: 12,
     marginLeft: 24,
+    itemSpacing: 0,
   },
   codeBlock: {
     fontSize: 14,

--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.web.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.web.ts
@@ -108,6 +108,7 @@ const DEFAULT_NORMALIZED_STYLE: MarkdownStyleInternal = Object.freeze({
     markerFontWeight: '500',
     gapWidth: 12,
     marginLeft: 24,
+    itemSpacing: 0,
   },
   codeBlock: {
     fontSize: 14,

--- a/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
@@ -39,6 +39,13 @@ interface ListStyle extends BaseBlockStyle {
   markerFontWeight?: string;
   gapWidth?: number;
   marginLeft?: number;
+  /**
+   * Vertical spacing between consecutive list items, including nested ones.
+   * Adds no space above the first item or below the last one — the outer
+   * edges are still controlled by `marginTop`/`marginBottom`.
+   * @default 0
+   */
+  itemSpacing?: number;
 }
 
 interface CodeBlockStyle extends BaseBlockStyle {

--- a/packages/react-native-enriched-markdown/src/types/MarkdownStyleInternal.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownStyleInternal.ts
@@ -49,6 +49,7 @@ interface ListStyleInternal extends BaseBlockStyleInternal {
   markerFontWeight: string;
   gapWidth: number;
   marginLeft: number;
+  itemSpacing: number;
 }
 
 interface CodeBlockStyleInternal extends BaseBlockStyleInternal {

--- a/packages/react-native-enriched-markdown/src/web/renderers/ListRenderers.tsx
+++ b/packages/react-native-enriched-markdown/src/web/renderers/ListRenderers.tsx
@@ -44,6 +44,7 @@ function ListItemRenderer({
   node,
   style,
   styles,
+  index,
   callbacks,
   renderChildren,
 }: RendererProps) {
@@ -85,7 +86,7 @@ function ListItemRenderer({
     : null;
 
   return (
-    <li style={listItemStyle(isTask)}>
+    <li style={listItemStyle(style, isTask, index === 0)}>
       <span style={checkedStyle}>
         {isTask && (
           <input

--- a/packages/react-native-enriched-markdown/src/web/renderers/ListRenderers.tsx
+++ b/packages/react-native-enriched-markdown/src/web/renderers/ListRenderers.tsx
@@ -86,7 +86,7 @@ function ListItemRenderer({
     : null;
 
   return (
-    <li style={listItemStyle(style, isTask, index === 0)}>
+    <li style={listItemStyle(style, isTask, (index ?? 0) === 0)}>
       <span style={checkedStyle}>
         {isTask && (
           <input

--- a/packages/react-native-enriched-markdown/src/web/renderers/index.tsx
+++ b/packages/react-native-enriched-markdown/src/web/renderers/index.tsx
@@ -35,6 +35,7 @@ export interface RenderNodeProps {
   callbacks: RendererCallbacks;
   capabilities: RenderCapabilities;
   parentType?: NodeType;
+  index?: number;
 }
 
 export function RenderNode({
@@ -44,20 +45,22 @@ export function RenderNode({
   callbacks,
   capabilities,
   parentType,
+  index,
 }: RenderNodeProps): ReactNode {
   const Renderer = RENDERERS[node.type];
   if (!Renderer) return null;
 
   const renderChildren = (childNode: ASTNode): ReactNode =>
-    childNode.children?.map((child, index) => (
+    childNode.children?.map((child, childIndex) => (
       <RenderNode
-        key={nodeKey(child, index)}
+        key={nodeKey(child, childIndex)}
         node={child}
         style={style}
         styles={styles}
         callbacks={callbacks}
         capabilities={capabilities}
         parentType={childNode.type}
+        index={childIndex}
       />
     )) ?? null;
 
@@ -67,6 +70,7 @@ export function RenderNode({
       style={style}
       styles={styles}
       parentType={parentType}
+      index={index}
       callbacks={callbacks}
       capabilities={capabilities}
       renderChildren={renderChildren}

--- a/packages/react-native-enriched-markdown/src/web/styles.ts
+++ b/packages/react-native-enriched-markdown/src/web/styles.ts
@@ -403,8 +403,17 @@ function tableStyle(style: MarkdownStyleInternal): CSSProperties {
   };
 }
 
-export function listItemStyle(isTask: boolean): CSSProperties | undefined {
-  return isTask ? { listStyle: 'none' } : undefined;
+export function listItemStyle(
+  style: MarkdownStyleInternal,
+  isTask: boolean,
+  isFirstChild: boolean
+): CSSProperties | undefined {
+  const { itemSpacing } = style.list;
+  const marginTop = !isFirstChild && itemSpacing > 0 ? itemSpacing : undefined;
+  if (isTask) {
+    return { listStyle: 'none', marginTop };
+  }
+  return marginTop !== undefined ? { marginTop } : undefined;
 }
 
 export function checkedTaskTextStyle(
@@ -548,7 +557,13 @@ export function buildStyles(style: MarkdownStyleInternal): Styles {
     h6: headingStyle(style, '6'),
     blockquote: blockquoteStyle(style),
     list: listStyle(style),
-    listNested: { ...listStyle(style), marginBottom: 0 },
+    listNested: {
+      ...listStyle(style),
+      // A nested list sits directly under its parent item's text; itemSpacing
+      // (not the list's outer margins) controls that gap, like on native.
+      marginTop: style.list.itemSpacing,
+      marginBottom: 0,
+    },
     listTask: listStyle(style, true),
     codeBlock,
     codeBlockFont: { fontFamily: codeBlock.fontFamily },

--- a/packages/react-native-enriched-markdown/src/web/styles.ts
+++ b/packages/react-native-enriched-markdown/src/web/styles.ts
@@ -561,7 +561,7 @@ export function buildStyles(style: MarkdownStyleInternal): Styles {
       ...listStyle(style),
       // A nested list sits directly under its parent item's text; itemSpacing
       // (not the list's outer margins) controls that gap, like on native.
-      marginTop: style.list.itemSpacing,
+      marginTop: Math.max(0, style.list.itemSpacing),
       marginBottom: 0,
     },
     listTask: listStyle(style, true),

--- a/packages/react-native-enriched-markdown/src/web/types.ts
+++ b/packages/react-native-enriched-markdown/src/web/types.ts
@@ -82,6 +82,8 @@ export interface RendererProps {
   style: MarkdownStyleInternal;
   styles: Styles;
   parentType?: NodeType;
+  /** Position among the parent node's children. */
+  index?: number;
   callbacks: RendererCallbacks;
   capabilities: RenderCapabilities;
   renderChildren: (node: ASTNode) => ReactNode;


### PR DESCRIPTION
### What/Why?
Closes #251

Adds a new `markdownStyle.list.itemSpacing` style option (default `0`) that inserts vertical space between list items. Applies to unordered, ordered, and task lists.

Until now there was no way to space items apart - `marginBottom`/`gap` don't work because lists are rendered as a single rich-text buffer, not individual views.

### Testing

- Storybook: `Block/Lists` (all five stories) and `Block/Task List` (Default + Nested) now have an `itemSpacing` slider (`markdownStyle.list.itemSpacing`) - drag it and watch the gaps.
- Worth checking specifically: nested lists (uniform gaps incl. parent→sublist boundary), ask lists, an item ending with a code block, and that there's no double spacing between the last item and the following block (list `marginBottom` unchanged).

#### Screenshots

| | iOS | Android |
| - | - | - |
| Default (0) | <img width="300" alt="image" src="https://github.com/user-attachments/assets/27fb9638-249f-441b-84d2-3390a7fd5920" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/d52f0c33-b592-4599-bcfb-31f5ff66067b" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/28391fd9-c724-464e-88ad-e5e266be700e" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/39fff550-69df-4243-bc83-14eab1b46707" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/44de4984-97f1-4cdc-a9b6-d4b9f71e58f5" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/bebf8e03-9028-46ba-a7f2-834b40b5b3bb" /> |
| 32 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/37a1fac6-bbf3-451a-a22a-f5b9c9b47c83" />  <img width="300" alt="image" src="https://github.com/user-attachments/assets/da44b7db-1395-4380-9d0c-06cded4303b3" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/30c67053-7d3d-4372-b9d6-690900f38a45" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/80ad0243-1000-41ed-80a7-d344505965f3" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/211709f6-edd0-47da-acd0-57dafd754ddf" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/d2a67188-8809-40cc-b5d9-b61e1646688a" /> |

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

