### PR TITLE
fix(input/ios): show trailing empty-line bullet marker immediately

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.h
@@ -17,6 +17,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL emptyBulletRTL;
 @property (nonatomic, assign) CGFloat listItemSpacing;
 
+#if !TARGET_OS_OSX
+/// Shows or updates a subview overlay that draws the trailing empty line's
+/// bullet.  drawGlyphsForGlyphRange: clips to the glyph area, which excludes
+/// the extra line fragment -- a subview is immune to that clipping.
+- (void)showTrailingBulletInTextView:(UITextView *)textView
+                       textContainer:(NSTextContainer *)container
+                            usedRect:(CGRect)usedRect;
+- (void)hideTrailingBullet;
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.mm
@@ -17,10 +17,42 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
   return origin.x + container.size.width - leadingOffset;
 }
 
+@interface ENRMInputListMarkerDrawer ()
+- (void)drawTrailingBulletMarkerInRect:(CGRect)bounds;
+@end
+
+#if !TARGET_OS_OSX
+
+#pragma mark - Trailing bullet overlay
+
+/// A lightweight overlay that draws the trailing empty line's list marker.
+/// drawGlyphsForGlyphRange: clips its context to the glyph area, which excludes
+/// the extra line fragment.  A subview is immune to that clipping.
+@interface ENRMTrailingBulletView : UIView
+@property (nonatomic, weak) ENRMInputListMarkerDrawer *drawer;
+@end
+
+@implementation ENRMTrailingBulletView
+
+- (void)drawRect:(CGRect)rect
+{
+  [_drawer drawTrailingBulletMarkerInRect:self.bounds];
+}
+
+@end
+
+#endif
+
 #pragma mark -
 
 @implementation ENRMInputListMarkerDrawer {
   NSMutableSet<NSNumber *> *_drawnParagraphLocations;
+#if !TARGET_OS_OSX
+  ENRMTrailingBulletView *_trailingBulletView;
+  __weak NSTextContainer *_trailingBulletTextContainer;
+  CGFloat _trailingBulletInsetLeft;
+  CGFloat _trailingBulletHeadIndent;
+#endif
 }
 
 - (instancetype)init
@@ -276,7 +308,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
                                                                    string:string];
                                           }];
 
-  // Trailing empty line has no glyph fragment — draw via extra line fragment.
+#if TARGET_OS_OSX
   if (self.emptyBulletDepth >= 0 && self.emptyBulletLocation >= storage.length &&
       layoutManager.extraLineFragmentTextContainer != nil) {
     UIFont *font = self.emptyBulletFont ?: ENRMFallbackFont();
@@ -294,6 +326,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
                            font:font
                           color:color];
   }
+#endif
 }
 
 - (void)drawEmptyEditorDecorationsWithInset:(UIEdgeInsets)inset layoutManager:(NSLayoutManager *)layoutManager
@@ -326,5 +359,68 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
                          font:font
                         color:color];
 }
