### PR TITLE
fix(android): crash indexoutofboundsexecption set span

### DIFF
--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
@@ -2,21 +2,39 @@ package com.swmansion.enriched.markdown.utils.text.view
 
 import android.os.Handler
 import android.os.Looper
-import android.text.Selection
 import android.text.Spannable
-import android.text.method.LinkMovementMethod
+import android.text.method.ArrowKeyMovementMethod
 import android.view.MotionEvent
 import android.view.ViewConfiguration
 import android.widget.TextView
 import com.swmansion.enriched.markdown.spans.LinkSpan
 import kotlin.math.abs
 
-class LinkLongPressMovementMethod : LinkMovementMethod() {
+/**
+ * Movement method that adds link tap / long-press handling on top of
+ * [ArrowKeyMovementMethod], the method `setTextIsSelectable` installs.
+ *
+ * This class must never mutate the buffer's Selection spans. It previously
+ * extended LinkMovementMethod, which removes the Selection on every touch that
+ * does not land on a link. That deleted the selection the platform Editor was
+ * concurrently building during a long-press gesture, so the Editor observed
+ * getSelectionStart()/getSelectionEnd() == -1 mid-gesture. AOSP tolerates that
+ * state, but Samsung's One UI Editor caches the offsets during the gesture and
+ * replays them after select-word via semSetSelection ->
+ * Selection.setSelection(spannable, -1, -1), crashing with
+ * "IndexOutOfBoundsException: setSpan (-1 ... -1) starts before 0".
+ * Link clicks are therefore dispatched from touch offsets here instead of
+ * relying on LinkMovementMethod's selection-based implementation, and
+ * [ArrowKeyMovementMethod] keeps text selection behavior identical to a plain
+ * selectable TextView.
+ */
+class LinkLongPressMovementMethod : ArrowKeyMovementMethod() {
   private val handler = Handler(Looper.getMainLooper())
   private var longPressRunnable: Runnable? = null
 
   private var startX = 0f
   private var startY = 0f
+  private var pressedLink: LinkSpan? = null
 
   var isLinkTouchActive: Boolean = false
     private set
@@ -31,9 +49,9 @@ class LinkLongPressMovementMethod : LinkMovementMethod() {
         startX = event.x
         startY = event.y
 
-        val span = findLinkSpan(widget, buffer, event)
-        isLinkTouchActive = span != null
-        span?.let { scheduleLongPress(widget, it) }
+        pressedLink = findLinkSpan(widget, buffer, event)
+        isLinkTouchActive = pressedLink != null
+        pressedLink?.let { scheduleLongPress(widget, it) }
       }
 
       MotionEvent.ACTION_MOVE -> {
@@ -43,25 +61,33 @@ class LinkLongPressMovementMethod : LinkMovementMethod() {
         ) {
           cancelLongPress()
           isLinkTouchActive = false
+          pressedLink = null
         }
       }
 
-      MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+      MotionEvent.ACTION_UP -> {
+        cancelLongPress()
+        val tappedLink = pressedLink
+        isLinkTouchActive = false
+        pressedLink = null
+
+        // LinkSpan.onClick itself swallows the click that follows a completed
+        // long-press (and resets its internal flag), so it is always invoked
+        // for a tap that started and ended on the same link.
+        if (tappedLink != null && findLinkSpan(widget, buffer, event) === tappedLink) {
+          tappedLink.onClick(widget)
+          return true
+        }
+      }
+
+      MotionEvent.ACTION_CANCEL -> {
         cancelLongPress()
         isLinkTouchActive = false
-        if (widget.hasSelection()) {
-          Selection.removeSelection(buffer)
-        }
+        pressedLink = null
       }
     }
 
-    val result = super.onTouchEvent(widget, buffer, event)
-
-    if (event.action == MotionEvent.ACTION_DOWN) {
-      Selection.removeSelection(buffer)
-    }
-
-    return result
+    return super.onTouchEvent(widget, buffer, event)
   }
 
   private fun scheduleLongPress(
@@ -72,9 +98,6 @@ class LinkLongPressMovementMethod : LinkMovementMethod() {
 
     longPressRunnable =
       Runnable {
-        if (widget.hasSelection()) {
-          Selection.removeSelection(widget.text as Spannable)
-        }
         if (span.onLongClick(widget)) {
           widget.cancelLongPress()
         }

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
@@ -38,6 +38,7 @@ class LinkLongPressMovementMethod : ArrowKeyMovementMethod() {
 
   var isLinkTouchActive: Boolean = false
     private set
+  private var isTouchWithinTextBounds: Boolean = true
 
   override fun onTouchEvent(
     widget: TextView,
@@ -51,6 +52,7 @@ class LinkLongPressMovementMethod : ArrowKeyMovementMethod() {
 
         pressedLink = findLinkSpan(widget, buffer, event)
         isLinkTouchActive = pressedLink != null
+        isTouchWithinTextBounds = charOffsetAt(widget, event) != null
         pressedLink?.let { scheduleLongPress(widget, it) }
       }
 
@@ -87,6 +89,10 @@ class LinkLongPressMovementMethod : ArrowKeyMovementMethod() {
       }
     }
 
+    if (!isTouchWithinTextBounds) {
+      return false
+    }
+
     return super.onTouchEvent(widget, buffer, event)
   }
 
@@ -116,10 +122,21 @@ class LinkLongPressMovementMethod : ArrowKeyMovementMethod() {
     widget: TextView,
     event: MotionEvent,
   ): Int? {
-    val x = event.x.toInt() - widget.totalPaddingLeft + widget.scrollX
-    val y = event.y.toInt() - widget.totalPaddingTop + widget.scrollY
+    val x = event.x - widget.totalPaddingLeft + widget.scrollX
+    val y = event.y - widget.totalPaddingTop + widget.scrollY
     val layout = widget.layout ?: return null
-    return layout.getOffsetForHorizontal(layout.getLineForVertical(y), x.toFloat())
+
+    if (y < 0f || y > layout.height) {
+      return null
+    }
+
+    val line = layout.getLineForVertical(y.toInt())
+
+    if (x < layout.getLineLeft(line) || x > layout.getLineRight(line)) {
+      return null
+    }
+
+    return layout.getOffsetForHorizontal(line, x)
   }
 
   private fun findLinkSpan(

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
@@ -12,21 +12,12 @@ import kotlin.math.abs
 
 /**
  * Movement method that adds link tap / long-press handling on top of
- * [ArrowKeyMovementMethod], the method `setTextIsSelectable` installs.
+ * [ArrowKeyMovementMethod], the method [setTextIsSelectable] installs.
  *
- * This class must never mutate the buffer's Selection spans. It previously
- * extended LinkMovementMethod, which removes the Selection on every touch that
- * does not land on a link. That deleted the selection the platform Editor was
- * concurrently building during a long-press gesture, so the Editor observed
- * getSelectionStart()/getSelectionEnd() == -1 mid-gesture. AOSP tolerates that
- * state, but Samsung's One UI Editor caches the offsets during the gesture and
- * replays them after select-word via semSetSelection ->
- * Selection.setSelection(spannable, -1, -1), crashing with
- * "IndexOutOfBoundsException: setSpan (-1 ... -1) starts before 0".
- * Link clicks are therefore dispatched from touch offsets here instead of
- * relying on LinkMovementMethod's selection-based implementation, and
- * [ArrowKeyMovementMethod] keeps text selection behavior identical to a plain
- * selectable TextView.
+ * Must never mutate the buffer's Selection spans — the platform Editor
+ * manages them during long-press gestures, and removing or overwriting
+ * them mid-gesture crashes on some OEM skins.
+ * See: https://github.com/software-mansion/react-native-enriched-markdown/issues/580
  */
 class LinkLongPressMovementMethod : ArrowKeyMovementMethod() {
   private val handler = Handler(Looper.getMainLooper())

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
@@ -2,9 +2,8 @@ package com.swmansion.enriched.markdown.utils.text.view
 
 import android.os.Handler
 import android.os.Looper
-import android.text.Selection
 import android.text.Spannable
-import android.text.method.LinkMovementMethod
+import android.text.method.ArrowKeyMovementMethod
 import android.view.MotionEvent
 import android.view.ViewConfiguration
 import android.widget.TextView
@@ -13,12 +12,31 @@ import com.swmansion.enriched.markdown.spans.SpoilerSpan
 import com.swmansion.enriched.markdown.spoiler.SpoilerCapable
 import kotlin.math.abs
 
-class LinkLongPressMovementMethod : LinkMovementMethod() {
+/**
+ * Movement method that adds link tap / long-press and spoiler tap handling on
+ * top of [ArrowKeyMovementMethod], the method `setTextIsSelectable` installs.
+ *
+ * This class must never mutate the buffer's Selection spans. It previously
+ * extended LinkMovementMethod, which removes the Selection on every touch that
+ * does not land on a link. That deleted the selection the platform Editor was
+ * concurrently building during a long-press gesture, so the Editor observed
+ * getSelectionStart()/getSelectionEnd() == -1 mid-gesture. AOSP tolerates that
+ * state, but Samsung's One UI Editor caches the offsets during the gesture and
+ * replays them after select-word via semSetSelection ->
+ * Selection.setSelection(spannable, -1, -1), crashing with
+ * "IndexOutOfBoundsException: setSpan (-1 ... -1) starts before 0".
+ * Link clicks are therefore dispatched from touch offsets here instead of
+ * relying on LinkMovementMethod's selection-based implementation, and
+ * [ArrowKeyMovementMethod] keeps text selection behavior identical to a plain
+ * selectable TextView.
+ */
+class LinkLongPressMovementMethod : ArrowKeyMovementMethod() {
   private val handler = Handler(Looper.getMainLooper())
   private var longPressRunnable: Runnable? = null
 
   private var startX = 0f
   private var startY = 0f
+  private var pressedLink: LinkSpan? = null
 
   var isLinkTouchActive: Boolean = false
     private set
@@ -34,10 +52,10 @@ class LinkLongPressMovementMethod : LinkMovementMethod() {
         startX = event.x
         startY = event.y
 
-        val span = findLinkSpan(widget, buffer, event)
-        isLinkTouchActive = span != null
+        pressedLink = findLinkSpan(widget, buffer, event)
+        isLinkTouchActive = pressedLink != null
         isTouchWithinTextBounds = charOffsetAt(widget, event) != null
-        span?.let { scheduleLongPress(widget, it) }
+        pressedLink?.let { scheduleLongPress(widget, it) }
       }
 
       MotionEvent.ACTION_MOVE -> {
@@ -47,17 +65,25 @@ class LinkLongPressMovementMethod : LinkMovementMethod() {
         ) {
           cancelLongPress()
           isLinkTouchActive = false
+          pressedLink = null
         }
       }
 
       MotionEvent.ACTION_UP -> {
         cancelLongPress()
+        val tappedLink = pressedLink
         isLinkTouchActive = false
-        if (widget.hasSelection()) {
-          Selection.removeSelection(buffer)
-        }
+        pressedLink = null
+
         if (handleSpoilerTap(widget, buffer, event)) {
-          Selection.removeSelection(buffer)
+          return true
+        }
+
+        // LinkSpan.onClick itself swallows the click that follows a completed
+        // long-press (and resets its internal flag), so it is always invoked
+        // for a tap that started and ended on the same link.
+        if (tappedLink != null && findLinkSpan(widget, buffer, event) === tappedLink) {
+          tappedLink.onClick(widget)
           return true
         }
       }
@@ -65,31 +91,19 @@ class LinkLongPressMovementMethod : LinkMovementMethod() {
       MotionEvent.ACTION_CANCEL -> {
         cancelLongPress()
         isLinkTouchActive = false
-        if (widget.hasSelection()) {
-          Selection.removeSelection(buffer)
-        }
+        pressedLink = null
       }
     }
 
-    // LinkMovementMethod.onTouchEvent does its own getOffsetForHorizontal
-    // without bounds checking, so it would click the nearest link even for
-    // taps in empty space past the end of a line. Skip the super call when
-    // the ACTION_DOWN landed outside actual text content so the touch falls
-    // through to the parent (e.g. RNGH Pressable).
+    // getOffsetForHorizontal snaps to the nearest character, so without this
+    // guard taps in empty space past the end of a line would still be treated
+    // as text touches. Let them fall through to the parent (e.g. RNGH
+    // Pressable) instead.
     if (!isTouchWithinTextBounds) {
       return false
     }
 
-    val result = super.onTouchEvent(widget, buffer, event)
-
-    // LinkMovementMethod sets a Selection highlight around the link on ACTION_DOWN,
-    // which causes a visible selection color on the link text while pressed.
-    // We remove that selection immediately so the user never sees it.
-    if (event.action == MotionEvent.ACTION_DOWN) {
-      Selection.removeSelection(buffer)
-    }
-
-    return result
+    return super.onTouchEvent(widget, buffer, event)
   }
 
   private fun scheduleLongPress(
@@ -100,9 +114,6 @@ class LinkLongPressMovementMethod : LinkMovementMethod() {
 
     longPressRunnable =
       Runnable {
-        if (widget.hasSelection()) {
-          Selection.removeSelection(widget.text as Spannable)
-        }
         // Execute the long click logic on the span
         if (span.onLongClick(widget)) {
           // If consumed, cancel the system's own long-press logic (like context menus)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
@@ -14,21 +14,12 @@ import kotlin.math.abs
 
 /**
  * Movement method that adds link tap / long-press and spoiler tap handling on
- * top of [ArrowKeyMovementMethod], the method `setTextIsSelectable` installs.
+ * top of [ArrowKeyMovementMethod], the method [setTextIsSelectable] installs.
  *
- * This class must never mutate the buffer's Selection spans. It previously
- * extended LinkMovementMethod, which removes the Selection on every touch that
- * does not land on a link. That deleted the selection the platform Editor was
- * concurrently building during a long-press gesture, so the Editor observed
- * getSelectionStart()/getSelectionEnd() == -1 mid-gesture. AOSP tolerates that
- * state, but Samsung's One UI Editor caches the offsets during the gesture and
- * replays them after select-word via semSetSelection ->
- * Selection.setSelection(spannable, -1, -1), crashing with
- * "IndexOutOfBoundsException: setSpan (-1 ... -1) starts before 0".
- * Link clicks are therefore dispatched from touch offsets here instead of
- * relying on LinkMovementMethod's selection-based implementation, and
- * [ArrowKeyMovementMethod] keeps text selection behavior identical to a plain
- * selectable TextView.
+ * Must never mutate the buffer's Selection spans — the platform Editor
+ * manages them during long-press gestures, and removing or overwriting
+ * them mid-gesture crashes on some OEM skins.
+ * See: https://github.com/software-mansion/react-native-enriched-markdown/issues/580
  */
 class LinkLongPressMovementMethod : ArrowKeyMovementMethod() {
   private val handler = Handler(Looper.getMainLooper())


### PR DESCRIPTION
### What/Why?

Fixes #580

Long-pressing an `EnrichedMarkdownText` (commonmark flavor, `selectable` default) crashes on
Samsung / One UI devices with:

```
java.lang.IndexOutOfBoundsException: setSpan (-1 ... -1) starts before 0
  at android.text.Selection.setSelection(...)
  at android.widget.TextView.semSetSelection(...)
```

##### Root cause. 
The component enables `setTextIsSelectable(true)` but installed a `LinkMovementMethod`-based movement method, and the two fight over the buffer's `Selection` spans. `LinkLongPressMovementMethod` removed the Selection on every `ACTION_DOWN` (and on UP/CANCEL, plus `LinkMovementMethod`'s own removal for any non-link touch), while the platform `Editor` - which processes each touch event *before* the movement method - was concurrently running its long-press word-selection machinery. Instrumentation on a stock emulator showed
`getSelectionStart()/getSelectionEnd()` returning `(-1, -1)` for the entire first half of every long-press gesture. AOSP tolerates that state; Samsung's One UI Editor caches the offsets mid-gesture and replays them after select-word via `semSetSelection` → `Selection.setSelection(spannable, -1, -1)` → crash. Replaying the cached offsets the way One UI
does reproduces the byte-identical exception on a stock emulator.

##### Fix.
`LinkLongPressMovementMethod` now extends `ArrowKeyMovementMethod` (the method `setTextIsSelectable` installs natively) and never mutates Selection spans. Link taps are dispatched from touch offsets: the pressed `LinkSpan` is recorded on `ACTION_DOWN` and `onClick` fires on `ACTION_UP` when the gesture stayed on the same span. Long-press scheduling, touch-slop cancellation, `isLinkTouchActive` (RNGH interop), spoiler taps, and the empty-space fall-through are unchanged. The same fix is ported to the copy in `packages/android-enriched-markdown/ui`.

###### Note
keyboard/d-pad traversal between links (a `LinkMovementMethod` feature) is not carried over; screen-reader link access is unaffected (handled by `accessibilityHelper`).

### Testing

> Repro setup (both paths): the reported crash is in the commonmark-flavor native view, and the example screens use `flavor="github"` (a different native view), so change the Playground preview to `flavor="commonmark"` (or remove the `flavor` prop) first. Then type `some **markdown** text` into the input so the preview renders it.

#### On a Samsung device (real crash, One UI) - NOT TESTED

1. Build the example app APK and install it (locally `yarn react-native-example android`, or upload the APK to a Remote Test Lab session - pick an Android 13 / One UI device).
2. In the Playground preview, **long-press a word and drag your finger slightly while holding**.
3. **Before this PR:** the app crashes with `IndexOutOfBoundsException: setSpan (-1 ... -1) starts before 0` (visible in logcat). **After this PR:** the word is selected normally with handles and the selection menu.

#### Without a Samsung device (any emulator - verifies the root cause and the fix)

The crash is Samsung-only, but the state that causes it is created by our code and is observable
anywhere. Add temporary logging around `super.onTouchEvent` in `EnrichedMarkdownText.onTouchEvent`:

```kotlin
Log.d("SelDebug", "${MotionEvent.actionToString(event.action)} BEFORE: $selectionStart..$selectionEnd")
val result = super.onTouchEvent(event)
Log.d("SelDebug", "${MotionEvent.actionToString(event.action)} AFTER:  $selectionStart..$selectionEnd")
```

1. Run the app, long-press a word in the preview while watching `adb logcat -s SelDebug`.
2. **Before this PR:** `ACTION_DOWN` flips the offsets to `-1..-1` and they stay there for every
   `ACTION_MOVE` until the long-press timeout selects the word — this is the invalid state
   Samsung's Editor caches and later feeds into `semSetSelection(-1, -1)`.
   **After this PR:** the offsets never become -1 at any point in the gesture; they keep their
   previous value until the long-press sets the word range.
3. (Optional, exact-crash proof) Replay the cached offsets the way One UI does — cache
   `selectionStart/End` after `super` on `ACTION_DOWN`, and on a later `ACTION_MOVE` where the
   buffer has a valid selection, call
   `Selection.setSelection(text as Spannable, cachedStart, cachedEnd)`. Before this PR a single
   long-press throws the byte-identical `setSpan (-1 ... -1)` exception on a stock emulator;
   after this PR the replay never fires because the cached offsets are never -1.

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)