### PR TITLE
refactor(input): extract list marker drawing into decorator pattern

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputDecorationDrawer.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputDecorationDrawer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Draws decorations (markers, borders, backgrounds) for the input layout manager.
+@protocol ENRMInputDecorationDrawer <NSObject>
+
+- (void)drawDecorationsForGlyphRange:(NSRange)glyphRange
+                       layoutManager:(NSLayoutManager *)layoutManager
+                             atPoint:(CGPoint)origin;
+
+- (void)drawEmptyEditorDecorationsWithInset:(UIEdgeInsets)inset layoutManager:(NSLayoutManager *)layoutManager;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputLayoutManager.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputLayoutManager.h
@@ -1,45 +1,19 @@
 #pragma once
 
+#import "ENRMInputDecorationDrawer.h"
 #import "ENRMUIKit.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Layout manager that draws the bullet marker for unordered-list lines into the
-/// head-indent column the list block handler reserves. Non-empty list lines are
-/// found by scanning the block-type/level attributes the formatter stamps; an
-/// empty list line (a just-toggled or just-continued item with no characters to
-/// anchor a marker to) is flagged explicitly by the orchestrator via the
-/// emptyBullet* properties below.
+@class ENRMInputListMarkerDrawer;
+
+/// Thin orchestrator that iterates registered decoration drawers during the draw pass.
 @interface ENRMInputLayoutManager : NSLayoutManager
 
-/// Depth of the marker to draw on an otherwise-empty list line. Negative disables
-/// the empty-line marker.
-@property (nonatomic, assign) NSInteger emptyBulletDepth;
+@property (nonatomic, strong, readonly) ENRMInputListMarkerDrawer *listMarkerDrawer;
+@property (nonatomic, copy) NSArray<id<ENRMInputDecorationDrawer>> *decorationDrawers;
 
-/// Whether the empty list line is an ordered item (draws its number instead of a
-/// bullet glyph), and the 1-based number to draw.
-@property (nonatomic, assign) BOOL emptyBulletOrdered;
-@property (nonatomic, assign) NSInteger emptyBulletOrdinal;
-
-/// Character location of the empty list line's paragraph (start of the line).
-@property (nonatomic, assign) NSUInteger emptyBulletLocation;
-
-/// Font/color for an empty list line's marker (no character to read them from).
-@property (nonatomic, strong, nullable) UIFont *emptyBulletFont;
-@property (nonatomic, strong, nullable) UIColor *emptyBulletColor;
-
-/// Whether the empty list line lays out right-to-left (no character to resolve
-/// the paragraph direction from), so its marker mirrors to the trailing edge.
-@property (nonatomic, assign) BOOL emptyBulletRTL;
-
-/// Leading spacing (points) applied above list items, so the empty-line marker's
-/// baseline can account for the spacing that pushes the text down in the fragment.
-@property (nonatomic, assign) CGFloat listItemSpacing;
-
-/// Draws the marker for a wholly empty editor. `drawGlyphsForGlyphRange:` is
-/// never called when there are zero glyphs, so the text view drives this from its
-/// own `drawRect:`. No-op unless an empty list line is flagged.
-- (void)drawEmptyEditorBulletWithInset:(UIEdgeInsets)inset;
+- (void)drawEmptyEditorDecorationsWithInset:(UIEdgeInsets)inset;
 
 @end
 

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputLayoutManager.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputLayoutManager.mm
@@ -1,327 +1,35 @@
 #import "ENRMInputLayoutManager.h"
-#import "ENRMInputBlockType.h"
-#import "ParagraphStyleUtils.h"
-#import <UIKit/UIKit.h>
+#import "ENRMInputListMarkerDrawer.h"
 
-@implementation ENRMInputLayoutManager {
-  // Reused across draw passes so a marker isn't drawn twice for a wrapped line's
-  // continuation fragments. Cleared at the start of each pass instead of freshly
-  // allocated, keeping the hot scroll path allocation-free.
-  NSMutableSet<NSNumber *> *_drawnParagraphLocations;
-}
+@implementation ENRMInputLayoutManager
 
 - (instancetype)init
 {
   if (self = [super init]) {
-    _emptyBulletDepth = -1;
-    _drawnParagraphLocations = [NSMutableSet set];
+    _listMarkerDrawer = [[ENRMInputListMarkerDrawer alloc] init];
+    _decorationDrawers = @[ _listMarkerDrawer ];
   }
   return self;
 }
 
