### PR TITLE
fix: block images overflow their line box

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
@@ -4,10 +4,9 @@ import android.text.SpannableStringBuilder
 import com.swmansion.enriched.markdown.parser.MarkdownASTNode
 import com.swmansion.enriched.markdown.spans.BlockquoteSpan
 import com.swmansion.enriched.markdown.utils.text.span.SPAN_FLAGS_CONTAINER_BACKGROUND
-import com.swmansion.enriched.markdown.utils.text.span.SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE
+import com.swmansion.enriched.markdown.utils.text.span.applyLineHeightSkippingImages
 import com.swmansion.enriched.markdown.utils.text.span.applyMarginBottom
 import com.swmansion.enriched.markdown.utils.text.span.applyMarginTop
-import com.swmansion.enriched.markdown.utils.text.span.createLineHeightSpan
 
 class BlockquoteRenderer(
   private val config: RendererConfig,
@@ -60,8 +59,9 @@ class BlockquoteRenderer(
       SPAN_FLAGS_CONTAINER_BACKGROUND,
     )
 
-    // Apply styling only to segments that are NOT nested quotes
-    applySpansExcludingNested(builder, nestedRanges, start, end, createLineHeightSpan(style.lineHeight))
+    // Apply line height only to segments that are NOT nested quotes, skipping
+    // block images so their expanded line metrics aren't re-clamped
+    applyLineHeightExcludingNested(builder, nestedRanges, start, end, style.lineHeight)
 
     // Margins are only applied by the outermost (root) quote
     if (depth == 0) {
@@ -70,22 +70,22 @@ class BlockquoteRenderer(
     }
   }
 
-  private fun applySpansExcludingNested(
+  private fun applyLineHeightExcludingNested(
     builder: SpannableStringBuilder,
     nestedRanges: List<Pair<Int, Int>>,
     start: Int,
     end: Int,
-    span: Any,
+    lineHeight: Float,
   ) {
     var currentPos = start
     for ((nestedStart, nestedEnd) in nestedRanges) {
       if (currentPos < nestedStart) {
-        builder.setSpan(span, currentPos, nestedStart, SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE)
+        applyLineHeightSkippingImages(builder, currentPos, nestedStart, lineHeight)
       }
       currentPos = nestedEnd
     }
     if (currentPos < end) {
-      builder.setSpan(span, currentPos, end, SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE)
+      applyLineHeightSkippingImages(builder, currentPos, end, lineHeight)
     }
   }
 }

--- a/packages/react-native-enriched-markdown/ios/renderer/ListItemRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/ListItemRenderer.m
@@ -132,7 +132,9 @@ NSString *const TaskIndexAttribute = @"TaskIndex";
     style.headIndent = totalIndent;
     if (lineHeightConfig > 0) {
       style.minimumLineHeight = lineHeightConfig;
-      style.maximumLineHeight = lineHeightConfig;
+      // Leave the maximum unclamped when the item holds a block image so its line
+      // can grow to the image box height (see ENRMRangeContainsBlockImage).
+      style.maximumLineHeight = ENRMRangeContainsBlockImage(output, range) ? 0 : lineHeightConfig;
     }
     NSMutableDictionary *attributesToApply = [metadata mutableCopy];
     attributesToApply[NSParagraphStyleAttributeName] = style;

--- a/packages/react-native-enriched-markdown/ios/renderer/ListItemRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/ListItemRenderer.m
@@ -132,8 +132,6 @@ NSString *const TaskIndexAttribute = @"TaskIndex";
     style.headIndent = totalIndent;
     if (lineHeightConfig > 0) {
       style.minimumLineHeight = lineHeightConfig;
-      // Leave the maximum unclamped when the item holds a block image so its line
-      // can grow to the image box height (see ENRMRangeContainsBlockImage).
       style.maximumLineHeight = ENRMRangeContainsBlockImage(output, range) ? 0 : lineHeightConfig;
     }
     NSMutableDictionary *attributesToApply = [metadata mutableCopy];

--- a/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.h
+++ b/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.h
@@ -45,6 +45,11 @@ NSUInteger applyBlockSpacingBefore(NSMutableAttributedString *output, NSUInteger
 void applyBlockSpacingAfter(NSMutableAttributedString *output, CGFloat marginBottom);
 void applyLineHeight(NSMutableAttributedString *output, NSRange range, CGFloat lineHeight);
 void applyBaselineOffset(NSMutableAttributedString *output, NSRange range);
+
+/// True when the range contains a block (non-inline) image attachment. Lines holding
+/// such attachments must not be clamped by maximumLineHeight or the image box
+/// overflows the line and paints over surrounding content.
+BOOL ENRMRangeContainsBlockImage(NSAttributedString *output, NSRange range);
 void applyTextAlignment(NSMutableAttributedString *output, NSRange range, NSTextAlignment textAlign);
 NSTextAlignment textAlignmentFromString(NSString *textAlign);
 

--- a/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
+++ b/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
@@ -282,8 +282,6 @@ void applyLineHeight(NSMutableAttributedString *output, NSRange range, CGFloat l
                   }];
 #endif
 
-  // A block image's line must grow to the image box height; keep the minimum so
-  // surrounding text lines still get the configured line height.
   BOOL hasBlockImage = ENRMRangeContainsBlockImage(output, range);
 
   NSMutableParagraphStyle *style = getOrCreateParagraphStyle(output, range.location);
@@ -374,7 +372,6 @@ void applyBaselineOffset(NSMutableAttributedString *output, NSRange range)
                     if (existingOffset != nil) {
                       return;
                     }
-                    // Keep block image attachments anchored to their baseline.
                     [output enumerateAttribute:NSAttachmentAttributeName
                                        inRange:subrange
                                        options:0

--- a/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
+++ b/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
@@ -1,5 +1,6 @@
 #import "ParagraphStyleUtils.h"
 #import "ENRMFeatureFlags.h"
+#import "ENRMImageAttachment.h"
 #import "LastElementUtils.h"
 #import <React/RCTI18nUtil.h>
 
@@ -246,6 +247,21 @@ void applyBlockSpacingAfter(NSMutableAttributedString *output, CGFloat marginBot
   [output addAttribute:NSParagraphStyleAttributeName value:spacerStyle range:NSMakeRange(spacerLocation, 1)];
 }
 
+BOOL ENRMRangeContainsBlockImage(NSAttributedString *output, NSRange range)
+{
+  __block BOOL found = NO;
+  [output enumerateAttribute:NSAttachmentAttributeName
+                     inRange:range
+                     options:0
+                  usingBlock:^(id value, __unused NSRange attrRange, BOOL *stop) {
+                    if ([value isKindOfClass:[ENRMImageAttachment class]] && !((ENRMImageAttachment *)value).isInline) {
+                      found = YES;
+                      *stop = YES;
+                    }
+                  }];
+  return found;
+}
+
 void applyLineHeight(NSMutableAttributedString *output, NSRange range, CGFloat lineHeight)
 {
   if (lineHeight <= 0) {
@@ -266,10 +282,14 @@ void applyLineHeight(NSMutableAttributedString *output, NSRange range, CGFloat l
                   }];
 #endif
 
+  // A block image's line must grow to the image box height; keep the minimum so
+  // surrounding text lines still get the configured line height.
+  BOOL hasBlockImage = ENRMRangeContainsBlockImage(output, range);
+
   NSMutableParagraphStyle *style = getOrCreateParagraphStyle(output, range.location);
 
   style.minimumLineHeight = lineHeight;
-  style.maximumLineHeight = hasMath ? 0 : lineHeight;
+  style.maximumLineHeight = (hasMath || hasBlockImage) ? 0 : lineHeight;
 
   [output addAttribute:NSParagraphStyleAttributeName value:style range:range];
 }
@@ -354,7 +374,19 @@ void applyBaselineOffset(NSMutableAttributedString *output, NSRange range)
                     if (existingOffset != nil) {
                       return;
                     }
-                    [output addAttribute:NSBaselineOffsetAttributeName value:@(baseLineOffset) range:subrange];
+                    // Keep block image attachments anchored to their baseline.
+                    [output enumerateAttribute:NSAttachmentAttributeName
+                                       inRange:subrange
+                                       options:0
+                                    usingBlock:^(id attachment, NSRange attachmentRange, BOOL *innerStop) {
+                                      if ([attachment isKindOfClass:[ENRMImageAttachment class]] &&
+                                          !((ENRMImageAttachment *)attachment).isInline) {
+                                        return;
+                                      }
+                                      [output addAttribute:NSBaselineOffsetAttributeName
+                                                     value:@(baseLineOffset)
+                                                     range:attachmentRange];
+                                    }];
                   }];
 }
 


