### PR TITLE
refactor(input): consolidate reentrancy flags into EditSession (iOS & Android)

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -27,8 +27,10 @@ import com.swmansion.enriched.markdown.input.autolink.LinkRegexConfig
 import com.swmansion.enriched.markdown.input.detection.DetectorPipeline
 import com.swmansion.enriched.markdown.input.detection.WordsUtils
 import com.swmansion.enriched.markdown.input.editing.EditContext
+import com.swmansion.enriched.markdown.input.editing.EditPhase
 import com.swmansion.enriched.markdown.input.editing.EditPipeline
 import com.swmansion.enriched.markdown.input.editing.EditPipelineHost
+import com.swmansion.enriched.markdown.input.editing.EditSession
 import com.swmansion.enriched.markdown.input.editing.InputConnectionWrapper
 import com.swmansion.enriched.markdown.input.editing.MarkdownEditableFactory
 import com.swmansion.enriched.markdown.input.editing.MarkdownTextWatcher
@@ -62,15 +64,8 @@ class EnrichedMarkdownTextInputView(
   val pendingStyles = mutableSetOf<StyleType>()
   val pendingStyleRemovals = mutableSetOf<StyleType>()
 
-  var isDuringTransaction = false
-    private set
+  val editSession = EditSession()
 
-  var blockEmitting = false
-
-  private var isTextChanging = false
-  var isProcessingTextChange = false
-    private set
-  private var didTextChangeRecently = false
   private var lastProcessedText: String = ""
   private var preEditSelectionStart = 0
   private var preEditSelectionEnd = 0
@@ -131,10 +126,6 @@ class EnrichedMarkdownTextInputView(
 
   private var headingOverrideBaseSizePx: Float? = null
   private var baseHintColor: Int? = null
-
-  // Guards re-entrancy while the empty-list-line ZWSP anchor is managed (its
-  // insert/delete + setSelection would otherwise loop back through the callbacks).
-  private var isManagingAnchor = false
 
   // Number of ZWSP empty-list anchors believed live in the buffer. Bumped on insert,
   // made exact on every strip scan (which recounts what it keeps), and reset when the
@@ -314,17 +305,16 @@ class EnrichedMarkdownTextInputView(
   }
 
   fun runAsATransaction(block: () -> Unit) {
-    try {
-      isDuringTransaction = true
+    if (editSession.phase != EditPhase.Idle) {
       block()
-    } finally {
-      isDuringTransaction = false
+    } else {
+      editSession.scoped(EditPhase.Processing) { block() }
     }
   }
 
   fun onBeforeTextChanged() {
-    if (isProcessingTextChange) return
-    isTextChanging = true
+    if (editSession.phase != EditPhase.Idle) return
+    editSession.isTextChanging = true
     preEditSelectionStart = selectionStart
     preEditSelectionEnd = selectionEnd
   }
@@ -334,12 +324,12 @@ class EnrichedMarkdownTextInputView(
     deletedLength: Int,
     insertedLength: Int,
   ) {
-    if (isProcessingTextChange) return
+    if (editSession.phase != EditPhase.Idle) return
 
     val currentText = text?.toString() ?: ""
     if (currentText == lastProcessedText) return
 
-    isProcessingTextChange = true
+    editSession.enter(EditPhase.Processing)
     try {
       val context =
         EditContext(
@@ -353,11 +343,11 @@ class EnrichedMarkdownTextInputView(
           pendingStyleRemovals = pendingStyleRemovals.toSet(),
         )
       editPipeline.processTextChange(context)
-      isTextChanging = false
-      didTextChangeRecently = true
+      editSession.isTextChanging = false
+      editSession.didTextChangeRecently = true
       lastProcessedText = text?.toString() ?: currentText
     } finally {
-      isProcessingTextChange = false
+      editSession.exit()
     }
   }
 
@@ -366,24 +356,22 @@ class EnrichedMarkdownTextInputView(
     selEnd: Int,
   ) {
     super.onSelectionChanged(selStart, selEnd)
-    if (!isComponentReady || isDuringTransaction) return
+    if (!isComponentReady || editSession.shouldSuppressTextWatcher) return
 
-    if (!isTextChanging) {
-      // Links (e.g. mentions) are atomic: snap a partial selection to the whole link, and a caret
-      // inside a link to its end. Returning lets the recursive onSelectionChanged emit for the result.
+    if (!editSession.isTextChanging) {
       formattingStore.selectionAdjustedForAtomicLinks(selStart, selEnd)?.let { (newStart, newEnd) ->
         setSelection(newStart, newEnd)
         return
       }
-      if (didTextChangeRecently) {
-        didTextChangeRecently = false
+      if (editSession.didTextChangeRecently) {
+        editSession.didTextChangeRecently = false
       } else {
         pendingStyles.clear()
         pendingStyleRemovals.clear()
       }
     }
 
-    if (!isTextChanging && !isProcessingTextChange) {
+    if (!editSession.isTextChanging && editSession.phase == EditPhase.Idle) {
       // The caret moving on/off an empty bullet line toggles the ZWSP anchor and the
       // placeholder visibility; skip during a text-change pass (handled there).
       syncEmptyListAnchor()
@@ -419,7 +407,7 @@ class EnrichedMarkdownTextInputView(
     postAdjust: (Editable) -> Unit = {},
   ) {
     val editable = text ?: return
-    isProcessingTextChange = true
+    editSession.enter(EditPhase.Processing)
     try {
       editable.replace(start, end, newText)
       adjustStoresForEdit(start, end - start, newText.length)
@@ -428,7 +416,7 @@ class EnrichedMarkdownTextInputView(
       applyFormattingAndEmit()
       eventEmitter.emitChangeText()
     } finally {
-      isProcessingTextChange = false
+      editSession.exit()
     }
   }
 
@@ -615,10 +603,10 @@ class EnrichedMarkdownTextInputView(
    * When called from `onAfterTextChanged` this mutates the [Editable] from inside
    * the text-change callback — normally an Android hazard around IME composition,
    * undo/redo, and accessibility. It is safe here, and deliberately synchronous,
-   * because: every buffer mutation is wrapped in [runAsATransaction] (which sets
-   * `isDuringTransaction`, so [MarkdownTextWatcher] early-returns and the edit does
-   * not re-enter this pass), the whole `onAfterTextChanged` body holds
-   * `isProcessingTextChange`, and [isManagingAnchor] blocks re-entry via the
+   * because: every buffer mutation is wrapped in [runAsATransaction] (which keeps
+   * [EditSession.phase] non-idle, so [MarkdownTextWatcher] early-returns and the edit
+   * does not re-enter this pass), the whole `onAfterTextChanged` body holds
+   * [EditPhase.Processing], and [EditPhase.ManagingAnchors] blocks re-entry via the
    * selection-change path. The mutation must stay synchronous: the single-stamp
    * ordering above, the caret placement past the anchor, and `lastProcessedText`
    * all depend on the buffer reaching its final state within this same callback —
@@ -626,9 +614,9 @@ class EnrichedMarkdownTextInputView(
    * and reintroduce the double-bullet and stale-caret bugs.
    */
   private fun syncEmptyListAnchor(restamp: Boolean = true): Boolean {
-    if (isManagingAnchor) return false
+    if (editSession.shouldSuppressAnchorSync) return false
     val editable = text ?: return false
-    isManagingAnchor = true
+    editSession.enter(EditPhase.ManagingAnchors)
     var anchorChanged = false
     try {
       // Strip every stale ZWSP first (a line that gained content or stopped being a
@@ -687,7 +675,7 @@ class EnrichedMarkdownTextInputView(
       syncHintVisibility()
       return anchorChanged
     } finally {
-      isManagingAnchor = false
+      editSession.exit()
     }
   }
 
@@ -1075,23 +1063,20 @@ class EnrichedMarkdownTextInputView(
 
   fun setValueFromJS(markdown: String) {
     val parsed = InputParser.parseToPlainTextAndRanges(markdown)
-    blockEmitting = true
+    editSession.enter(EditPhase.Importing)
     try {
-      runAsATransaction {
-        formattingStore.clearAll()
-        formattingStore.setRanges(parsed.formattingRanges)
-        blockStore.setRanges(parsed.blockRanges)
-        setText(parsed.plainText)
-        setSelection(text?.length ?: 0)
-      }
-      // Parsed markdown never contains the ZWSP anchor, so the fresh document has none.
+      formattingStore.clearAll()
+      formattingStore.setRanges(parsed.formattingRanges)
+      blockStore.setRanges(parsed.blockRanges)
+      setText(parsed.plainText)
+      setSelection(text?.length ?: 0)
       zwspAnchorCount = 0
       applyFormatting()
       forceScrollToSelection()
       layoutManager.invalidateLayout()
       lastProcessedText = text?.toString() ?: ""
     } finally {
-      blockEmitting = false
+      editSession.exit()
     }
   }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/EditSession.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/EditSession.kt
@@ -1,0 +1,52 @@
+package com.swmansion.enriched.markdown.input.editing
+
+enum class EditPhase {
+  Idle,
+  Processing,
+  Importing,
+  ManagingAnchors,
+}
+
+/**
+ * Tracks the current editing phase and exposes computed suppression queries.
+ * Replaces the scattered boolean flags (`isProcessingTextChange`,
+ * `isDuringTransaction`, `blockEmitting`, `isManagingAnchor`) that previously
+ * guarded re-entrant code paths in the view.
+ */
+class EditSession {
+  var phase: EditPhase = EditPhase.Idle
+    private set
+
+  var isTextChanging: Boolean = false
+  var didTextChangeRecently: Boolean = false
+
+  val shouldSuppressTextWatcher: Boolean
+    get() = phase != EditPhase.Idle
+
+  val shouldSuppressEvents: Boolean
+    get() = phase == EditPhase.Importing
+
+  val shouldSuppressAnchorSync: Boolean
+    get() = phase == EditPhase.ManagingAnchors
+
+  fun enter(newPhase: EditPhase) {
+    phase = newPhase
+  }
+
+  fun exit() {
+    phase = EditPhase.Idle
+  }
+
+  fun <T> scoped(
+    newPhase: EditPhase,
+    block: () -> T,
+  ): T {
+    val previous = phase
+    phase = newPhase
+    try {
+      return block()
+    } finally {
+      phase = previous
+    }
+  }
+}

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/MarkdownTextWatcher.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/MarkdownTextWatcher.kt
@@ -17,7 +17,7 @@ class MarkdownTextWatcher(
     count: Int,
     after: Int,
   ) {
-    if (view.isDuringTransaction || view.isProcessingTextChange) return
+    if (view.editSession.shouldSuppressTextWatcher) return
     editStart = start
     deletedLength = count
     insertedLength = after
@@ -30,12 +30,12 @@ class MarkdownTextWatcher(
     before: Int,
     count: Int,
   ) {
-    if (view.isDuringTransaction || view.isProcessingTextChange) return
+    if (view.editSession.shouldSuppressTextWatcher) return
     view.layoutManager.invalidateLayout()
   }
 
   override fun afterTextChanged(editable: Editable) {
-    if (view.isDuringTransaction || view.isProcessingTextChange) return
+    if (view.editSession.shouldSuppressTextWatcher) return
     view.onAfterTextChanged(editStart, deletedLength, insertedLength)
   }
 }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/layout/InputEventEmitter.kt
@@ -232,7 +232,7 @@ class InputEventEmitter(
   }
 
   private fun dispatch(event: Event<*>) {
-    if (view.blockEmitting) return
+    if (view.editSession.shouldSuppressEvents) return
     val reactContext = view.context as? ReactContext ?: return
     val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.id)
     dispatcher?.dispatchEvent(event)

--- a/packages/react-native-enriched-markdown/ios/input/ENRMEditPipeline.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMEditPipeline.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Orchestrates the data-model phases of the per-keystroke edit pipeline:
 /// store adjustment, orphan pruning, pending styles, and block continuation.
 ///
-/// Formatting (which needs `_textView`, `_formatterStyle`, `_isApplyingFormatting`)
+/// Formatting (which needs `_textView`, `_formatterStyle`, `ENRMEditPhaseFormatting`)
 /// and UI updates (typing attributes, placeholder, events, height) stay on the view.
 /// The pipeline tells the view whether the edit touched a newline so the view can
 /// pick full vs scoped formatting.

--- a/packages/react-native-enriched-markdown/ios/input/ENRMEditSession.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMEditSession.h
@@ -1,0 +1,36 @@
+#import "ENRMUIKit.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, ENRMEditPhase) {
+  ENRMEditPhaseIdle,
+  ENRMEditPhaseProcessing,
+  ENRMEditPhaseFormatting,
+  ENRMEditPhaseImporting,
+};
+
+/// Tracks the current editing phase and exposes computed suppression queries.
+/// Replaces the scattered boolean flags (`_isApplyingFormatting`, `_isTextChanging`,
+/// `blockEmitting`, `_lastTextChangeTime`) that previously guarded re-entrant
+/// code paths in the view.
+@interface ENRMEditSession : NSObject
+
+@property (nonatomic, readonly) ENRMEditPhase phase;
+
+- (instancetype)initWithTextView:(ENRMPlatformTextView *)textView;
+
+- (void)enterPhase:(ENRMEditPhase)newPhase;
+- (void)exitPhase;
+
+- (void)recordTextChange;
+
+@property (nonatomic, readonly) BOOL isComposing;
+@property (nonatomic, readonly) BOOL isPostEditGracePeriod;
+@property (nonatomic, readonly) BOOL shouldSuppressFormatting;
+@property (nonatomic, readonly) BOOL shouldSuppressEvents;
+@property (nonatomic, readonly) BOOL shouldSuppressSelectionSideEffects;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/input/ENRMEditSession.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMEditSession.mm
@@ -1,0 +1,63 @@
+#import "ENRMEditSession.h"
+
+static const CFTimeInterval kPostEditGracePeriod = 0.1;
+
+@implementation ENRMEditSession {
+  __weak ENRMPlatformTextView *_textView;
+  CFTimeInterval _lastTextChangeTime;
+}
+
+- (instancetype)initWithTextView:(ENRMPlatformTextView *)textView
+{
+  if (self = [super init]) {
+    _textView = textView;
+    _phase = ENRMEditPhaseIdle;
+    _lastTextChangeTime = 0;
+  }
+  return self;
+}
+
+- (void)enterPhase:(ENRMEditPhase)newPhase
+{
+  _phase = newPhase;
+}
+
+- (void)exitPhase
+{
+  _phase = ENRMEditPhaseIdle;
+}
+
+- (void)recordTextChange
+{
+  _lastTextChangeTime = CACurrentMediaTime();
+}
+
+- (BOOL)isComposing
+{
+  ENRMPlatformTextView *tv = _textView;
+  if (!tv)
+    return NO;
+  return ENRMHasMarkedText(tv);
+}
+
+- (BOOL)isPostEditGracePeriod
+{
+  return _lastTextChangeTime > 0 && (CACurrentMediaTime() - _lastTextChangeTime) < kPostEditGracePeriod;
+}
+
+- (BOOL)shouldSuppressFormatting
+{
+  return _phase == ENRMEditPhaseFormatting || _phase == ENRMEditPhaseImporting;
+}
+
+- (BOOL)shouldSuppressEvents
+{
+  return _phase == ENRMEditPhaseImporting;
+}
+
+- (BOOL)shouldSuppressSelectionSideEffects
+{
+  return _phase != ENRMEditPhaseIdle;
+}
+
+@end

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.h
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.h
@@ -4,10 +4,12 @@
 #ifndef EnrichedMarkdownTextInput_h
 #define EnrichedMarkdownTextInput_h
 
+@class ENRMEditSession;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EnrichedMarkdownTextInput : RCTViewComponentView
-@property (nonatomic, assign) BOOL blockEmitting;
+@property (nonatomic, readonly) ENRMEditSession *editSession;
 - (CGSize)measureSize:(CGFloat)maxWidth;
 - (nullable NSString *)markdownForSelectedRange;
 - (void)copyToClipboard;

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -5,6 +5,7 @@
 #import "ENRMBlockStore.h"
 #import "ENRMDetectorPipeline.h"
 #import "ENRMEditPipeline.h"
+#import "ENRMEditSession.h"
 #import "ENRMFormattingRange.h"
 #import "ENRMFormattingStore.h"
 #import "ENRMInputFormatter.h"
@@ -67,10 +68,8 @@ using namespace facebook::react;
   ENRMBlockStore *_blockStore;
   NSMutableSet<NSNumber *> *_pendingStyles;
   NSMutableSet<NSNumber *> *_pendingStyleRemovals;
-  BOOL _isApplyingFormatting;
-  BOOL _isTextChanging;
   BOOL _emitMarkdown;
-  CFTimeInterval _lastTextChangeTime;
+  ENRMEditSession *_editSession;
 
   ENRMPlaceholderLabel *_placeholderLabel;
 
@@ -133,6 +132,8 @@ using namespace facebook::react;
   NSString *_formatMenuLinkLabel;
 }
 
+@synthesize editSession = _editSession;
+
 #pragma mark - Fabric lifecycle
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -152,7 +153,6 @@ using namespace facebook::react;
     _props = defaultProps;
 
     self.backgroundColor = [RCTUIColor clearColor];
-    _blockEmitting = NO;
     _heightUpdateCounter = 0;
     _formatter = [[ENRMInputFormatter alloc] init];
     _formatterStyle = [[ENRMInputFormatterStyle alloc] init];
@@ -174,6 +174,7 @@ using namespace facebook::react;
         .bold = YES, .italic = YES, .underline = YES, .strikethrough = YES, .spoiler = YES, .link = YES};
 
     [self setupTextView];
+    _editSession = [[ENRMEditSession alloc] initWithTextView:_textView];
 
     [self setupDetectorPipeline];
 
@@ -652,11 +653,11 @@ using namespace facebook::react;
   ENRMInputParser *parser = [[ENRMInputParser alloc] init];
   ENRMParseResult *parsed = [parser parseToPlainTextAndRanges:markdown];
 
-  _blockEmitting = YES;
+  [_editSession enterPhase:ENRMEditPhaseImporting];
 
-  _isApplyingFormatting = YES;
+  [_editSession enterPhase:ENRMEditPhaseFormatting];
   ENRMSetPlainText(_textView, parsed.plainText);
-  _isApplyingFormatting = NO;
+  [_editSession enterPhase:ENRMEditPhaseImporting];
 
   [_formattingStore setRanges:parsed.formattingRanges];
   [_blockStore setRanges:parsed.blockRanges];
@@ -665,7 +666,7 @@ using namespace facebook::react;
   [self applyFormatting];
   [self updatePlaceholderVisibility];
 
-  _blockEmitting = NO;
+  [_editSession exitPhase];
 }
 
 - (void)replaceTextInRange:(NSRange)selection
@@ -675,9 +676,9 @@ using namespace facebook::react;
 {
   NSUInteger editLocation = selection.location;
 
-  _isApplyingFormatting = YES;
+  [_editSession enterPhase:ENRMEditPhaseFormatting];
   ENRMReplaceTextInRange(_textView, text, selection);
-  _isApplyingFormatting = NO;
+  [_editSession exitPhase];
 
   NSString *plainText = [self adjustStoresForEditAtLocation:editLocation
                                               deletedLength:selection.length
@@ -765,13 +766,13 @@ using namespace facebook::react;
 
 - (void)applyFormattingScopedToRange:(NSRange)scope
 {
-  if (_isApplyingFormatting) {
+  if (_editSession.shouldSuppressFormatting) {
     return;
   }
-  if (ENRMHasMarkedText(_textView)) {
+  if (_editSession.isComposing) {
     return;
   }
-  _isApplyingFormatting = YES;
+  [_editSession enterPhase:ENRMEditPhaseFormatting];
 
   NSRange savedSelection = _textView.selectedRange;
 
@@ -788,7 +789,7 @@ using namespace facebook::react;
     _textView.selectedRange = savedSelection;
   }
 
-  _isApplyingFormatting = NO;
+  [_editSession exitPhase];
 }
 
 - (void)applyWritingDirection
@@ -1656,12 +1657,7 @@ using namespace facebook::react;
 
 - (void)resetPendingStylesForSelectionChange
 {
-  // Skip system-driven selection adjustments (e.g., predictive text) that fire
-  // immediately after a text edit (PR #406).
-  static const CFTimeInterval kPostEditGracePeriod = 0.1;
-  BOOL isPostEditAdjustment =
-      (_lastTextChangeTime > 0 && (CACurrentMediaTime() - _lastTextChangeTime) < kPostEditGracePeriod);
-  if (isPostEditAdjustment) {
+  if (_editSession.isPostEditGracePeriod) {
     return;
   }
   [_pendingStyles removeAllObjects];
@@ -1702,7 +1698,7 @@ using namespace facebook::react;
 
 - (std::shared_ptr<EnrichedMarkdownTextInputEventEmitter const>)getEventEmitter
 {
-  if (_eventEmitter == nullptr || _blockEmitting) {
+  if (_eventEmitter == nullptr || _editSession.shouldSuppressEvents) {
     return nullptr;
   }
   return std::static_pointer_cast<EnrichedMarkdownTextInputEventEmitter const>(_eventEmitter);
@@ -2081,7 +2077,7 @@ using namespace facebook::react;
 
 - (void)handleTextChanged
 {
-  if (ENRMHasMarkedText(_textView)) {
+  if (_editSession.isComposing) {
     return;
   }
 
@@ -2205,7 +2201,7 @@ using namespace facebook::react;
 {
   [self stripLinkTypingAttributes];
 
-  if (_textView.selectedRange.length == 0 && !_isTextChanging) {
+  if (_textView.selectedRange.length == 0 && _editSession.phase == ENRMEditPhaseIdle) {
     NSString *text = ENRMGetPlainText(_textView);
     if (text.length > 0) {
       NSRange paragraphRange = [text paragraphRangeForRange:_textView.selectedRange];
@@ -2237,19 +2233,19 @@ using namespace facebook::react;
   [self capturePreEditBlockForRange:range];
   _preEditParagraphWasEmpty = [self preEditParagraphWasEmpty:range];
   _preEditReplacedNewline = [self replacedRangeTouchesNewline:range];
-  _isTextChanging = YES;
+  [_editSession enterPhase:ENRMEditPhaseProcessing];
   [self stripLinkTypingAttributes];
   return YES;
 }
 
 - (void)textViewDidChange:(UITextView *)textView
 {
-  if (_isApplyingFormatting) {
+  if (_editSession.shouldSuppressFormatting) {
     return;
   }
   [self handleTextChanged];
-  _isTextChanging = NO;
-  _lastTextChangeTime = CACurrentMediaTime();
+  [_editSession exitPhase];
+  [_editSession recordTextChange];
   _lastSelectedRange = textView.selectedRange;
 }
 
@@ -2267,9 +2263,7 @@ using namespace facebook::react;
 - (void)textViewDidChangeSelection:(UITextView *)textView
 {
   NSRange newSelection = textView.selectedRange;
-  // Links (e.g. mentions) are atomic: snap a partial selection to the whole link, and a caret inside
-  // a link to its end. Returning hands the adjusted selection to the recursive change (no double emit).
-  if (!_isApplyingFormatting && !_isTextChanging && !ENRMHasMarkedText(_textView)) {
+  if (!_editSession.shouldSuppressSelectionSideEffects && !_editSession.isComposing) {
     NSRange adjusted = [_formattingStore selectionAdjustedForAtomicLinks:newSelection];
     if (!NSEqualRanges(adjusted, newSelection)) {
       _textView.selectedRange = adjusted;
@@ -2279,11 +2273,11 @@ using namespace facebook::react;
   NSRange previousSelection = _lastSelectedRange;
   _lastSelectedRange = newSelection;
 
-  if (_isApplyingFormatting || _isTextChanging) {
+  if (_editSession.shouldSuppressSelectionSideEffects) {
     return;
   }
 
-  if (ENRMHasMarkedText(_textView)) {
+  if (_editSession.isComposing) {
     return;
   }
 
@@ -2353,27 +2347,26 @@ using namespace facebook::react;
   [self capturePreEditBlockForRange:range];
   _preEditParagraphWasEmpty = [self preEditParagraphWasEmpty:range];
   _preEditReplacedNewline = [self replacedRangeTouchesNewline:range];
-  _isTextChanging = YES;
+  [_editSession enterPhase:ENRMEditPhaseProcessing];
   return text;
 }
 
 - (void)textInputDidChange
 {
-  if (_isApplyingFormatting) {
-    _isTextChanging = NO;
+  if (_editSession.shouldSuppressFormatting) {
+    [_editSession exitPhase];
     return;
   }
   [self handleTextChanged];
-  _isTextChanging = NO;
-  _lastTextChangeTime = CACurrentMediaTime();
+  [_editSession exitPhase];
+  [_editSession recordTextChange];
   _lastSelectedRange = _textView.selectedRange;
 }
 
 - (void)textInputDidChangeSelection
 {
   NSRange newSelection = _textView.selectedRange;
-  // Atomic link snapping — same logic as textViewDidChangeSelection: (iOS).
-  if (!_isApplyingFormatting && !_isTextChanging && !ENRMHasMarkedText(_textView)) {
+  if (!_editSession.shouldSuppressSelectionSideEffects && !_editSession.isComposing) {
     NSRange adjusted = [_formattingStore selectionAdjustedForAtomicLinks:newSelection];
     if (!NSEqualRanges(adjusted, newSelection)) {
       _textView.selectedRange = adjusted;
@@ -2383,11 +2376,11 @@ using namespace facebook::react;
   NSRange previousSelection = _lastSelectedRange;
   _lastSelectedRange = newSelection;
 
-  if (_isApplyingFormatting || _isTextChanging) {
+  if (_editSession.shouldSuppressSelectionSideEffects) {
     return;
   }
 
-  if (ENRMHasMarkedText(_textView)) {
+  if (_editSession.isComposing) {
     return;
   }
 

--- a/packages/react-native-enriched-markdown/ios/input/internals/EnrichedMarkdownTextInputShadowNode.mm
+++ b/packages/react-native-enriched-markdown/ios/input/internals/EnrichedMarkdownTextInputShadowNode.mm
@@ -1,4 +1,5 @@
 #import "EnrichedMarkdownTextInputShadowNode.h"
+#import "ENRMEditSession.h"
 #import "EnrichedMarkdownTextInput.h"
 #import <react/utils/ManagedObjectWrapper.h>
 #import <yoga/Yoga.h>
@@ -37,7 +38,7 @@ id EnrichedMarkdownTextInputShadowNode::setupMockInputView_(CGFloat width) const
   EnrichedMarkdownTextInput *mockView =
       [[EnrichedMarkdownTextInput alloc] initWithFrame:CGRectMake(20000, 20000, width, 1000)];
 
-  mockView.blockEmitting = YES;
+  [mockView.editSession enterPhase:ENRMEditPhaseImporting];
 
   const auto props = this->getProps();
   [mockView updateProps:props oldProps:nullptr];


### PR DESCRIPTION
### What/Why?
Replace scattered boolean flags (isProcessingTextChange, isDuringTransaction, blockEmitting, isManagingAnchor, _isApplyingFormatting, _isTextChanging, etc.) with a single EditSession state machine per platform. Each flag becomes either a phase in the state machine or a computed query derived from the current phase.

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