-/// Draws the depth-styled bullet (filled dot, ring, then square — cycling every
-/// three levels) centered at (markerX, centerY). The glyph is sized at ~30% of
-/// the text point size so it reads as a marker, not a character.
-- (void)drawBulletAtX:(CGFloat)markerX
-              centerY:(CGFloat)centerY
-                depth:(NSInteger)depth
-                 font:(UIFont *)font
-                color:(UIColor *)color
-{
-  CGContextRef ctx = UIGraphicsGetCurrentContext();
-  if (!ctx || isnan(markerX) || isnan(centerY)) {
-    return;
-  }
-  CGFloat size = MAX(4.0, font.pointSize * 0.30);
-  CGRect bulletRect = CGRectMake(markerX - size / 2.0, centerY - size / 2.0, size, size);
-  CGContextSaveGState(ctx);
-  switch (((depth % 3) + 3) % 3) {
-    case 0:
-      [color setFill];
-      CGContextFillEllipseInRect(ctx, bulletRect);
-      break;
-    case 1: {
-      CGFloat lineWidth = MAX(1.0, size * 0.15);
-      [color setStroke];
-      CGContextSetLineWidth(ctx, lineWidth);
-      CGContextStrokeEllipseInRect(ctx, CGRectInset(bulletRect, lineWidth / 2.0, lineWidth / 2.0));
-      break;
-    }
-    default:
-      [color setFill];
-      CGContextFillRect(ctx, bulletRect);
-      break;
-  }
-  CGContextRestoreGState(ctx);
-}
-
-/// Draws an ordered item's number ("3.") right-aligned so the dot sits a small
-/// pad before the text column, sharing the bullet's baseline math.
-- (void)drawOrderedMarkerEndingAtX:(CGFloat)markerRight
-                         baselineY:(CGFloat)baselineY
-                           ordinal:(NSInteger)ordinal
-                              font:(UIFont *)font
-                             color:(UIColor *)color
-{
-  NSString *label = [NSString stringWithFormat:@"%ld.", (long)MAX(ordinal, (NSInteger)1)];
-  NSDictionary *attrs = @{NSFontAttributeName : font, NSForegroundColorAttributeName : color};
-  CGSize size = [label sizeWithAttributes:attrs];
-  [label drawAtPoint:CGPointMake(markerRight - size.width, baselineY - font.ascender) withAttributes:attrs];
-}
-
-/// RTL counterpart of drawOrderedMarkerEndingAtX:: draws ".3" left-aligned from
-/// `markerLeft` so the dot sits a small pad after the (right-anchored) text
-/// column. Mirrors the readonly renderer's ListMarkerDrawer.
-- (void)drawOrderedMarkerStartingAtX:(CGFloat)markerLeft
-                           baselineY:(CGFloat)baselineY
-                             ordinal:(NSInteger)ordinal
-                                font:(UIFont *)font
-                               color:(UIColor *)color
-{
-  NSString *label = [NSString stringWithFormat:@".%ld", (long)MAX(ordinal, (NSInteger)1)];
-  NSDictionary *attrs = @{NSFontAttributeName : font, NSForegroundColorAttributeName : color};
-  [label drawAtPoint:CGPointMake(markerLeft, baselineY - font.ascender) withAttributes:attrs];
-}
-
-/// Marker anchor for an RTL list line: the text column is anchored a head
-/// indent from the trailing (right) edge, so the marker mirrors past it.
-/// `leadingOffset` is the same padding+indent that positions the LTR column.
-static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, CGFloat leadingOffset)
-{
-  return origin.x + container.size.width - leadingOffset;
-}
-
-/// Draws the list marker (ordered "N." / RTL ".N", or a depth-styled bullet) for
-/// one list line, resolving its horizontal anchor from the paragraph direction.
-/// Shared by the in-text fragment pass and the trailing empty-line pass so the
-/// RTL/ordered placement math lives in exactly one place.
-- (void)drawListMarkerOrdered:(BOOL)isOrdered
-                        depth:(NSInteger)depth
-                      ordinal:(NSInteger)ordinal
-                          rtl:(BOOL)isRTL
-                    baselineY:(CGFloat)baselineY
-                       origin:(CGPoint)origin
-                     usedRect:(CGRect)usedRect
-                    container:(NSTextContainer *)container
-                         font:(UIFont *)font
-                        color:(UIColor *)color
-{
-  CGFloat leadingOffset = container.lineFragmentPadding + (depth + 1) * kENRMListIndentPerDepth;
-  if (isOrdered) {
-    if (isRTL) {
-      [self
-          drawOrderedMarkerStartingAtX:ENRMTrailingMarkerX(origin, container, leadingOffset) + kENRMListBulletGap / 2.0
-                             baselineY:baselineY
-                               ordinal:ordinal
-                                  font:font
-                                 color:color];
-    } else {
-      [self drawOrderedMarkerEndingAtX:origin.x + usedRect.origin.x - kENRMListBulletGap / 2.0
-                             baselineY:baselineY
-                               ordinal:ordinal
-                                  font:font
-                                 color:color];
-    }
-  } else {
-    CGFloat markerX = isRTL ? ENRMTrailingMarkerX(origin, container, leadingOffset) + kENRMListBulletGap
-                            : origin.x + usedRect.origin.x - kENRMListBulletGap;
-    CGFloat centerY = baselineY - (font.xHeight + font.capHeight) / 4.0;
-    [self drawBulletAtX:markerX centerY:centerY depth:depth font:font color:color];
-  }
-}
+#pragma mark - NSLayoutManager Overrides
 
 - (void)drawGlyphsForGlyphRange:(NSRange)glyphsToShow atPoint:(CGPoint)origin
 {
   [super drawGlyphsForGlyphRange:glyphsToShow atPoint:origin];
 
-  NSTextStorage *storage = self.textStorage;
-  NSString *string = storage.string;
-  NSMutableSet<NSNumber *> *drawnParagraphs = _drawnParagraphLocations;
-  [drawnParagraphs removeAllObjects];
-
-  [self enumerateLineFragmentsForGlyphRange:glyphsToShow
-                                 usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer *container,
-                                              NSRange glyphRange, BOOL *stop) {
-                                   NSRange charRange = [self characterRangeForGlyphRange:glyphRange
-                                                                        actualGlyphRange:NULL];
-                                   if (charRange.location == NSNotFound) {
-                                     return;
-                                   }
-
-                                   NSRange paraRange = (charRange.location < string.length)
-                                                           ? [string paragraphRangeForRange:charRange]
-                                                           : NSMakeRange(charRange.location, 0);
-                                   // Wrapped continuation fragments share their line's paragraph; only the
-                                   // first fragment of a list line draws a marker.
-                                   if ([drawnParagraphs containsObject:@(paraRange.location)]) {
-                                     return;
-                                   }
-
-                                   BOOL isAttributedListLine = NO;
-                                   BOOL isOrdered = NO;
-                                   NSInteger depth = 0;
-                                   NSInteger ordinal = 1;
-                                   if (charRange.location < storage.length) {
-                                     NSNumber *type = [storage attribute:ENRMBlockTypeAttributeName
-                                                                 atIndex:charRange.location
-                                                          effectiveRange:NULL];
-                                     if (type && ENRMBlockTypeIsListItem((ENRMInputBlockType)type.integerValue) &&
-                                         charRange.location == paraRange.location) {
-                                       isAttributedListLine = YES;
-                                       isOrdered = type.integerValue == ENRMInputBlockTypeOrderedListItem;
-                                       NSNumber *depthValue = [storage attribute:ENRMBlockLevelAttributeName
-                                                                         atIndex:charRange.location
-                                                                  effectiveRange:NULL];
-                                       depth = depthValue ? depthValue.integerValue : 0;
-                                       NSNumber *ordinalValue = [storage attribute:ENRMBlockOrdinalAttributeName
-                                                                           atIndex:charRange.location
-                                                                    effectiveRange:NULL];
-                                       ordinal = ordinalValue ? ordinalValue.integerValue : 1;
-                                     }
-                                   }
-
-                                   // An empty list line has no character carrying the attribute, so the
-                                   // orchestrator points us at it explicitly.
-                                   BOOL isEmptyListLine = self.emptyBulletDepth >= 0 &&
-                                                          charRange.location == self.emptyBulletLocation &&
-                                                          !isAttributedListLine;
-                                   if (isEmptyListLine) {
-                                     depth = self.emptyBulletDepth;
-                                     isOrdered = self.emptyBulletOrdered;
-                                     ordinal = self.emptyBulletOrdinal;
-                                   }
-
-                                   if (!isAttributedListLine && !isEmptyListLine) {
-                                     return;
-                                   }
-                                   [drawnParagraphs addObject:@(paraRange.location)];
-
-                                   UIFont *font = nil;
-                                   UIColor *color = nil;
-                                   // An empty list line has no character carrying the font/color, so
-                                   // use the values the orchestrator supplied for the empty marker.
-                                   if (isEmptyListLine) {
-                                     font = self.emptyBulletFont;
-                                     color = self.emptyBulletColor;
-                                   }
-                                   if (!font && charRange.location < storage.length) {
-                                     font = [storage attribute:NSFontAttributeName
-                                                       atIndex:charRange.location
-                                                effectiveRange:NULL];
-                                   }
-                                   if (!color && charRange.location < storage.length) {
-                                     color = [storage attribute:NSForegroundColorAttributeName
-                                                        atIndex:charRange.location
-                                                 effectiveRange:NULL];
-                                   }
-                                   if (!font) {
-                                     font = [UIFont systemFontOfSize:16];
-                                   }
-                                   if (!color) {
-                                     color = [UIColor labelColor];
-                                   }
-
-                                   // An empty line's only glyph is a newline, whose location sits at the
-                                   // line's bottom rather than a text baseline — using it would draw the
-                                   // marker too low. Derive the baseline from the font ascender (plus the
-                                   // leading paragraph spacing, which pushes the text down within the
-                                   // fragment) so an empty list line's bullet lands exactly where the
-                                   // first typed glyph's bullet will.
-                                   CGFloat baselineOffset = isEmptyListLine
-                                                                ? self.listItemSpacing + font.ascender
-                                                                : [self locationForGlyphAtIndex:glyphRange.location].y;
-                                   CGFloat baselineY = origin.y + rect.origin.y + baselineOffset;
-
-                                   // An RTL paragraph anchors its text column to the trailing edge, so
-                                   // the marker mirrors to the right of the column (and an ordered
-                                   // marker flips to ".N"), matching the readonly ListMarkerDrawer.
-                                   BOOL isRTL;
-                                   if (isEmptyListLine) {
-                                     isRTL = self.emptyBulletRTL;
-                                   } else {
-                                     isRTL = ENRMParagraphIsRTL([storage attribute:NSParagraphStyleAttributeName
-                                                                           atIndex:charRange.location
-                                                                    effectiveRange:NULL]);
-                                   }
-
-                                   [self drawListMarkerOrdered:isOrdered
-                                                         depth:depth
-                                                       ordinal:ordinal
-                                                           rtl:isRTL
-                                                     baselineY:baselineY
-                                                        origin:origin
-                                                      usedRect:usedRect
-                                                     container:container
-                                                          font:font
-                                                         color:color];
-                                 }];
-
-  // The trailing empty line (including a wholly empty editor) has no glyph
-  // fragment — the enumeration above skips it — so draw its marker via the extra
-  // line fragment when the orchestrator has flagged it as an empty list line.
-  if (self.emptyBulletDepth >= 0 && self.emptyBulletLocation >= storage.length &&
-      self.extraLineFragmentTextContainer != nil) {
-    UIFont *font = self.emptyBulletFont ?: [UIFont systemFontOfSize:16];
-    UIColor *color = self.emptyBulletColor ?: [UIColor labelColor];
-    CGRect used = self.extraLineFragmentUsedRect;
-    NSTextContainer *extraContainer = self.extraLineFragmentTextContainer;
-    // Use the same optical center as the in-text marker (baseline minus half the
-    // cap/x-height), not the geometric line-box center (font.lineHeight / 2): the
-    // two diverge by a font-dependent amount, so a geometric center would shift
-    // the empty-line bullet relative to where the first typed glyph's bullet lands
-    // (visible with fonts whose ascender/descender are asymmetric).
-    CGFloat baselineY = origin.y + used.origin.y + font.ascender;
-    [self drawListMarkerOrdered:self.emptyBulletOrdered
-                          depth:self.emptyBulletDepth
-                        ordinal:self.emptyBulletOrdinal
-                            rtl:self.emptyBulletRTL
-                      baselineY:baselineY
-                         origin:origin
-                       usedRect:used
-                      container:extraContainer
-                           font:font
-                          color:color];
+  for (id<ENRMInputDecorationDrawer> drawer in _decorationDrawers) {
+    [drawer drawDecorationsForGlyphRange:glyphsToShow layoutManager:self atPoint:origin];
   }
 }
 
