### PR TITLE
feat: match rn textinput keyboard-dismiss behavior on taps outside the input

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -728,6 +728,8 @@ Fires when the input loses focus.
 | -------------- | ------------- | -------- |
 | `() => void`   | -             | Both     |
 
+The input participates in React Native's text-input focus tracking (`TextInput.State`), so blur also happens through the platform's standard keyboard-dismiss paths: taps outside the input inside a `ScrollView` (per its `keyboardShouldPersistTaps` setting) and `Keyboard.dismiss()`. See [Keyboard Dismissal](INPUT.md#keyboard-dismissal).
+
 ### `onStartMention`
 
 Fires when a new mention flow starts. See [Mentions](MENTIONS.md#events).

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -220,6 +220,16 @@ You can find some examples in the [usage section](#usage) or in the example app.
 - [onChangeSelection](API_REFERENCE.md#onchangeselection) - returns `{ start, end }` of the current selection, useful for working with [links](#links).
 - [onKeyPress](API_REFERENCE.md#onkeypress) - returns `{ nativeEvent: { key } }` for every keystroke before it is applied to the content, mirroring React Native TextInput's `onKeyPress`.
 
+## Keyboard Dismissal
+
+`EnrichedMarkdownTextInput` registers with React Native's text-input focus tracking (`TextInput.State`), so scroll containers treat it exactly like the built-in `TextInput`. No props on the input are involved — the behavior is controlled by the surrounding `ScrollView` / `FlatList`:
+
+- With the soft keyboard open, tapping outside the focused input blurs it and dismisses the keyboard, following the scroll container's [`keyboardShouldPersistTaps`](https://reactnative.dev/docs/scrollview#keyboardshouldpersisttaps) setting. In the default `'never'` mode the dismissing tap is consumed (the classic first-tap-dismisses, second-tap-presses behavior); `'handled'` dismisses only on taps no child handles; `'always'` never auto-dismisses.
+- Scrolling does not dismiss the keyboard unless the container sets [`keyboardDismissMode`](https://reactnative.dev/docs/scrollview#keyboarddismissmode).
+- [`Keyboard.dismiss()`](https://reactnative.dev/docs/keyboard#dismiss) blurs the input when it is the focused field.
+
+Matching `TextInput`, none of this applies while a hardware keyboard is in use (for example the iOS Simulator with **Connect Hardware Keyboard** enabled): with no soft keyboard on screen there is nothing to dismiss, so outside taps intentionally leave the input focused.
+
 ## RTL Support
 
 `EnrichedMarkdownTextInput` resolves writing direction **per paragraph**, matching the read-only [`EnrichedMarkdownText`](RTL.md) renderer. Arabic, Hebrew, and Persian content right-aligns automatically as the user types — even mixed with English paragraphs in the same input.

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -527,19 +527,11 @@ export const EnrichedMarkdownTextInput = ({
 
   const handleFocus = useCallback(() => {
     TextInputState.focusInput(nativeRef.current);
-    console.log(
-      'registry focused?',
-      TextInputState.currentlyFocusedInput() != null
-    );
     onFocus?.();
   }, [onFocus]);
 
   const handleBlur = useCallback(() => {
     TextInputState.blurInput(nativeRef.current);
-    console.log(
-      'registry blurred?',
-      TextInputState.currentlyFocusedInput() == null
-    );
     onBlur?.();
   }, [onBlur]);
 

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
 } from 'react';
@@ -41,6 +42,7 @@ import type {
 import { normalizeMarkdownTextInputStyle } from './normalizeMarkdownTextInputStyle';
 import { normalizeMenuItem } from './normalizeMenuItem';
 import { toNativeRegexConfig } from './utils/regexParser';
+import { TextInputState } from './utils/textInputState';
 import type { RefObject } from 'react';
 
 type NativeRef = HostInstance;
@@ -354,6 +356,27 @@ export const EnrichedMarkdownTextInput = ({
     };
   }, []);
 
+  /**
+   * Mirrors the built-in TextInput's TextInputState integration so scroll
+   * containers' keyboardShouldPersistTaps logic and Keyboard.dismiss treat
+   * this input like a native TextInput. See utils/textInputState.ts for the
+   * full rationale. The unmount cleanup blurs through blurTextInput so both
+   * the registry entry and the native focus are released, matching the
+   * TextInput unmount path.
+   */
+  useLayoutEffect(() => {
+    const instance = nativeRef.current;
+    if (instance == null) return;
+
+    TextInputState.registerInput(instance);
+    return () => {
+      if (TextInputState.currentlyFocusedInput() === instance) {
+        TextInputState.blurTextInput(instance);
+      }
+      TextInputState.unregisterInput(instance);
+    };
+  }, []);
+
   const normalizedStyle = normalizeMarkdownTextInputStyle(markdownStyle);
 
   const normalizedSelectionMenuConfig = useMemo(() => {
@@ -503,10 +526,20 @@ export const EnrichedMarkdownTextInput = ({
   );
 
   const handleFocus = useCallback(() => {
+    TextInputState.focusInput(nativeRef.current);
+    console.log(
+      'registry focused?',
+      TextInputState.currentlyFocusedInput() != null
+    );
     onFocus?.();
   }, [onFocus]);
 
   const handleBlur = useCallback(() => {
+    TextInputState.blurInput(nativeRef.current);
+    console.log(
+      'registry blurred?',
+      TextInputState.currentlyFocusedInput() == null
+    );
     onBlur?.();
   }, [onBlur]);
 

--- a/packages/react-native-enriched-markdown/src/utils/textInputState.ts
+++ b/packages/react-native-enriched-markdown/src/utils/textInputState.ts
@@ -1,0 +1,43 @@
+/**
+ * Bridges EnrichedMarkdownTextInput into React Native's TextInputState focus
+ * registry so it participates in RN's keyboard-dismiss behavior (issue #577).
+ *
+ * RN's tap-to-dismiss logic (ScrollView's keyboardShouldPersistTaps handling
+ * and Keyboard.dismiss) is implemented entirely in JS. ScrollView's responder
+ * handlers consult TextInputState, a plain JS module holding the set of
+ * registered inputs and the currently focused one, to decide whether a tap
+ * outside the focused field should blur it. A custom native input that never
+ * registers is invisible to that logic: ScrollView concludes no text input is
+ * focused and leaves the keyboard up.
+ *
+ * Registering a non-TextInput host component is safe by design. When
+ * ScrollView dismisses, TextInputState.blurTextInput dispatches the built-in
+ * TextInput's "blur" command at the registered instance, and Fabric command
+ * dispatch is name-based; TextInputState.js states "commands don't actually
+ * care as long as the thing being passed in actually has a command with that
+ * name". EnrichedMarkdownTextInput ships focus/blur commands under those
+ * exact names, so the dispatch lands in the existing native handlers and no
+ * native changes are needed.
+ *
+ * The registry has no complete public export: TextInput.State exposes only
+ * blurTextInput/focusTextInput/currentlyFocusedInput and lacks the
+ * registerInput/focusInput/blurInput bookkeeping functions, so a deep import
+ * is required. This is the same approach @expensify/react-native-live-markdown
+ * uses. The import is typed here via a local interface; requiring at runtime
+ * keeps the internal module out of the public type surface.
+ */
+import type { HostInstance } from 'react-native';
+
+interface TextInputStateModule {
+  registerInput(input: HostInstance): void;
+  unregisterInput(input: HostInstance): void;
+  focusInput(input: HostInstance | null): void;
+  blurInput(input: HostInstance | null): void;
+  blurTextInput(input: HostInstance | null): void;
+  currentlyFocusedInput(): HostInstance | null;
+}
+
+export const TextInputState =
+  // eslint-disable-next-line @react-native/no-deep-imports
+  require('react-native/Libraries/Components/TextInput/TextInputState')
+    .default as TextInputStateModule;

--- a/packages/react-native-enriched-markdown/src/utils/textInputState.ts
+++ b/packages/react-native-enriched-markdown/src/utils/textInputState.ts
@@ -37,7 +37,15 @@ interface TextInputStateModule {
   currentlyFocusedInput(): HostInstance | null;
 }
 
-export const TextInputState =
+/**
+ * The internal module's export shape has changed across RN versions: newer
+ * versions use `export default` (surfacing as `.default` after Metro's CJS
+ * transform) while older ones assigned `module.exports` directly. A raw
+ * require bypasses Babel's import interop, so both shapes are handled here.
+ */
+const TextInputStateModuleImpl =
   // eslint-disable-next-line @react-native/no-deep-imports
-  require('react-native/Libraries/Components/TextInput/TextInputState')
-    .default as TextInputStateModule;
+  require('react-native/Libraries/Components/TextInput/TextInputState');
+
+export const TextInputState = (TextInputStateModuleImpl.default ??
+  TextInputStateModuleImpl) as TextInputStateModule;

--- a/packages/react-native-enriched-markdown/src/utils/textInputState.ts
+++ b/packages/react-native-enriched-markdown/src/utils/textInputState.ts
@@ -2,29 +2,13 @@
  * Bridges EnrichedMarkdownTextInput into React Native's TextInputState focus
  * registry so it participates in RN's keyboard-dismiss behavior (issue #577).
  *
- * RN's tap-to-dismiss logic (ScrollView's keyboardShouldPersistTaps handling
- * and Keyboard.dismiss) is implemented entirely in JS. ScrollView's responder
- * handlers consult TextInputState, a plain JS module holding the set of
- * registered inputs and the currently focused one, to decide whether a tap
- * outside the focused field should blur it. A custom native input that never
- * registers is invisible to that logic: ScrollView concludes no text input is
- * focused and leaves the keyboard up.
+ * Registering a non-TextInput host component is safe: TextInputState's
+ * blurTextInput dispatches the built-in TextInput's "blur" command at the
+ * registered instance, and Fabric command dispatch is name-based — it works
+ * as long as the component ships a command with that name, which ours does.
  *
- * Registering a non-TextInput host component is safe by design. When
- * ScrollView dismisses, TextInputState.blurTextInput dispatches the built-in
- * TextInput's "blur" command at the registered instance, and Fabric command
- * dispatch is name-based; TextInputState.js states "commands don't actually
- * care as long as the thing being passed in actually has a command with that
- * name". EnrichedMarkdownTextInput ships focus/blur commands under those
- * exact names, so the dispatch lands in the existing native handlers and no
- * native changes are needed.
- *
- * The registry has no complete public export: TextInput.State exposes only
- * blurTextInput/focusTextInput/currentlyFocusedInput and lacks the
- * registerInput/focusInput/blurInput bookkeeping functions, so a deep import
- * is required. This is the same approach @expensify/react-native-live-markdown
- * uses. The import is typed here via a local interface; requiring at runtime
- * keeps the internal module out of the public type surface.
+ * A deep import is required because the public TextInput.State API lacks the
+ * registerInput/focusInput/blurInput bookkeeping functions.
  */
 import type { HostInstance } from 'react-native';
 


### PR DESCRIPTION
### What/Why?
Closes #577.

When `EnrichedMarkdownTextInput` was focused inside a `ScrollView`/`FlatList`, tapping outside it (e.g. on the message list above a chat composer) left the input focused and the keyboard up - unlike the built-in TextInput, which blurs per the scroll container's keyboardShouldPersistTaps setting.

RN's tap-to-dismiss behavior is implemented entirely in JS: ScrollView's responder handlers consult TextInputState (a JS-side registry of host instances) to decide whether a tap should dismiss the keyboard. A custom input that never registers is invisible to that logic — ScrollView concludes no text input is focused and does nothing.

We mirror behaviour of RN by:
  - register on mount / unregister (blurring first if focused) on unmount,
  - `focusInput`/`blurInput` on the native focus/blur events, so all focus sources are tracked (tap, ref.focus(), autoFocus).

### Testing
In the example app's Playground screen (its ScrollView uses keyboardShouldPersistTaps="handled"):
1. Focus the input so the soft keyboard opens.
2. Tap a non-touchable area (the Preview box, padding between button rows) → input blurs, keyboard dismisses. Taps on
buttons still fire without dismissing (correct 'handled' semantics).
3. Temporarily remove the keyboardShouldPersistTaps prop (default 'never') → the first tap on a button only dismisses the
keyboard, the second presses it - stock TextInput two-tap behavior.
4. Tap inside the focused input → caret moves, keyboard stays.
5. Scroll while focused → keyboard stays.

#### Screenshots 

https://github.com/user-attachments/assets/76bf9f58-c6cb-47f1-aa6f-c2cb9108ff78


https://github.com/user-attachments/assets/594a1d7f-8a16-41d6-8cc6-d17b86f9fd83



### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

