### PR TITLE
feat: on key press support

### DIFF
--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/EnrichedMarkdownTextInputStory.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/EnrichedMarkdownTextInputStory.tsx
@@ -65,6 +65,74 @@ export function EnrichedMarkdownTextInputStory({
   );
 }
 
+const MAX_RECENT_KEYS = 12;
+
+export function KeyPressStory({
+  title,
+  description,
+  onKeyPress,
+}: {
+  title: string;
+  description: string;
+  onKeyPress?: EnrichedMarkdownTextInputProps['onKeyPress'];
+}) {
+  const inputRef = useRef<EnrichedMarkdownTextInputInstance>(null);
+  const [state, setState] = useState<StyleState | null>(null);
+  const [hasSelection, setHasSelection] = useState(false);
+  const [recentKeys, setRecentKeys] = useState<string[]>([]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.description}>{description}</Text>
+
+      <View style={styles.block}>
+        <Text style={styles.label}>Input</Text>
+        <View style={styles.editorContainer}>
+          <EnrichedMarkdownTextInput
+            ref={inputRef}
+            placeholder="Type to see key presses…"
+            placeholderTextColor="#9CA3AF"
+            style={styles.input}
+            onChangeState={setState}
+            onChangeSelection={(sel) => setHasSelection(sel.start !== sel.end)}
+            onKeyPress={(e) => {
+              const { key } = e.nativeEvent;
+              setRecentKeys((prev) => [key, ...prev].slice(0, MAX_RECENT_KEYS));
+              onKeyPress?.(e);
+            }}
+          />
+          <FormattingToolbar
+            state={state}
+            inputRef={inputRef}
+            hasSelection={hasSelection}
+          />
+        </View>
+      </View>
+
+      <View style={styles.block}>
+        <Text style={styles.label}>Last keys (newest first)</Text>
+        {recentKeys.length === 0 ? (
+          <Text style={styles.description}>No keys pressed yet</Text>
+        ) : (
+          <View style={styles.keyRow}>
+            {recentKeys.map((key, index) => (
+              <View
+                key={`${index}-${key}`}
+                style={[styles.keyChip, index === 0 && styles.keyChipLatest]}
+              >
+                <Text style={styles.keyChipText}>
+                  {key === ' ' ? 'Space' : key}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
+      </View>
+    </ScrollView>
+  );
+}
+
 export const DEFAULT_MENTION_USERS = [
   { id: 'u_1', name: 'Alice', url: 'user://u_1' },
   { id: 'u_2', name: 'Bob', url: 'user://u_2' },
@@ -265,6 +333,28 @@ const styles = StyleSheet.create({
   },
   suggestionText: {
     fontSize: 14,
+    color: '#111827',
+  },
+  keyRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  keyChip: {
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+    borderRadius: 6,
+    backgroundColor: '#F3F4F6',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  keyChipLatest: {
+    borderColor: '#2563EB',
+    backgroundColor: '#DBEAFE',
+  },
+  keyChipText: {
+    fontSize: 14,
+    fontWeight: '600',
     color: '#111827',
   },
 });

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/props/KeyPress.stories.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/props/KeyPress.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { KeyPressStory } from '../EnrichedMarkdownTextInputStory';
+import { storyMeta } from '../shared/storyMeta';
+import type { InputStory } from '../shared/storyTypes';
+
+export default storyMeta('Props', 'Key Press');
+
+export const Default: InputStory = {
+  render: (args) => (
+    <KeyPressStory
+      title="onKeyPress"
+      description="Fires on every keystroke before it is applied to the content — nativeEvent.key is the pressed character, or Backspace / Enter. The latest keys show up below the input; every press is also logged to the Actions tab."
+      onKeyPress={args.onKeyPress}
+    />
+  ),
+};

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/shared/storyMeta.ts
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/shared/storyMeta.ts
@@ -6,6 +6,7 @@ export type InputStoryCategory = 'Inline' | 'Props' | 'Methods';
 export const inputActionArgTypes = {
   onChangeMarkdown: { action: 'onChangeMarkdown' },
   onChangeText: { action: 'onChangeText' },
+  onKeyPress: { action: 'onKeyPress' },
   onFocus: { action: 'onFocus' },
   onBlur: { action: 'onBlur' },
   onLinkDetected: { action: 'onLinkDetected' },

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -655,6 +655,24 @@ interface StyleState {
 }
 ```
 
+### `onKeyPress`
+
+Fires on every keystroke, before the change is applied to the input content — mirroring React Native TextInput's `onKeyPress`. `nativeEvent.key` is the pressed character, or a named key: `Backspace`, `Enter`, `Tab` (iOS additionally reports `Escape`). On Android the key reported for soft keyboard input may lag actual typing when autocomplete suggestions are involved. Paste operations do not fire the event.
+
+| Type                                                          | Default Value | Platform |
+| ------------------------------------------------------------- | ------------- | -------- |
+| `(e: NativeSyntheticEvent<{ key: string }>) => void`          | -             | Both     |
+
+**Example:**
+
+```tsx
+<EnrichedMarkdownTextInput
+  onKeyPress={({ nativeEvent: { key } }) => {
+    console.log('Pressed key:', key);
+  }}
+/>
+```
+
 ### `onCaretRectChange`
 
 Fires when the caret's pixel position changes (typing, selection change, content reflow). The rect is relative to the input's top-left corner, in density-independent pixels. The native side diffs the rect before emitting, so redundant events are suppressed.

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -195,6 +195,7 @@ You can find some examples in the [usage section](#usage) or in the example app.
 - [onChangeText](API_REFERENCE.md#onchangetext) - returns the input's plain text (without Markdown syntax) anytime it changes.
 - [onChangeMarkdown](API_REFERENCE.md#onchangemarkdown) - returns the Markdown string parsed from current input text and styles anytime it would change. As parsing the Markdown on each input change can be expensive, not assigning the event's callback will skip the serialization for better performance.
 - [onChangeSelection](API_REFERENCE.md#onchangeselection) - returns `{ start, end }` of the current selection, useful for working with [links](#links).
+- [onKeyPress](API_REFERENCE.md#onkeypress) - returns `{ nativeEvent: { key } }` for every keystroke before it is applied to the content, mirroring React Native TextInput's `onKeyPress`.
 
 ## RTL Support
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
@@ -25,6 +25,7 @@ import com.swmansion.enriched.markdown.input.events.OnContextMenuItemPressEvent
 import com.swmansion.enriched.markdown.input.events.OnEndMentionEvent
 import com.swmansion.enriched.markdown.input.events.OnInputBlurEvent
 import com.swmansion.enriched.markdown.input.events.OnInputFocusEvent
+import com.swmansion.enriched.markdown.input.events.OnInputKeyPressEvent
 import com.swmansion.enriched.markdown.input.events.OnLinkDetectedEvent
 import com.swmansion.enriched.markdown.input.events.OnRequestCaretRectResultEvent
 import com.swmansion.enriched.markdown.input.events.OnRequestMarkdownResultEvent
@@ -91,6 +92,7 @@ class EnrichedMarkdownTextInputManager :
       OnChangeMarkdownEvent.EVENT_NAME,
       OnChangeSelectionEvent.EVENT_NAME,
       OnChangeStateEvent.EVENT_NAME,
+      OnInputKeyPressEvent.EVENT_NAME,
       OnRequestMarkdownResultEvent.EVENT_NAME,
       OnRequestCaretRectResultEvent.EVENT_NAME,
       OnCaretRectChangeEvent.EVENT_NAME,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -167,10 +167,20 @@ class EnrichedMarkdownTextInputView(
     return InputConnectionWrapper(base, this)
   }
 
+  // Plain Tab is consumed before the platform's focus navigation so it inserts
+  // a tab character and emits onKeyPress, matching iOS. Shift/Ctrl+Tab still
+  // navigate focus.
   override fun onKeyDown(
     keyCode: Int,
     event: KeyEvent?,
   ): Boolean {
+    if (keyCode == KeyEvent.KEYCODE_TAB && event?.hasNoModifiers() != false) {
+      eventEmitter.emitKeyPress("Tab")
+      val start = minOf(selectionStart, selectionEnd).coerceAtLeast(0)
+      val end = maxOf(selectionStart, selectionEnd).coerceAtLeast(0)
+      text?.replace(start, end, "\t")
+      return true
+    }
     if (keyCode == KeyEvent.KEYCODE_DEL && deleteLinkBeforeCursor()) {
       return true
     }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/InputConnectionWrapper.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/InputConnectionWrapper.kt
@@ -68,10 +68,19 @@ class InputConnectionWrapper(
       if (cursorMovedBackwardsOrAtBeginningOfInput || (!noPreviousSelection && cursorDidNotMove)) {
         BACKSPACE_KEY_VALUE
       } else {
-        editText.text?.get(currentSelectionStart - 1).toString()
+        codePointBeforeCursor(currentSelectionStart)
       }
-    dispatchKeyPressOrEnqueue(key)
+    if (key.isNotEmpty()) {
+      dispatchKeyPressOrEnqueue(key)
+    }
     return consumed
+  }
+
+  private fun codePointBeforeCursor(cursor: Int): String {
+    val content = editText.text ?: return ""
+    val end = cursor.coerceAtMost(content.length)
+    if (end < 1) return ""
+    return String(Character.toChars(Character.codePointBefore(content, end)))
   }
 
   override fun commitText(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/InputConnectionWrapper.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/InputConnectionWrapper.kt
@@ -5,12 +5,35 @@ import android.view.inputmethod.InputConnection
 import com.swmansion.enriched.markdown.input.EnrichedMarkdownTextInputView
 import android.view.inputmethod.InputConnectionWrapper as AndroidInputConnectionWrapper
 
+/**
+ * Intercepts IME traffic for two purposes: atomic link deletion (a backspace
+ * right after a link removes the whole link) and the `onKeyPress` event.
+ *
+ * Key derivation mirrors React Native's ReactEditTextInputConnectionWrapper.
+ * Soft keyboards don't report discrete key presses; the pressed key is inferred
+ * from InputConnection side effects:
+ * - [setComposingText] receives the whole composing region, not a one-character
+ *   diff, so the key is derived from cursor movement: a cursor that moved
+ *   backwards (or stayed put while collapsing a selection) means "Backspace",
+ *   otherwise the key is the character left of the cursor.
+ * - [commitText] with an empty string means "Backspace"; short strings (a char,
+ *   or a surrogate pair) are the key itself; longer strings are autocomplete
+ *   insertions, not key presses.
+ * - [deleteSurroundingText] is a backspace with nothing to compose.
+ * - [sendKeyEvent] is used by some keyboards (e.g. SwiftKey) for delete/enter
+ *   and by number-pad keys.
+ * IMEs wrap composed-word commits in a batch edit that ends with the actual
+ * user input, so during a batch only the last inferred key is emitted at
+ * [endBatchEdit]. Newlines are normalized to "Enter".
+ */
 class InputConnectionWrapper(
   target: InputConnection,
   private val editText: EnrichedMarkdownTextInputView,
 ) : AndroidInputConnectionWrapper(target, false) {
   var isBatchEdit = false
     private set
+
+  private var pendingKey: String? = null
 
   override fun beginBatchEdit(): Boolean {
     isBatchEdit = true
@@ -19,23 +42,54 @@ class InputConnectionWrapper(
 
   override fun endBatchEdit(): Boolean {
     isBatchEdit = false
+    pendingKey?.let {
+      dispatchKeyPress(it)
+      pendingKey = null
+    }
     return super.endBatchEdit()
   }
 
   override fun setComposingText(
     text: CharSequence,
     newCursorPosition: Int,
-  ): Boolean = super.setComposingText(text, newCursorPosition)
+  ): Boolean {
+    val previousSelectionStart = editText.selectionStart
+    val previousSelectionEnd = editText.selectionEnd
+
+    val consumed = super.setComposingText(text, newCursorPosition)
+
+    val currentSelectionStart = editText.selectionStart
+    val noPreviousSelection = previousSelectionStart == previousSelectionEnd
+    val cursorDidNotMove = currentSelectionStart == previousSelectionStart
+    val cursorMovedBackwardsOrAtBeginningOfInput =
+      currentSelectionStart < previousSelectionStart || currentSelectionStart <= 0
+
+    val key =
+      if (cursorMovedBackwardsOrAtBeginningOfInput || (!noPreviousSelection && cursorDidNotMove)) {
+        BACKSPACE_KEY_VALUE
+      } else {
+        editText.text?.get(currentSelectionStart - 1).toString()
+      }
+    dispatchKeyPressOrEnqueue(key)
+    return consumed
+  }
 
   override fun commitText(
     text: CharSequence,
     newCursorPosition: Int,
-  ): Boolean = super.commitText(text, newCursorPosition)
+  ): Boolean {
+    val key = text.toString()
+    if (key.length <= 2) {
+      dispatchKeyPressOrEnqueue(key.ifEmpty { BACKSPACE_KEY_VALUE })
+    }
+    return super.commitText(text, newCursorPosition)
+  }
 
   override fun deleteSurroundingText(
     beforeLength: Int,
     afterLength: Int,
   ): Boolean {
+    dispatchKeyPress(BACKSPACE_KEY_VALUE)
     if (beforeLength == 1 && afterLength == 0 && editText.deleteLinkBeforeCursor()) {
       return true
     }
@@ -43,12 +97,43 @@ class InputConnectionWrapper(
   }
 
   override fun sendKeyEvent(event: KeyEvent): Boolean {
-    if (event.action == KeyEvent.ACTION_DOWN &&
-      event.keyCode == KeyEvent.KEYCODE_DEL &&
-      editText.deleteLinkBeforeCursor()
-    ) {
-      return true
+    if (event.action == KeyEvent.ACTION_DOWN) {
+      val isNumberKey = event.unicodeChar in 48..57
+      when (event.keyCode) {
+        KeyEvent.KEYCODE_DEL -> dispatchKeyPress(BACKSPACE_KEY_VALUE)
+        KeyEvent.KEYCODE_ENTER -> dispatchKeyPress(ENTER_KEY_VALUE)
+        else -> if (isNumberKey) dispatchKeyPress(event.number.toString())
+      }
+      if (event.keyCode == KeyEvent.KEYCODE_DEL && editText.deleteLinkBeforeCursor()) {
+        return true
+      }
     }
     return super.sendKeyEvent(event)
+  }
+
+  private fun dispatchKeyPressOrEnqueue(key: String) {
+    if (isBatchEdit) {
+      pendingKey = key
+    } else {
+      dispatchKeyPress(key)
+    }
+  }
+
+  private fun dispatchKeyPress(key: String) {
+    val resolved =
+      when (key) {
+        NEWLINE_RAW_VALUE -> ENTER_KEY_VALUE
+        TAB_RAW_VALUE -> TAB_KEY_VALUE
+        else -> key
+      }
+    editText.eventEmitter.emitKeyPress(resolved)
+  }
+
+  companion object {
+    private const val NEWLINE_RAW_VALUE = "\n"
+    private const val TAB_RAW_VALUE = "\t"
+    private const val BACKSPACE_KEY_VALUE = "Backspace"
+    private const val ENTER_KEY_VALUE = "Enter"
+    private const val TAB_KEY_VALUE = "Tab"
   }
 }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnInputKeyPressEvent.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/events/OnInputKeyPressEvent.kt
@@ -1,0 +1,24 @@
+package com.swmansion.enriched.markdown.input.events
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class OnInputKeyPressEvent(
+  surfaceId: Int,
+  viewId: Int,
+  private val key: String,
+) : Event<OnInputKeyPressEvent>(surfaceId, viewId) {
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap =
+    Arguments.createMap().apply {
+      putString("key", key)
+    }
+
+  override fun canCoalesce(): Boolean = false
+
+  companion object {
+    const val EVENT_NAME = "onInputKeyPress"
+  }
+}

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
@@ -14,6 +14,7 @@ import com.swmansion.enriched.markdown.input.events.OnContextMenuItemPressEvent
 import com.swmansion.enriched.markdown.input.events.OnEndMentionEvent
 import com.swmansion.enriched.markdown.input.events.OnInputBlurEvent
 import com.swmansion.enriched.markdown.input.events.OnInputFocusEvent
+import com.swmansion.enriched.markdown.input.events.OnInputKeyPressEvent
 import com.swmansion.enriched.markdown.input.events.OnLinkDetectedEvent
 import com.swmansion.enriched.markdown.input.events.OnRequestCaretRectResultEvent
 import com.swmansion.enriched.markdown.input.events.OnRequestMarkdownResultEvent
@@ -70,6 +71,10 @@ class InputEventEmitter(
         headingLevel,
       ),
     )
+  }
+
+  fun emitKeyPress(key: String) {
+    dispatch(OnInputKeyPressEvent(surfaceId(), view.id, key))
   }
 
   fun emitFocus() {

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -1461,6 +1461,37 @@ using namespace facebook::react;
   emitter->onChangeText({.value = std::string([plainText UTF8String] ?: "")});
 }
 
+/// Maps the replacement text of a pending edit to RN TextInput's
+/// `onKeyPress` key names: empty text means deletion ("Backspace"), and
+/// leading \n, \t and ESC map to "Enter", "Tab" and "Escape".
+- (void)emitOnKeyPress:(NSString *)text
+{
+  auto emitter = [self getEventEmitter];
+  if (emitter == nullptr) {
+    return;
+  }
+  NSString *key;
+  if (text.length == 0) {
+    key = @"Backspace";
+  } else {
+    switch ([text characterAtIndex:0]) {
+      case '\n':
+        key = @"Enter";
+        break;
+      case '\t':
+        key = @"Tab";
+        break;
+      case 0x1B:
+        key = @"Escape";
+        break;
+      default:
+        key = text;
+        break;
+    }
+  }
+  emitter->onInputKeyPress({.key = std::string([key UTF8String] ?: "")});
+}
+
 - (void)emitOnChangeMarkdown
 {
   auto emitter = [self getEventEmitter];
@@ -1839,6 +1870,7 @@ using namespace facebook::react;
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text
 {
+  [self emitOnKeyPress:text];
   if ([self deleteLinkForReplacementRange:range replacementText:text]) {
     return NO;
   }
@@ -1949,6 +1981,7 @@ using namespace facebook::react;
 
 - (nullable NSString *)textInputShouldChangeText:(NSString *)text inRange:(NSRange)range
 {
+  [self emitOnKeyPress:text];
   if ([self deleteLinkForReplacementRange:range replacementText:text]) {
     return nil;
   }

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -13,6 +13,7 @@ import EnrichedMarkdownTextInputNativeComponent, {
   type OnChangeMarkdownEvent,
   type OnChangeSelectionEvent,
   type OnChangeStateEvent,
+  type OnKeyPressEvent,
   type OnRequestMarkdownResultEvent,
   type OnRequestCaretRectResultEvent,
   type OnCaretRectChangeEvent,
@@ -23,6 +24,7 @@ import EnrichedMarkdownTextInputNativeComponent, {
   type OnEndMentionEvent,
 } from './EnrichedMarkdownTextInputNativeComponent';
 export type {
+  OnKeyPressEvent,
   OnLinkDetected,
   OnStartMentionEvent,
   OnChangeMentionEvent,
@@ -199,6 +201,14 @@ export interface EnrichedMarkdownTextInputProps extends Omit<
   onChangeMarkdown?: (markdown: string) => void;
   onChangeSelection?: (selection: { start: number; end: number }) => void;
   onChangeState?: (state: StyleState) => void;
+  /**
+   * Called on every keystroke before it is applied to the input content,
+   * mirroring React Native TextInput's `onKeyPress`. `nativeEvent.key` is the
+   * pressed character, or `Backspace` / `Enter` / `Tab` (iOS also reports
+   * `Escape`). On Android soft keyboards may lag actual typing when
+   * autocomplete suggestions are involved.
+   */
+  onKeyPress?: (e: NativeSyntheticEvent<OnKeyPressEvent>) => void;
   onCaretRectChange?: (rect: CaretRect) => void;
   onLinkDetected?: (event: OnLinkDetected) => void;
   mentionIndicators?: string[];
@@ -276,6 +286,7 @@ export const EnrichedMarkdownTextInput = ({
   onChangeMarkdown,
   onChangeSelection,
   onChangeState,
+  onKeyPress,
   onCaretRectChange,
   onLinkDetected,
   mentionIndicators,
@@ -597,6 +608,7 @@ export const EnrichedMarkdownTextInput = ({
         handleChangeSelection as NativeProps['onChangeSelection']
       }
       onChangeState={handleChangeState as NativeProps['onChangeState']}
+      onInputKeyPress={onKeyPress as NativeProps['onInputKeyPress']}
       onLinkDetected={handleLinkDetected as NativeProps['onLinkDetected']}
       onInputFocus={handleFocus as NativeProps['onInputFocus']}
       onInputBlur={handleBlur as NativeProps['onInputBlur']}

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -201,13 +201,6 @@ export interface EnrichedMarkdownTextInputProps extends Omit<
   onChangeMarkdown?: (markdown: string) => void;
   onChangeSelection?: (selection: { start: number; end: number }) => void;
   onChangeState?: (state: StyleState) => void;
-  /**
-   * Called on every keystroke before it is applied to the input content,
-   * mirroring React Native TextInput's `onKeyPress`. `nativeEvent.key` is the
-   * pressed character, or `Backspace` / `Enter` / `Tab` (iOS also reports
-   * `Escape`). On Android soft keyboards may lag actual typing when
-   * autocomplete suggestions are involved.
-   */
   onKeyPress?: (e: NativeSyntheticEvent<OnKeyPressEvent>) => void;
   onCaretRectChange?: (rect: CaretRect) => void;
   onLinkDetected?: (event: OnLinkDetected) => void;

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInputNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInputNativeComponent.ts
@@ -61,6 +61,10 @@ export interface OnChangeMarkdownEvent {
   value: string;
 }
 
+export interface OnKeyPressEvent {
+  key: string;
+}
+
 export interface OnChangeSelectionEvent {
   start: CodegenTypes.Int32;
   end: CodegenTypes.Int32;
@@ -276,6 +280,7 @@ export interface NativeProps extends ViewProps {
   onChangeText?: CodegenTypes.DirectEventHandler<OnChangeTextEvent>;
   onChangeMarkdown?: CodegenTypes.DirectEventHandler<OnChangeMarkdownEvent>;
   onChangeSelection?: CodegenTypes.DirectEventHandler<OnChangeSelectionEvent>;
+  onInputKeyPress?: CodegenTypes.DirectEventHandler<OnKeyPressEvent>;
   onChangeState?: CodegenTypes.DirectEventHandler<OnChangeStateEvent>;
   onInputFocus?: CodegenTypes.DirectEventHandler<TargetedEvent>;
   onInputBlur?: CodegenTypes.DirectEventHandler<TargetedEvent>;

--- a/packages/react-native-enriched-markdown/src/index.tsx
+++ b/packages/react-native-enriched-markdown/src/index.tsx
@@ -31,6 +31,7 @@ export type {
   ContextMenuItem,
   InputSelectionMenuConfig,
   FormatMenuConfig,
+  OnKeyPressEvent,
   OnLinkDetected,
   OnStartMentionEvent,
   OnChangeMentionEvent,


### PR DESCRIPTION
### What/Why?
closes #348

Adds an `onKeyPress` prop to `EnrichedMarkdownTextInput`, **mirroring React Native TextInput's API** 
```ts
({ nativeEvent: { key }}) => void
```

**BREAKING CHANGE**
On Android Plain Tab is now consumed in `onKeyDown` so it inserts `\t` and emits `Tab` like iOS instead of moving focus; Shift/Ctrl+Tab still navigate focus. 

Without `onKeyPress` there was no way to observe a keystroke before it is applied to the input content.

- `nativeEvent.key` is the pressed character, or a named key: `Backspace`, `Enter`, `Tab` (iOS additionally reports
`Escape`). Paste never fires the event.
- iOS/macOS emitted from `shouldChangeTextInRange` / `textInputShouldChangeText` with RN core's key mapping (empty - `Backspace`, `\n` - `Enter`, `\t` - `Tab`, ESC - `Escape`). The custom `paste:` override bypasses the delegate, so pastes are excluded by construction.
- Android's key inference ported from RN's `ReactEditTextInputConnectionWrapper` into the existing
`InputConnectionWrapper` (cursor-movement heuristics for composing text, ≤2-char commits, batch-edit queueing,
SwiftKey/number-pad `sendKeyEvent`). .
- Updated docs (`API_REFERENCE.md`, `INPUT.md`).
- New Storybook story **EnrichedMarkdownTextInput -> Props -> Key Press** showing the latest pressed keys as chips;
`onKeyPress` is also wired into the shared Actions arg types, so all input stories log it.

### Testing

1. Open the example app, Storybook, `EnrichedMarkdownTextInput/Props/Key Press`.
2. Type characters, backspace, and enter - chips appear below the input (newest highlighted) and events land in the Actions tab.
3. With a hardware keyboard, press Tab - a tab character is inserted and `Tab` is reported on both platforms (Android no
longer moves focus to the toolbar).
4. Paste text via the context menu - no key press event fires.

#### Screenshots

##### iOS

https://github.com/user-attachments/assets/d969203e-2dbd-4234-85ed-b0950035282b

##### Android

https://github.com/user-attachments/assets/a6a8d57f-cc32-45ba-ab02-7014397ef084

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