+
+#if !TARGET_OS_OSX
+
+#pragma mark - Trailing Bullet Overlay
+
+- (void)drawTrailingBulletMarkerInRect:(CGRect)bounds
+{
+  if (self.emptyBulletDepth < 0 || !_trailingBulletTextContainer) {
+    return;
+  }
+
+  UIFont *font = self.emptyBulletFont ?: ENRMFallbackFont();
+  UIColor *color = self.emptyBulletColor ?: ENRMFallbackColor();
+
+  CGRect usedRect = CGRectMake(_trailingBulletHeadIndent, 0, 0, bounds.size.height);
+  CGPoint origin = CGPointMake(_trailingBulletInsetLeft, 0);
+
+  [self drawListMarkerOrdered:self.emptyBulletOrdered
+                        depth:self.emptyBulletDepth
+                      ordinal:self.emptyBulletOrdinal
+                          rtl:self.emptyBulletRTL
+                    baselineY:font.ascender
+                       origin:origin
+                     usedRect:usedRect
+                    container:_trailingBulletTextContainer
+                         font:font
+                        color:color];
+}
+
+- (void)showTrailingBulletInTextView:(UITextView *)textView
+                       textContainer:(NSTextContainer *)container
+                            usedRect:(CGRect)usedRect
+{
+  if (!_trailingBulletView) {
+    _trailingBulletView = [[ENRMTrailingBulletView alloc] init];
+    _trailingBulletView.backgroundColor = [UIColor clearColor];
+    _trailingBulletView.opaque = NO;
+    _trailingBulletView.userInteractionEnabled = NO;
+  }
+
+  if (_trailingBulletView.superview != textView) {
+    [_trailingBulletView removeFromSuperview];
+    [textView addSubview:_trailingBulletView];
+  }
+
+  UIEdgeInsets inset = textView.textContainerInset;
+  _trailingBulletView.frame =
+      CGRectMake(0, inset.top + usedRect.origin.y, textView.bounds.size.width, usedRect.size.height);
+  _trailingBulletView.drawer = self;
+  _trailingBulletTextContainer = container;
+  _trailingBulletInsetLeft = inset.left;
+  _trailingBulletHeadIndent = usedRect.origin.x;
+  _trailingBulletView.hidden = NO;
+  [textView bringSubviewToFront:_trailingBulletView];
+  [_trailingBulletView setNeedsDisplay];
+}
+
+- (void)hideTrailingBullet
+{
+  _trailingBulletView.hidden = YES;
+}
+
+#endif
 
 @end

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputTextView.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputTextView.mm
@@ -8,7 +8,9 @@ NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-markdown.
 
 #if !TARGET_OS_OSX
 
