### PR TITLE
fix(ios): reset typing attributes when input is cleared to remove stale list indent

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -672,6 +672,10 @@ using namespace facebook::react;
   [self applyFormatting];
   [self updatePlaceholderVisibility];
 
+  if (parsed.plainText.length == 0) {
+    [self resetBaseTypingAttributes];
+  }
+
   [_editSession exitPhase];
 }
 


### PR DESCRIPTION
### What/Why?

When a message containing a list is sent and the input is cleared, the cursor retains the list's paragraph indent (`headIndent`/`firstLineHeadIndent`). This happens because `importMarkdown:` clears the text storage and formatting/block stores but doesn't reset `UITextView.typingAttributes`, which persist independently.

This PR resets typing attributes to the base font/color when `importMarkdown:` receives an empty string, matching the behavior already present in the text-change handler's "text becomes empty" path.

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