-- (void)drawEmptyEditorBulletWithInset:(UIEdgeInsets)inset
+#pragma mark - Empty Editor
+
+- (void)drawEmptyEditorDecorationsWithInset:(UIEdgeInsets)inset
 {
-  if (self.emptyBulletDepth < 0) {
-    return;
+  for (id<ENRMInputDecorationDrawer> drawer in _decorationDrawers) {
+    [drawer drawEmptyEditorDecorationsWithInset:inset layoutManager:self];
   }
-  UIFont *font = self.emptyBulletFont ?: [UIFont systemFontOfSize:16];
-  UIColor *color = self.emptyBulletColor ?: [UIColor labelColor];
-  // Text for a depth-d item starts at (d + 1) * kENRMListIndentPerDepth from the
-  // leading edge (see the list block handler); the marker sits a gap before that.
-  // In RTL the leading edge is the container's right side, so mirror the anchor.
-  CGFloat headIndent = (self.emptyBulletDepth + 1) * kENRMListIndentPerDepth;
-  NSTextContainer *container = self.textContainers.firstObject;
-  BOOL isRTL = self.emptyBulletRTL && container != nil;
-  CGFloat trailingX = inset.left + (container ? container.size.width : 0) - headIndent;
-  CGFloat markerX = isRTL ? trailingX + kENRMListBulletGap : inset.left + headIndent - kENRMListBulletGap;
-  // Optical center (baseline minus half the cap/x-height) to match the in-text
-  // marker, rather than the geometric line-box center; see the extra-line-fragment
-  // path. TextKit doesn't apply paragraphSpacingBefore to the first paragraph, so
-  // no spacing offset here.
-  CGFloat baselineY = inset.top + font.ascender;
-  if (self.emptyBulletOrdered) {
-    if (isRTL) {
-      [self drawOrderedMarkerStartingAtX:(trailingX + kENRMListBulletGap / 2.0)
-                               baselineY:baselineY
-                                 ordinal:self.emptyBulletOrdinal
-                                    font:font
-                                   color:color];
-    } else {
-      [self drawOrderedMarkerEndingAtX:(markerX + kENRMListBulletGap / 2.0)
-                             baselineY:baselineY
-                               ordinal:self.emptyBulletOrdinal
-                                  font:font
-                                 color:color];
-    }
-    return;
-  }
-  CGFloat centerY = baselineY - (font.xHeight + font.capHeight) / 4.0;
-  [self drawBulletAtX:markerX centerY:centerY depth:self.emptyBulletDepth font:font color:color];
 }
 
 @end

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#import "ENRMInputDecorationDrawer.h"
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Draws list markers (bullets / ordered numbers) into the head-indent column.
+@interface ENRMInputListMarkerDrawer : NSObject <ENRMInputDecorationDrawer>
+
+@property (nonatomic, assign) NSInteger emptyBulletDepth;
+@property (nonatomic, assign) BOOL emptyBulletOrdered;
+@property (nonatomic, assign) NSInteger emptyBulletOrdinal;
+@property (nonatomic, assign) NSUInteger emptyBulletLocation;
+@property (nonatomic, strong, nullable) UIFont *emptyBulletFont;
+@property (nonatomic, strong, nullable) UIColor *emptyBulletColor;
+@property (nonatomic, assign) BOOL emptyBulletRTL;
+@property (nonatomic, assign) CGFloat listItemSpacing;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.mm
@@ -1,0 +1,330 @@
+#import "ENRMInputListMarkerDrawer.h"
+#import "ENRMInputBlockType.h"
+#import "ParagraphStyleUtils.h"
+
+static UIFont *ENRMFallbackFont(void)
+{
+  return [UIFont systemFontOfSize:16];
+}
+
+static UIColor *ENRMFallbackColor(void)
+{
+  return [UIColor labelColor];
+}
+
+static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, CGFloat leadingOffset)
+{
+  return origin.x + container.size.width - leadingOffset;
+}
+
+#pragma mark -
+
+@implementation ENRMInputListMarkerDrawer {
+  NSMutableSet<NSNumber *> *_drawnParagraphLocations;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _emptyBulletDepth = -1;
+    _drawnParagraphLocations = [NSMutableSet set];
+  }
+  return self;
+}
+
+#pragma mark - Primitive Drawing
+
+- (void)drawBulletAtX:(CGFloat)markerX
+              centerY:(CGFloat)centerY
+                depth:(NSInteger)depth
+                 font:(UIFont *)font
+                color:(UIColor *)color
+{
+  CGContextRef ctx = UIGraphicsGetCurrentContext();
+  if (!ctx || isnan(markerX) || isnan(centerY)) {
+    return;
+  }
+
+  CGFloat size = MAX(4.0, font.pointSize * 0.30);
+  CGRect bulletRect = CGRectMake(markerX - size / 2.0, centerY - size / 2.0, size, size);
+
+  CGContextSaveGState(ctx);
+  NSInteger style = ((depth % 3) + 3) % 3;
+  switch (style) {
+    case 0:
+      [color setFill];
+      CGContextFillEllipseInRect(ctx, bulletRect);
+      break;
+    case 1: {
+      CGFloat lineWidth = MAX(1.0, size * 0.15);
+      [color setStroke];
+      CGContextSetLineWidth(ctx, lineWidth);
+      CGContextStrokeEllipseInRect(ctx, CGRectInset(bulletRect, lineWidth / 2.0, lineWidth / 2.0));
+      break;
+    }
+    default:
+      [color setFill];
+      CGContextFillRect(ctx, bulletRect);
+      break;
+  }
+  CGContextRestoreGState(ctx);
+}
+
+- (void)drawOrderedMarkerEndingAtX:(CGFloat)markerRight
+                         baselineY:(CGFloat)baselineY
+                           ordinal:(NSInteger)ordinal
+                              font:(UIFont *)font
+                             color:(UIColor *)color
+{
+  NSString *label = [NSString stringWithFormat:@"%ld.", (long)MAX(ordinal, (NSInteger)1)];
+  NSDictionary *attrs = @{NSFontAttributeName : font, NSForegroundColorAttributeName : color};
+  CGSize labelSize = [label sizeWithAttributes:attrs];
+  [label drawAtPoint:CGPointMake(markerRight - labelSize.width, baselineY - font.ascender) withAttributes:attrs];
+}
+
+- (void)drawOrderedMarkerStartingAtX:(CGFloat)markerLeft
+                           baselineY:(CGFloat)baselineY
+                             ordinal:(NSInteger)ordinal
+                                font:(UIFont *)font
+                               color:(UIColor *)color
+{
+  NSString *label = [NSString stringWithFormat:@".%ld", (long)MAX(ordinal, (NSInteger)1)];
+  NSDictionary *attrs = @{NSFontAttributeName : font, NSForegroundColorAttributeName : color};
+  [label drawAtPoint:CGPointMake(markerLeft, baselineY - font.ascender) withAttributes:attrs];
+}
+
+#pragma mark - Composite Marker
+
+- (void)drawListMarkerOrdered:(BOOL)isOrdered
+                        depth:(NSInteger)depth
+                      ordinal:(NSInteger)ordinal
+                          rtl:(BOOL)isRTL
+                    baselineY:(CGFloat)baselineY
+                       origin:(CGPoint)origin
+                     usedRect:(CGRect)usedRect
+                    container:(NSTextContainer *)container
+                         font:(UIFont *)font
+                        color:(UIColor *)color
+{
+  CGFloat leadingOffset = container.lineFragmentPadding + (depth + 1) * kENRMListIndentPerDepth;
+
+  if (isOrdered) {
+    if (isRTL) {
+      CGFloat anchorX = ENRMTrailingMarkerX(origin, container, leadingOffset) + kENRMListBulletGap / 2.0;
+      [self drawOrderedMarkerStartingAtX:anchorX baselineY:baselineY ordinal:ordinal font:font color:color];
+    } else {
+      CGFloat anchorX = origin.x + usedRect.origin.x - kENRMListBulletGap / 2.0;
+      [self drawOrderedMarkerEndingAtX:anchorX baselineY:baselineY ordinal:ordinal font:font color:color];
+    }
+    return;
+  }
+
+  CGFloat markerX = isRTL ? ENRMTrailingMarkerX(origin, container, leadingOffset) + kENRMListBulletGap
+                          : origin.x + usedRect.origin.x - kENRMListBulletGap;
+  CGFloat centerY = baselineY - (font.xHeight + font.capHeight) / 4.0;
+  [self drawBulletAtX:markerX centerY:centerY depth:depth font:font color:color];
+}
+
+#pragma mark - Attribute Resolution
+
+- (BOOL)readListAttributesAtIndex:(NSUInteger)charIndex
+                          storage:(NSTextStorage *)storage
+                        paraStart:(NSUInteger)paraStart
+                        isOrdered:(out BOOL *)outOrdered
+                            depth:(out NSInteger *)outDepth
+                          ordinal:(out NSInteger *)outOrdinal
+{
+  if (charIndex >= storage.length) {
+    return NO;
+  }
+
+  NSNumber *type = [storage attribute:ENRMBlockTypeAttributeName atIndex:charIndex effectiveRange:NULL];
+  if (!type || !ENRMBlockTypeIsListItem((ENRMInputBlockType)type.integerValue) || charIndex != paraStart) {
+    return NO;
+  }
+
+  *outOrdered = (type.integerValue == ENRMInputBlockTypeOrderedListItem);
+
+  NSNumber *depthValue = [storage attribute:ENRMBlockLevelAttributeName atIndex:charIndex effectiveRange:NULL];
+  *outDepth = depthValue ? depthValue.integerValue : 0;
+
+  NSNumber *ordinalValue = [storage attribute:ENRMBlockOrdinalAttributeName atIndex:charIndex effectiveRange:NULL];
+  *outOrdinal = ordinalValue ? ordinalValue.integerValue : 1;
+
+  return YES;
+}
+
+- (void)resolveMarkerFont:(out UIFont **)outFont
+                    color:(out UIColor **)outColor
+                  atIndex:(NSUInteger)charIndex
+                  storage:(NSTextStorage *)storage
+          isEmptyListLine:(BOOL)isEmptyListLine
+{
+  UIFont *font = nil;
+  UIColor *color = nil;
+
+  if (isEmptyListLine) {
+    font = self.emptyBulletFont;
+    color = self.emptyBulletColor;
+  }
+  if (!font && charIndex < storage.length) {
+    font = [storage attribute:NSFontAttributeName atIndex:charIndex effectiveRange:NULL];
+  }
+  if (!color && charIndex < storage.length) {
+    color = [storage attribute:NSForegroundColorAttributeName atIndex:charIndex effectiveRange:NULL];
+  }
+
+  *outFont = font ?: ENRMFallbackFont();
+  *outColor = color ?: ENRMFallbackColor();
+}
+
+#pragma mark - Fragment Processing
+
+- (void)processLineFragmentRect:(CGRect)rect
+                       usedRect:(CGRect)usedRect
+                      container:(NSTextContainer *)container
+                     glyphRange:(NSRange)glyphRange
+                         origin:(CGPoint)origin
+                  layoutManager:(NSLayoutManager *)layoutManager
+                        storage:(NSTextStorage *)storage
+                         string:(NSString *)string
+{
+  NSRange charRange = [layoutManager characterRangeForGlyphRange:glyphRange actualGlyphRange:NULL];
+  if (charRange.location == NSNotFound) {
+    return;
+  }
+
+  NSRange paraRange = (charRange.location < string.length) ? [string paragraphRangeForRange:charRange]
+                                                           : NSMakeRange(charRange.location, 0);
+
+  if ([_drawnParagraphLocations containsObject:@(paraRange.location)]) {
+    return;
+  }
+
+  BOOL isOrdered = NO;
+  NSInteger depth = 0;
+  NSInteger ordinal = 1;
+  BOOL isAttributedListLine = [self readListAttributesAtIndex:charRange.location
+                                                      storage:storage
+                                                    paraStart:paraRange.location
+                                                    isOrdered:&isOrdered
+                                                        depth:&depth
+                                                      ordinal:&ordinal];
+
+  BOOL isEmptyListLine =
+      !isAttributedListLine && self.emptyBulletDepth >= 0 && charRange.location == self.emptyBulletLocation;
+  if (isEmptyListLine) {
+    depth = self.emptyBulletDepth;
+    isOrdered = self.emptyBulletOrdered;
+    ordinal = self.emptyBulletOrdinal;
+  }
+
+  if (!isAttributedListLine && !isEmptyListLine) {
+    return;
+  }
+  [_drawnParagraphLocations addObject:@(paraRange.location)];
+
+  UIFont *font;
+  UIColor *color;
+  [self resolveMarkerFont:&font
+                    color:&color
+                  atIndex:charRange.location
+                  storage:storage
+          isEmptyListLine:isEmptyListLine];
+
+  CGFloat baselineOffset = isEmptyListLine ? self.listItemSpacing + font.ascender
+                                           : [layoutManager locationForGlyphAtIndex:glyphRange.location].y;
+  CGFloat baselineY = origin.y + rect.origin.y + baselineOffset;
+
+  BOOL isRTL = isEmptyListLine ? self.emptyBulletRTL
+                               : ENRMParagraphIsRTL([storage attribute:NSParagraphStyleAttributeName
+                                                               atIndex:charRange.location
+                                                        effectiveRange:NULL]);
+
+  [self drawListMarkerOrdered:isOrdered
+                        depth:depth
+                      ordinal:ordinal
+                          rtl:isRTL
+                    baselineY:baselineY
+                       origin:origin
+                     usedRect:usedRect
+                    container:container
+                         font:font
+                        color:color];
+}
+
+#pragma mark - ENRMInputDecorationDrawer
+
+- (void)drawDecorationsForGlyphRange:(NSRange)glyphRange
+                       layoutManager:(NSLayoutManager *)layoutManager
+                             atPoint:(CGPoint)origin
+{
+  NSTextStorage *storage = layoutManager.textStorage;
+  NSString *string = storage.string;
+  [_drawnParagraphLocations removeAllObjects];
+
+  [layoutManager enumerateLineFragmentsForGlyphRange:glyphRange
+                                          usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer *container,
+                                                       NSRange fragmentGlyphRange, __unused BOOL *stop) {
+                                            [self processLineFragmentRect:rect
+                                                                 usedRect:usedRect
+                                                                container:container
+                                                               glyphRange:fragmentGlyphRange
+                                                                   origin:origin
+                                                            layoutManager:layoutManager
+                                                                  storage:storage
+                                                                   string:string];
+                                          }];
+
+  // Trailing empty line has no glyph fragment — draw via extra line fragment.
+  if (self.emptyBulletDepth >= 0 && self.emptyBulletLocation >= storage.length &&
+      layoutManager.extraLineFragmentTextContainer != nil) {
+    UIFont *font = self.emptyBulletFont ?: ENRMFallbackFont();
+    UIColor *color = self.emptyBulletColor ?: ENRMFallbackColor();
+    CGRect used = layoutManager.extraLineFragmentUsedRect;
+    CGFloat baselineY = origin.y + used.origin.y + font.ascender;
+    [self drawListMarkerOrdered:self.emptyBulletOrdered
+                          depth:self.emptyBulletDepth
+                        ordinal:self.emptyBulletOrdinal
+                            rtl:self.emptyBulletRTL
+                      baselineY:baselineY
+                         origin:origin
+                       usedRect:used
+                      container:layoutManager.extraLineFragmentTextContainer
+                           font:font
+                          color:color];
+  }
+}
+
+- (void)drawEmptyEditorDecorationsWithInset:(UIEdgeInsets)inset layoutManager:(NSLayoutManager *)layoutManager
+{
+  if (self.emptyBulletDepth < 0) {
+    return;
+  }
+
+  UIFont *font = self.emptyBulletFont ?: ENRMFallbackFont();
+  UIColor *color = self.emptyBulletColor ?: ENRMFallbackColor();
+  NSTextContainer *container = layoutManager.textContainers.firstObject;
+  BOOL isRTL = self.emptyBulletRTL && container != nil;
+
+  CGFloat headIndent = (self.emptyBulletDepth + 1) * kENRMListIndentPerDepth;
+  CGFloat padding = container ? container.lineFragmentPadding : 0;
+  CGRect syntheticUsedRect = CGRectMake(padding + headIndent, 0, 0, 0);
+  CGPoint syntheticOrigin = CGPointMake(inset.left, 0);
+  NSTextContainer *drawContainer = container ?: [[NSTextContainer alloc] initWithSize:CGSizeMake(0, CGFLOAT_MAX)];
+
+  CGFloat baselineY = inset.top + font.ascender;
+
+  [self drawListMarkerOrdered:self.emptyBulletOrdered
+                        depth:self.emptyBulletDepth
+                      ordinal:self.emptyBulletOrdinal
+                          rtl:isRTL
+                    baselineY:baselineY
+                       origin:syntheticOrigin
+                     usedRect:syntheticUsedRect
+                    container:drawContainer
+                         font:font
+                        color:color];
+}
+
+@end

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputTextView.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputTextView.mm
@@ -115,11 +115,11 @@ NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-markdown.
 {
   [super drawRect:rect];
   // A wholly empty editor has no glyphs, so the layout manager's
-  // drawGlyphsForGlyphRange: never runs — draw the just-toggled list marker here.
+  // drawGlyphsForGlyphRange: never runs — draw decorations here instead.
   if (self.text.length == 0) {
     NSLayoutManager *layoutManager = self.layoutManager;
     if ([layoutManager isKindOfClass:[ENRMInputLayoutManager class]]) {
-      [(ENRMInputLayoutManager *)layoutManager drawEmptyEditorBulletWithInset:self.textContainerInset];
+      [(ENRMInputLayoutManager *)layoutManager drawEmptyEditorDecorationsWithInset:self.textContainerInset];
     }
   }
 }

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -13,6 +13,7 @@
 #import "ENRMInputFormatter.h"
 #import "ENRMInputLayoutManager.h"
 #import "ENRMInputLinkPrompt.h"