-@implementation ENRMInputTextView
+@implementation ENRMInputTextView {
+  CGFloat _lastLayoutWidth;
+}
 
 - (void)copy:(id)sender
 {
@@ -74,7 +76,9 @@ NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-markdown.
 - (void)layoutSubviews
 {
   [super layoutSubviews];
-  if (self.markdownTextInput != nil) {
+  CGFloat currentWidth = self.bounds.size.width;
+  if (self.markdownTextInput != nil && fabs(currentWidth - _lastLayoutWidth) > 0.5) {
+    _lastLayoutWidth = currentWidth;
     [self.markdownTextInput scheduleRelayoutIfNeeded];
   }
 }
@@ -128,7 +132,9 @@ NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-markdown.
 
 #else // TARGET_OS_OSX
 
-@implementation ENRMInputTextView
+@implementation ENRMInputTextView {
+  CGFloat _lastLayoutWidth;
+}
 
 - (void)copy:(id)sender
 {
@@ -208,7 +214,9 @@ NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-markdown.
 - (void)layout
 {
   [super layout];
-  if (self.markdownTextInput != nil) {
+  CGFloat currentWidth = self.bounds.size.width;
+  if (self.markdownTextInput != nil && fabs(currentWidth - _lastLayoutWidth) > 0.5) {
+    _lastLayoutWidth = currentWidth;
     [self.markdownTextInput scheduleRelayoutIfNeeded];
   }
 }

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -538,20 +538,23 @@ using namespace facebook::react;
     return;
   }
 
-  dispatch_async(dispatch_get_main_queue(), ^{
-    NSUInteger textLength = self->_textView.textStorage.length;
-    if (textLength == 0) {
-      return;
-    }
-    NSRange wholeRange = NSMakeRange(0, textLength);
-    NSRange actualRange = NSMakeRange(0, 0);
-    [self->_textView.layoutManager invalidateLayoutForCharacterRange:wholeRange actualCharacterRange:&actualRange];
-    [self->_textView.layoutManager ensureLayoutForCharacterRange:actualRange];
-    [self->_textView.layoutManager invalidateDisplayForCharacterRange:wholeRange];
+  NSUInteger textLength = _textView.textStorage.length;
+  if (textLength == 0) {
+    return;
+  }
 
-    CGSize measuredSize = [self measureSize:self->_textView.frame.size.width];
-    ENRMSetContentSize(self->_textView, measuredSize);
-  });
+  NSRange wholeRange = NSMakeRange(0, textLength);
+  [_textView.layoutManager invalidateLayoutForCharacterRange:wholeRange actualCharacterRange:NULL];
+  [_textView.layoutManager ensureLayoutForTextContainer:_textView.textContainer];
+  [_textView.layoutManager invalidateDisplayForCharacterRange:wholeRange];
+
+  CGSize measuredSize = [self measureSize:_textView.frame.size.width];
+  CGSize currentSize = _textView.contentSize;
+  BOOL sizeChanged =
+      fabs(currentSize.width - measuredSize.width) > 0.5 || fabs(currentSize.height - measuredSize.height) > 0.5;
+  if (sizeChanged) {
+    ENRMSetContentSize(_textView, measuredSize);
+  }
 }
 
 #pragma mark - Window attachment
@@ -1166,12 +1169,27 @@ using namespace facebook::react;
   listDrawer.emptyBulletRTL = [self emptyListLineIsRTL];
   listDrawer.listItemSpacing = _formatterStyle.listItemSpacing;
 
-  // An empty editor never runs the formatter (it early-returns at length 0), so
-  // the trailing/extra line fragment the marker draws into isn't laid out yet —
-  // force it so the bullet appears before the first keystroke.
-  if (show && text.length == 0) {
+  BOOL isTrailing = show && text.length > 0 && location >= text.length;
+
+  // Ensure the extra line fragment is laid out so we can read
+  // extraLineFragmentTextContainer / extraLineFragmentUsedRect.  The
+  // empty-editor case (length 0) has no glyphs at all; the trailing-line case
+  // (location >= length) has glyphs on preceding lines but the extra line
+  // fragment lives beyond them and isn't covered by ensureLayoutForCharRange:.
+  if (show && (text.length == 0 || location >= text.length)) {
     [_layoutManager ensureLayoutForTextContainer:_textView.textContainer];
   }
+
+#if !TARGET_OS_OSX
+  if (isTrailing && _layoutManager.extraLineFragmentTextContainer != nil) {
+    [listDrawer showTrailingBulletInTextView:_textView
+                               textContainer:_layoutManager.extraLineFragmentTextContainer
+                                    usedRect:_layoutManager.extraLineFragmentUsedRect];
+  } else {
+    [listDrawer hideTrailingBullet];
+  }
+#endif
+
   ENRMSetNeedsDisplay(_textView);
 
   // The empty-editor bullet would otherwise overlap the placeholder.


### PR DESCRIPTION
### What/Why?
When pressing Enter at the end of a list item, the new trailing empty line should immediately show a bullet marker. Instead, the bullet was invisible until the user started typing.
**Root cause — two intertwined bugs:**
1. **Invisible trailing bullet draw.** `drawGlyphsForGlyphRange:` clips its CoreGraphics context to the glyph area. The trailing empty line lives in the *extra line fragment*, which has no glyphs — so the bullet was drawn but clipped away by the text system.
2. **Infinite relayout loop.** `layoutSubviews` unconditionally called `scheduleRelayoutIfNeeded`, which invalidated layout → updated content size → triggered `layoutSubviews` again, repeating indefinitely. This also cleared the `extraLineFragmentTextContainer` between cycles, preventing earlier fix attempts from working.
### How?
**Trailing bullet — subview overlay (iOS):**
- Introduced `ENRMTrailingBulletView`, a lightweight transparent UIView that draws the list marker in its own `drawRect:`. Subviews composite on top of UITextView's internal tile layers, so they're immune to glyph-area clipping.
- The list marker drawer (`ENRMInputListMarkerDrawer`) owns the view and all positioning state. This keeps all three marker rendering paths in one place: normal lines (glyph draw pass), empty editor (`drawRect:`), and trailing empty line (subview overlay).
- On macOS, the original `drawGlyphsForGlyphRange:` path is preserved — `NSTextView` doesn't use tiled rendering, so glyph-area clipping isn't an issue there.
**Relayout loop — two guards:**
- `layoutSubviews` / `layout` now only schedules a relayout when the view's width actually changes (> 0.5pt delta). Width is the only dimension that affects text reflow.
- `_performRelayout` skips `ENRMSetContentSize` when the measured size matches the current content size, breaking the `setContentSize → layoutSubviews → relayout` feedback cycle.
- Removed the unnecessary `dispatch_async` wrapper from `_performRelayout` — `performSelector:afterDelay:0` already defers to the next run loop.
**Layout fix for extra line fragment:**
- `ensureLayoutForTextContainer:` is now called (instead of `ensureLayoutForCharacterRange:`) so the extra line fragment rect is populated before the bullet overlay is positioned.

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