### PR DESCRIPTION
### What/Why?
Fixes #552.

Block images are drawn at their configured box height (`markdownStyle.image.height`), but any fixed line-height clamp covering the image's line kept the line at normal text height, so the image painted over surrounding content instead of reserving its space. Standalone image paragraphs already bypassed the clamp - the bug hit every path where an image shares a range with text:

- iOS - a soft break keeps the image and the following text in one paragraph (`\u2028`), and `applyLineHeight` sets
  both `minimumLineHeight` and `maximumLineHeight` on the whole paragraph, clamping the image's line to text height (case 2 of the repro from the issue). `ListItemRenderer` and `BlockquoteRenderer` apply the same min/max clamp to their ranges (cases 5 and 6).
- Android - paragraphs and lists already use `applyLineHeightSkippingImages`, but `BlockquoteRenderer` applied a plain `LineHeightSpan` across the image, re-clamping the metrics that `ImageSpan.chooseHeight` had expanded (case 6).

### Testing
Render the issue's minimal repro markdown

#### Screenshots

| | Before | After |
| - | - | - |
| iOS | <video width="300" src="https://github.com/user-attachments/assets/22a6febd-de9e-4f0b-99be-4b16d4b810af" /> | <video width="300" src="https://github.com/user-attachments/assets/c65ca0c2-ac79-4688-a6e6-5990073dca7f" /> |
| Android | <video width="300" src="https://github.com/user-attachments/assets/0299852a-1cbf-4144-9ea0-9dced89d7fd9" /> | <video width="300" src="https://github.com/user-attachments/assets/f4144891-dae6-4dda-a1aa-f3a1ada10bc7" /> |


### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