+#import "ENRMInputListMarkerDrawer.h"
 #import "ENRMInputParser.h"
 #import "ENRMInputTextView.h"
 #import "ENRMLinkCoordinator.h"
@@ -1155,14 +1156,15 @@ using namespace facebook::react;
     }
   }
 
-  _layoutManager.emptyBulletDepth = show ? depth : -1;
-  _layoutManager.emptyBulletOrdered = ordered;
-  _layoutManager.emptyBulletOrdinal = ordinal;
-  _layoutManager.emptyBulletLocation = location;
-  _layoutManager.emptyBulletFont = _formatterStyle.baseFont;
-  _layoutManager.emptyBulletColor = _formatterStyle.baseTextColor;
-  _layoutManager.emptyBulletRTL = [self emptyListLineIsRTL];
-  _layoutManager.listItemSpacing = _formatterStyle.listItemSpacing;
+  ENRMInputListMarkerDrawer *listDrawer = _layoutManager.listMarkerDrawer;
+  listDrawer.emptyBulletDepth = show ? depth : -1;
+  listDrawer.emptyBulletOrdered = ordered;
+  listDrawer.emptyBulletOrdinal = ordinal;
+  listDrawer.emptyBulletLocation = location;
+  listDrawer.emptyBulletFont = _formatterStyle.baseFont;
+  listDrawer.emptyBulletColor = _formatterStyle.baseTextColor;
+  listDrawer.emptyBulletRTL = [self emptyListLineIsRTL];
+  listDrawer.listItemSpacing = _formatterStyle.listItemSpacing;
 
   // An empty editor never runs the formatter (it early-returns at length 0), so
   // the trailing/extra line fragment the marker draws into isn't laid out yet —


### PR DESCRIPTION
### What/Why?
Introduce ENRMInputDecorationDrawer protocol and extract all list-marker rendering from ENRMInputLayoutManager into ENRMInputListMarkerDrawer. The layout manager is now a thin orchestrator that iterates registered drawers, making it trivial to add new decorations (e.g. blockquote borders) without modifying existing code.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

