### PR TITLE
refactor(input): extract ENRMInputEventEmitter from EnrichedMarkdownTextInput 

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputEventEmitter.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputEventEmitter.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#import "ENRMBlockRange.h"
+#import "ENRMInputStyledRange.h"
+#import "ENRMUIKit.h"
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+#import <ReactNativeEnrichedMarkdown/EventEmitters.h>
+#import <memory>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ENRMInputEventEmitterDataSource <NSObject>
+
+#ifdef __cplusplus
+- (std::shared_ptr<facebook::react::EnrichedMarkdownTextInputEventEmitter const>)fabricEventEmitter;
+#endif
+
+- (NSString *)plainText;
+- (NSRange)selectedRange;
+- (BOOL)isEffectiveStyleActive:(ENRMInputStyleType)type atPosition:(NSUInteger)position;
+- (BOOL)isStyleActive:(ENRMInputStyleType)type inRange:(NSRange)range;
+- (NSInteger)headingLevelForCursorParagraph;
+- (nullable ENRMBlockRange *)listBlockForCursorParagraph;
+- (NSString *)currentMarkdown;
+- (CGRect)computeCaretRect;
+
+@end
+
+@interface ENRMInputEventEmitter : NSObject
+
+@property (nonatomic, assign) BOOL emitMarkdown;
+
+- (instancetype)initWithDataSource:(id<ENRMInputEventEmitterDataSource>)dataSource;
+
+- (void)emitOnChangeText;
+- (void)emitOnKeyPress:(NSString *)text;
+- (void)emitOnChangeMarkdown;
+- (void)emitOnChangeSelection;
+- (void)emitOnChangeState;
+- (void)emitFormattingChanged;
+- (void)emitCaretRectChangeIfNeeded;
+- (void)invalidateCachedState;
+- (void)emitContextMenuItemPress:(NSString *)itemText;
+- (void)emitOnFocus;
+- (void)emitOnBlur;
+- (void)emitOnLinkDetectedWithText:(NSString *)text url:(NSString *)url range:(NSRange)range;
+- (void)emitOnStartMention:(NSString *)indicator;
+- (void)emitOnChangeMentionWithIndicator:(NSString *)indicator text:(NSString *)text;
+- (void)emitOnEndMention:(NSString *)indicator;
+- (void)requestMarkdown:(NSInteger)requestId;
+- (void)requestCaretRect:(NSInteger)requestId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputEventEmitter.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputEventEmitter.mm
@@ -1,0 +1,312 @@
+#import "ENRMInputEventEmitter.h"
+
+using namespace facebook::react;
+
+#define ENRM_GUARD_EMITTER(name)                                                                                       \
+  auto name = [self emitter];                                                                                          \
+  if (name == nullptr) {                                                                                               \
+    return;                                                                                                            \
+  }
+
+@implementation ENRMInputEventEmitter {
+  __weak id<ENRMInputEventEmitterDataSource> _dataSource;
+
+  struct {
+    BOOL bold, italic, underline, strikethrough, spoiler, link, initialized;
+    NSInteger headingLevel;
+    BOOL unorderedList;
+    NSInteger unorderedListDepth;
+    BOOL orderedList;
+    NSInteger orderedListDepth;
+  } _prevState;
+
+  std::optional<CGRect> _prevCaretRect;
+}
+
+- (instancetype)initWithDataSource:(id<ENRMInputEventEmitterDataSource>)dataSource
+{
+  self = [super init];
+  if (self) {
+    _dataSource = dataSource;
+  }
+  return self;
+}
+
+#pragma mark - Private
+
+- (std::shared_ptr<EnrichedMarkdownTextInputEventEmitter const>)emitter
+{
+  return [_dataSource fabricEventEmitter];
+}
+
+#pragma mark - Simple emitters
+
+- (void)emitOnChangeText
+{
+  ENRM_GUARD_EMITTER(emitter);
+  NSString *plainText = [_dataSource plainText];
+  emitter->onChangeText({.value = std::string([plainText UTF8String] ?: "")});
+}
+
+/// Maps the replacement text of a pending edit to RN TextInput's
+/// `onKeyPress` key names: empty text means deletion ("Backspace"), and
+/// leading \n, \t and ESC map to "Enter", "Tab" and "Escape".
+- (void)emitOnKeyPress:(NSString *)text
+{
+  ENRM_GUARD_EMITTER(emitter);
+  NSString *key;
+  if (text.length == 0) {
+    key = @"Backspace";
+  } else {
+    switch ([text characterAtIndex:0]) {
+      case '\n':
+        key = @"Enter";
+        break;
+      case '\t':
+        key = @"Tab";
+        break;
+      case 0x1B:
+        key = @"Escape";
+        break;
+      default:
+        key = text;
+        break;
+    }
+  }
+  emitter->onInputKeyPress({.key = std::string([key UTF8String] ?: "")});
+}
+
+- (void)emitOnChangeMarkdown
+{
+  ENRM_GUARD_EMITTER(emitter);
+  NSString *markdown = [_dataSource currentMarkdown];
+  emitter->onChangeMarkdown({.value = std::string([markdown UTF8String] ?: "")});
+}
+
+- (void)emitOnChangeSelection
+{
+  ENRM_GUARD_EMITTER(emitter);
+  NSRange selection = [_dataSource selectedRange];
+  emitter->onChangeSelection({
+      .start = static_cast<int>(selection.location),
+      .end = static_cast<int>(NSMaxRange(selection)),
+  });
+}
+
+- (void)emitOnFocus
+{
+  ENRM_GUARD_EMITTER(emitter);
+  emitter->onInputFocus({});
+}
+
+- (void)emitOnBlur
+{
+  ENRM_GUARD_EMITTER(emitter);
+  emitter->onInputBlur({});
+}
+
+- (void)emitOnLinkDetectedWithText:(NSString *)text url:(NSString *)url range:(NSRange)range
+{
+  ENRM_GUARD_EMITTER(emitter);
+  emitter->onLinkDetected({
+      .text = std::string([text UTF8String] ?: ""),
+      .url = std::string([url UTF8String] ?: ""),
+      .start = static_cast<int>(range.location),
+      .end = static_cast<int>(range.location + range.length),
+  });
+}
+
+- (void)emitOnStartMention:(NSString *)indicator
+{
+  ENRM_GUARD_EMITTER(emitter);
+  emitter->onStartMention({.indicator = std::string([indicator UTF8String] ?: "")});
+}
+
+- (void)emitOnChangeMentionWithIndicator:(NSString *)indicator text:(NSString *)text
+{
+  ENRM_GUARD_EMITTER(emitter);
+  emitter->onChangeMention({
+      .indicator = std::string([indicator UTF8String] ?: ""),
+      .text = std::string([text UTF8String] ?: ""),
+  });
+}
+
+- (void)emitOnEndMention:(NSString *)indicator
+{
+  ENRM_GUARD_EMITTER(emitter);
+  emitter->onEndMention({.indicator = std::string([indicator UTF8String] ?: "")});
+}
+
+#pragma mark - Stateful emitters
+
+- (void)emitOnChangeState
+{
+  ENRM_GUARD_EMITTER(emitter);
+
+  NSUInteger cursor = [_dataSource selectedRange].location;
+  BOOL boldActive = [_dataSource isEffectiveStyleActive:ENRMInputStyleTypeStrong atPosition:cursor];
+  BOOL italicActive = [_dataSource isEffectiveStyleActive:ENRMInputStyleTypeEmphasis atPosition:cursor];
+  BOOL underlineActive = [_dataSource isEffectiveStyleActive:ENRMInputStyleTypeUnderline atPosition:cursor];
+  BOOL strikethroughActive = [_dataSource isEffectiveStyleActive:ENRMInputStyleTypeStrikethrough atPosition:cursor];
+  BOOL spoilerActive = [_dataSource isEffectiveStyleActive:ENRMInputStyleTypeSpoiler atPosition:cursor];
+  BOOL linkActive = [_dataSource isEffectiveStyleActive:ENRMInputStyleTypeLink atPosition:cursor];
+
+  NSInteger headingLevel = [_dataSource headingLevelForCursorParagraph];
+
+  NSInteger listDepth = 0;
+  ENRMBlockRange *emitListBlock = [_dataSource listBlockForCursorParagraph];
+  BOOL unorderedListActive = emitListBlock != nil && emitListBlock.type == ENRMInputBlockTypeUnorderedListItem;
+  BOOL orderedListActive = emitListBlock != nil && emitListBlock.type == ENRMInputBlockTypeOrderedListItem;
+  if (emitListBlock != nil) {
+    listDepth = emitListBlock.level;
+  }
+
+  if (_prevState.initialized && _prevState.bold == boldActive && _prevState.italic == italicActive &&
+      _prevState.underline == underlineActive && _prevState.strikethrough == strikethroughActive &&
+      _prevState.spoiler == spoilerActive && _prevState.link == linkActive && _prevState.headingLevel == headingLevel &&
+      _prevState.unorderedList == unorderedListActive && _prevState.unorderedListDepth == listDepth &&
+      _prevState.orderedList == orderedListActive && _prevState.orderedListDepth == listDepth) {
+    return;
+  }
+
+  _prevState.bold = boldActive;
+  _prevState.italic = italicActive;
+  _prevState.underline = underlineActive;
+  _prevState.strikethrough = strikethroughActive;
+  _prevState.spoiler = spoilerActive;
+  _prevState.link = linkActive;
+  _prevState.headingLevel = headingLevel;
+  _prevState.unorderedList = unorderedListActive;
+  _prevState.unorderedListDepth = listDepth;
+  _prevState.orderedList = orderedListActive;
+  _prevState.orderedListDepth = listDepth;
+  _prevState.initialized = YES;
+
+  emitter->onChangeState({
+      .bold = {.isActive = boldActive},
+      .italic = {.isActive = italicActive},
+      .underline = {.isActive = underlineActive},
+      .strikethrough = {.isActive = strikethroughActive},
+      .spoiler = {.isActive = spoilerActive},
+      .link = {.isActive = linkActive},
+      .heading = {.isActive = headingLevel > 0, .level = static_cast<int>(headingLevel)},
+      .unorderedList = {.isActive = unorderedListActive,
+                        .depth = static_cast<int>(unorderedListActive ? listDepth : 0)},
+      .orderedList = {.isActive = orderedListActive, .depth = static_cast<int>(orderedListActive ? listDepth : 0)},
+  });
+}
+
+- (void)emitCaretRectChangeIfNeeded
+{
+  ENRM_GUARD_EMITTER(emitter);
+
+  CGRect caretRect = [_dataSource computeCaretRect];
+
+  if (_prevCaretRect.has_value() && CGRectEqualToRect(_prevCaretRect.value(), caretRect)) {
+    return;
+  }
+
+  _prevCaretRect = caretRect;
+
+  emitter->onCaretRectChange({
+      .x = caretRect.origin.x,
+      .y = caretRect.origin.y,
+      .width = caretRect.size.width,
+      .height = caretRect.size.height,
+  });
+}
+
+- (void)invalidateCachedState
+{
+  _prevState.initialized = NO;
+  _prevCaretRect.reset();
+}
+
+- (void)emitContextMenuItemPress:(NSString *)itemText
+{
+  ENRM_GUARD_EMITTER(eventEmitter);
+
+  NSRange selectedRange = [_dataSource selectedRange];
+  NSString *selectedText = selectedRange.length > 0 ? [[_dataSource plainText] substringWithRange:selectedRange] : @"";
+
+  auto isActive = [&](ENRMInputStyleType type) -> BOOL {
+    if (selectedRange.length > 0) {
+      return [_dataSource isStyleActive:type inRange:selectedRange];
+    }
+    return [_dataSource isEffectiveStyleActive:type atPosition:selectedRange.location];
+  };
+
+  BOOL boldActive = isActive(ENRMInputStyleTypeStrong);
+  BOOL italicActive = isActive(ENRMInputStyleTypeEmphasis);
+  BOOL underlineActive = isActive(ENRMInputStyleTypeUnderline);
+  BOOL strikethroughActive = isActive(ENRMInputStyleTypeStrikethrough);
+  BOOL spoilerActive = isActive(ENRMInputStyleTypeSpoiler);
+  BOOL linkActive = isActive(ENRMInputStyleTypeLink);
+  NSInteger headingLevel = [_dataSource headingLevelForCursorParagraph];
+  NSInteger listDepth = 0;
+  ENRMBlockRange *emitListBlock = [_dataSource listBlockForCursorParagraph];
+  BOOL unorderedListActive = emitListBlock != nil && emitListBlock.type == ENRMInputBlockTypeUnorderedListItem;
+  BOOL orderedListActive = emitListBlock != nil && emitListBlock.type == ENRMInputBlockTypeOrderedListItem;
+  if (emitListBlock != nil) {
+    listDepth = emitListBlock.level;
+  }
+
+  eventEmitter->onContextMenuItemPress({
+      .itemText = std::string(itemText.UTF8String),
+      .selectedText = std::string(selectedText.UTF8String),
+      .selectionStart = static_cast<int>(selectedRange.location),
+      .selectionEnd = static_cast<int>(NSMaxRange(selectedRange)),
+      .styleState =
+          {
+              .bold = {.isActive = boldActive},
+              .italic = {.isActive = italicActive},
+              .underline = {.isActive = underlineActive},
+              .strikethrough = {.isActive = strikethroughActive},
+              .spoiler = {.isActive = spoilerActive},
+              .link = {.isActive = linkActive},
+              .heading = {.isActive = headingLevel > 0, .level = static_cast<int>(headingLevel)},
+              .unorderedList = {.isActive = unorderedListActive,
+                                .depth = static_cast<int>(unorderedListActive ? listDepth : 0)},
+              .orderedList = {.isActive = orderedListActive,
+                              .depth = static_cast<int>(orderedListActive ? listDepth : 0)},
+          },
+  });
+}
+
+#pragma mark - Compound helpers
+
+- (void)emitFormattingChanged
+{
+  [self emitOnChangeState];
+  if (_emitMarkdown) {
+    [self emitOnChangeMarkdown];
+  }
+}
+
+#pragma mark - Request-response
+
+- (void)requestMarkdown:(NSInteger)requestId
+{
+  ENRM_GUARD_EMITTER(emitter);
+  NSString *markdown = [_dataSource currentMarkdown];
+  emitter->onRequestMarkdownResult({
+      .requestId = static_cast<int>(requestId),
+      .markdown = std::string([markdown UTF8String] ?: ""),
+  });
+}
+
+- (void)requestCaretRect:(NSInteger)requestId
+{
+  ENRM_GUARD_EMITTER(emitter);
+
+  CGRect caretRect = [_dataSource computeCaretRect];
+  emitter->onRequestCaretRectResult({
+      .requestId = static_cast<int>(requestId),
+      .x = caretRect.origin.x,
+      .y = caretRect.origin.y,
+      .width = caretRect.size.width,
+      .height = caretRect.size.height,
+  });
+}
+
+@end

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput+ContextMenu.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput+ContextMenu.mm
@@ -78,11 +78,11 @@
   [customItemTexts enumerateObjectsUsingBlock:^(NSString *itemText, NSUInteger index, BOOL *_) {
     NSString *iconName = index < customItemIcons.count ? customItemIcons[index] : nil;
     UIImage *image = iconName.length > 0 ? [UIImage systemImageNamed:iconName] : nil;
-    UIAction *customAction =
-        [UIAction actionWithTitle:itemText
-                            image:image
-                       identifier:nil
-                          handler:^(__kindof UIAction *_) { [weakSelf emitContextMenuItemPress:itemText]; }];
+    UIAction *customAction = [UIAction
+        actionWithTitle:itemText
+                  image:image
+             identifier:nil
+                handler:^(__kindof UIAction *_) { [weakSelf.inputEventEmitter emitContextMenuItemPress:itemText]; }];
     [allActions addObject:customAction];
   }];
 
@@ -118,7 +118,7 @@
   NSArray<NSMenuItem *> *customItems =
       ENRMBuildContextMenuItems([self contextMenuItemTexts], [self contextMenuItemIcons], textView,
                                 ^(NSString *itemText, NSString *_, NSUInteger __, NSUInteger ___) {
-                                  [weakSelf emitContextMenuItemPress:itemText];
+                                  [weakSelf.inputEventEmitter emitContextMenuItemPress:itemText];
                                 });
   ENRMPrependMenuItems(menu, customItems);
 

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput+Internal.h
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput+Internal.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#import "ENRMInputEventEmitter.h"
 #import "ENRMInputStyledRange.h"
 #import "EnrichedMarkdownTextInput.h"
 
@@ -31,6 +32,8 @@ typedef struct {
 
 @interface EnrichedMarkdownTextInput (Internal)
 
+@property (nonatomic, readonly) ENRMInputEventEmitter *inputEventEmitter;
+
 - (void)toggleBold;
 - (void)toggleItalic;
 - (void)toggleUnderline;
@@ -47,7 +50,6 @@ typedef struct {
 
 - (BOOL)isEffectiveStyleActive:(ENRMInputStyleType)type atPosition:(NSUInteger)position;
 
-- (void)emitContextMenuItemPress:(NSString *)itemText;
 - (NSArray<NSString *> *)contextMenuItemTexts;
 - (NSArray<NSString *> *)contextMenuItemIcons;
 - (ENRMInputSelectionMenuConfig)inputSelectionMenuConfig;

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -10,6 +10,7 @@
 #import "ENRMEditSession.h"
 #import "ENRMFormattingRange.h"
 #import "ENRMFormattingStore.h"
+#import "ENRMInputEventEmitter.h"
 #import "ENRMInputFormatter.h"
 #import "ENRMInputLayoutManager.h"
 #import "ENRMInputLinkPrompt.h"
@@ -47,10 +48,10 @@ using namespace facebook::react;
 
 #if !TARGET_OS_OSX
 @interface EnrichedMarkdownTextInput () <RCTEnrichedMarkdownTextInputViewProtocol, UITextViewDelegate,
-                                         ENRMEditPipelineHost>
+                                         ENRMEditPipelineHost, ENRMInputEventEmitterDataSource>
 #else
 @interface EnrichedMarkdownTextInput () <RCTEnrichedMarkdownTextInputViewProtocol, RCTBackedTextInputDelegate,
-                                         ENRMEditPipelineHost>
+                                         ENRMEditPipelineHost, ENRMInputEventEmitterDataSource>
 #endif
 - (void)setupTextView;
 - (void)applyFormatting;
@@ -70,7 +71,7 @@ using namespace facebook::react;
   ENRMBlockStore *_blockStore;
   NSMutableSet<NSNumber *> *_pendingStyles;
   NSMutableSet<NSNumber *> *_pendingStyleRemovals;
-  BOOL _emitMarkdown;
+  ENRMInputEventEmitter *_inputEventEmitter;
   ENRMEditSession *_editSession;
 
   ENRMPlaceholderLabel *_placeholderLabel;
@@ -78,15 +79,6 @@ using namespace facebook::react;
   NSUInteger _lastTextLength;
   NSRange _lastSelectedRange;
   NSRange _preEditSelectedRange;
-
-  struct {
-    BOOL bold, italic, underline, strikethrough, spoiler, link, initialized;
-    NSInteger headingLevel;
-    BOOL unorderedList;
-    NSInteger unorderedListDepth;
-    BOOL orderedList;
-    NSInteger orderedListDepth;
-  } _prevState;
 
   // Block type/level of the line being edited, captured before a text change so
   // a Return that continues a list (or an autocorrect/paste that replaces the
@@ -98,8 +90,6 @@ using namespace facebook::react;
   // applies (the deleted characters are gone afterwards). Drives the full-vs-
   // scoped reformat decision in handleTextChanged.
   BOOL _preEditReplacedNewline;
-
-  std::optional<CGRect> _prevCaretRect;
 
 #if TARGET_OS_OSX
   NSScrollView *_scrollView;
@@ -174,6 +164,7 @@ using namespace facebook::react;
 
     [self setupTextView];
     _editSession = [[ENRMEditSession alloc] initWithTextView:_textView];
+    _inputEventEmitter = [[ENRMInputEventEmitter alloc] initWithDataSource:self];
 
     [self setupDetectorPipeline];
 
@@ -201,7 +192,11 @@ using namespace facebook::react;
 
   __weak EnrichedMarkdownTextInput *weakSelf = self;
   _autoLinkDetector.onLinkDetected = ^(NSString *text, NSString *url, NSRange range) {
-    [weakSelf emitOnLinkDetectedWithText:text url:url range:range];
+    EnrichedMarkdownTextInput *strongSelf = weakSelf;
+    if (strongSelf == nil) {
+      return;
+    }
+    [strongSelf->_inputEventEmitter emitOnLinkDetectedWithText:text url:url range:range];
   };
 
   _detectorPipeline = [[ENRMDetectorPipeline alloc] init];
@@ -419,7 +414,7 @@ using namespace facebook::react;
     ENRMApplySelectionColor(_textView, newViewProps.selectionColor);
   }
 
-  _emitMarkdown = newViewProps.isOnChangeMarkdownSet;
+  _inputEventEmitter.emitMarkdown = newViewProps.isOnChangeMarkdownSet;
 
   {
     auto configFromProp = [](const auto &prop) {
@@ -712,9 +707,9 @@ using namespace facebook::react;
   [_detectorPipeline processTextChange:plainText modificationRange:NSMakeRange(editLocation, text.length)];
 
   [self updatePlaceholderVisibility];
-  [self emitOnChangeText];
-  [self emitOnChangeSelection];
-  [self emitFormattingChanged];
+  [_inputEventEmitter emitOnChangeText];
+  [_inputEventEmitter emitOnChangeSelection];
+  [_inputEventEmitter emitFormattingChanged];
   [self requestHeightUpdate];
   [self scheduleRelayoutIfNeeded];
 }
@@ -829,9 +824,9 @@ using namespace facebook::react;
 {
   [self importMarkdown:markdown];
   _lastSelectedRange = _textView.selectedRange;
-  [self emitOnChangeText];
-  [self emitOnChangeSelection];
-  [self emitOnChangeState];
+  [_inputEventEmitter emitOnChangeText];
+  [_inputEventEmitter emitOnChangeSelection];
+  [_inputEventEmitter emitOnChangeState];
   [self requestHeightUpdate];
 }
 
@@ -841,8 +836,8 @@ using namespace facebook::react;
   NSInteger clampedStart = MIN(MAX(start, 0), textLen);
   NSInteger clampedEnd = MIN(MAX(end, clampedStart), textLen);
   _textView.selectedRange = NSMakeRange((NSUInteger)clampedStart, (NSUInteger)(clampedEnd - clampedStart));
-  [self emitOnChangeSelection];
-  [self emitOnChangeState];
+  [_inputEventEmitter emitOnChangeSelection];
+  [_inputEventEmitter emitOnChangeState];
 }
 
 - (void)toggleBold
@@ -908,7 +903,7 @@ using namespace facebook::react;
 
   [self applyFormatting];
   [self syncTypingAttributesWithPendingStyles];
-  [self emitFormattingChanged];
+  [_inputEventEmitter emitFormattingChanged];
 }
 
 - (void)toggleHeading:(NSInteger)level
@@ -948,7 +943,7 @@ using namespace facebook::react;
     [self clearListParagraphStyleFromTypingAttributes];
   }
   [self updateEmptyBulletMarker];
-  [self emitFormattingChanged];
+  [_inputEventEmitter emitFormattingChanged];
 }
 
 - (void)toggleUnorderedList
@@ -984,7 +979,7 @@ using namespace facebook::react;
   [self applyFormatting];
   [self syncTypingAttributesWithCursorBlock];
   [self updateEmptyBulletMarker];
-  [self emitFormattingChanged];
+  [_inputEventEmitter emitFormattingChanged];
 }
 
 - (nullable ENRMBlockRange *)listBlockForCursorParagraph
@@ -1300,7 +1295,7 @@ using namespace facebook::react;
     return;
   }
   [self applyFormatting];
-  [self emitFormattingChanged];
+  [_inputEventEmitter emitFormattingChanged];
 }
 
 - (void)insertLink:(NSString *)text url:(NSString *)url
@@ -1348,7 +1343,7 @@ using namespace facebook::react;
   [self dispatchMentionEvents:[_mentionCoordinator clearWithIndicatorOverride:indicator]];
   [self replaceTextInRange:activeRange withText:replacement formattingRanges:@[ linkRange ]];
   _textView.selectedRange = NSMakeRange(activeRange.location + replacement.length, 0);
-  [self emitOnChangeSelection];
+  [_inputEventEmitter emitOnChangeSelection];
 }
 
 - (void)removeLink
@@ -1357,7 +1352,7 @@ using namespace facebook::react;
     return;
   }
   [self applyFormatting];
-  [self emitFormattingChanged];
+  [_inputEventEmitter emitFormattingChanged];
 }
 
 - (void)showLinkPrompt
@@ -1402,15 +1397,7 @@ using namespace facebook::react;
 
 - (void)requestMarkdown:(NSInteger)requestId
 {
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-  NSString *markdown = [_clipboardCoordinator serializeFullDocument:ENRMGetPlainText(_textView)];
-  emitter->onRequestMarkdownResult({
-      .requestId = static_cast<int>(requestId),
-      .markdown = std::string([markdown UTF8String] ?: ""),
-  });
+  [_inputEventEmitter requestMarkdown:requestId];
 }
 
 - (CGRect)computeCaretRect
@@ -1436,19 +1423,7 @@ using namespace facebook::react;
 
 - (void)requestCaretRect:(NSInteger)requestId
 {
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-
-  CGRect caretRect = [self computeCaretRect];
-  emitter->onRequestCaretRectResult({
-      .requestId = static_cast<int>(requestId),
-      .x = caretRect.origin.x,
-      .y = caretRect.origin.y,
-      .width = caretRect.size.width,
-      .height = caretRect.size.height,
-  });
+  [_inputEventEmitter requestCaretRect:requestId];
 }
 
 - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args
@@ -1517,22 +1492,31 @@ using namespace facebook::react;
   }
 }
 
-#pragma mark - Event emitters
+#pragma mark - ENRMInputEventEmitterDataSource
 
-- (void)emitFormattingChanged
-{
-  [self emitOnChangeState];
-  if (_emitMarkdown) {
-    [self emitOnChangeMarkdown];
-  }
-}
-
-- (std::shared_ptr<EnrichedMarkdownTextInputEventEmitter const>)getEventEmitter
+- (std::shared_ptr<EnrichedMarkdownTextInputEventEmitter const>)fabricEventEmitter
 {
   if (_eventEmitter == nullptr || _editSession.shouldSuppressEvents) {
     return nullptr;
   }
   return std::static_pointer_cast<EnrichedMarkdownTextInputEventEmitter const>(_eventEmitter);
+}
+
+- (NSRange)selectedRange
+{
+  return _textView.selectedRange;
+}
+
+- (BOOL)isStyleActive:(ENRMInputStyleType)type inRange:(NSRange)range
+{
+  return [_formattingStore isStyleActive:type inRange:range];
+}
+
+- (NSString *)currentMarkdown
+{
+  return [self serializeText:ENRMGetPlainText(_textView)
+                      ranges:[self allRangesIncludingTransient]
+                 blockRanges:_blockStore.allRanges];
 }
 
 - (NSArray<ENRMFormattingRange *> *)allRangesIncludingTransient
@@ -1561,13 +1545,13 @@ using namespace facebook::react;
   for (ENRMMentionEvent *event in events) {
     switch (event.type) {
       case ENRMMentionEventStart:
-        [self emitOnStartMention:event.indicator];
+        [_inputEventEmitter emitOnStartMention:event.indicator];
         break;
       case ENRMMentionEventChange:
-        [self emitOnChangeMentionWithIndicator:event.indicator text:event.text];
+        [_inputEventEmitter emitOnChangeMentionWithIndicator:event.indicator text:event.text];
         break;
       case ENRMMentionEventEnd:
-        [self emitOnEndMention:event.indicator];
+        [_inputEventEmitter emitOnEndMention:event.indicator];
         break;
     }
   }
@@ -1598,155 +1582,6 @@ using namespace facebook::react;
   return YES;
 }
 
-- (void)emitOnChangeText
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-  NSString *plainText = ENRMGetPlainText(_textView);
-  emitter->onChangeText({.value = std::string([plainText UTF8String] ?: "")});
-}
-
-/// Maps the replacement text of a pending edit to RN TextInput's
-/// `onKeyPress` key names: empty text means deletion ("Backspace"), and
-/// leading \n, \t and ESC map to "Enter", "Tab" and "Escape".
-- (void)emitOnKeyPress:(NSString *)text
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-  NSString *key;
-  if (text.length == 0) {
-    key = @"Backspace";
-  } else {
-    switch ([text characterAtIndex:0]) {
-      case '\n':
-        key = @"Enter";
-        break;
-      case '\t':
-        key = @"Tab";
-        break;
-      case 0x1B:
-        key = @"Escape";
-        break;
-      default:
-        key = text;
-        break;
-    }
-  }
-  emitter->onInputKeyPress({.key = std::string([key UTF8String] ?: "")});
-}
-
-- (void)emitOnChangeMarkdown
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-  NSString *markdown = [self serializeText:ENRMGetPlainText(_textView)
-                                    ranges:[self allRangesIncludingTransient]
-                               blockRanges:_blockStore.allRanges];
-  emitter->onChangeMarkdown({.value = std::string([markdown UTF8String] ?: "")});
-}
-
-- (void)emitOnChangeSelection
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-  NSRange selection = _textView.selectedRange;
-  emitter->onChangeSelection({
-      .start = static_cast<int>(selection.location),
-      .end = static_cast<int>(NSMaxRange(selection)),
-  });
-}
-
-- (void)emitOnChangeState
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-
-  NSUInteger cursor = _textView.selectedRange.location;
-  BOOL boldActive = [self isEffectiveStyleActive:ENRMInputStyleTypeStrong atPosition:cursor];
-  BOOL italicActive = [self isEffectiveStyleActive:ENRMInputStyleTypeEmphasis atPosition:cursor];
-  BOOL underlineActive = [self isEffectiveStyleActive:ENRMInputStyleTypeUnderline atPosition:cursor];
-  BOOL strikethroughActive = [self isEffectiveStyleActive:ENRMInputStyleTypeStrikethrough atPosition:cursor];
-  BOOL spoilerActive = [self isEffectiveStyleActive:ENRMInputStyleTypeSpoiler atPosition:cursor];
-  BOOL linkActive = [self isEffectiveStyleActive:ENRMInputStyleTypeLink atPosition:cursor];
-
-  NSInteger headingLevel = [self headingLevelForCursorParagraph];
-
-  NSInteger listDepth = 0;
-  ENRMBlockRange *emitListBlock = [self listBlockForCursorParagraph];
-  BOOL unorderedListActive = emitListBlock != nil && emitListBlock.type == ENRMInputBlockTypeUnorderedListItem;
-  BOOL orderedListActive = emitListBlock != nil && emitListBlock.type == ENRMInputBlockTypeOrderedListItem;
-  if (emitListBlock != nil) {
-    listDepth = emitListBlock.level;
-  }
-
-  if (_prevState.initialized && _prevState.bold == boldActive && _prevState.italic == italicActive &&
-      _prevState.underline == underlineActive && _prevState.strikethrough == strikethroughActive &&
-      _prevState.spoiler == spoilerActive && _prevState.link == linkActive && _prevState.headingLevel == headingLevel &&
-      _prevState.unorderedList == unorderedListActive && _prevState.unorderedListDepth == listDepth &&
-      _prevState.orderedList == orderedListActive && _prevState.orderedListDepth == listDepth) {
-    return;
-  }
-
-  _prevState.bold = boldActive;
-  _prevState.italic = italicActive;
-  _prevState.underline = underlineActive;
-  _prevState.strikethrough = strikethroughActive;
-  _prevState.spoiler = spoilerActive;
-  _prevState.link = linkActive;
-  _prevState.headingLevel = headingLevel;
-  _prevState.unorderedList = unorderedListActive;
-  _prevState.unorderedListDepth = listDepth;
-  _prevState.orderedList = orderedListActive;
-  _prevState.orderedListDepth = listDepth;
-  _prevState.initialized = YES;
-
-  emitter->onChangeState({
-      .bold = {.isActive = boldActive},
-      .italic = {.isActive = italicActive},
-      .underline = {.isActive = underlineActive},
-      .strikethrough = {.isActive = strikethroughActive},
-      .spoiler = {.isActive = spoilerActive},
-      .link = {.isActive = linkActive},
-      .heading = {.isActive = headingLevel > 0, .level = static_cast<int>(headingLevel)},
-      .unorderedList = {.isActive = unorderedListActive,
-                        .depth = static_cast<int>(unorderedListActive ? listDepth : 0)},
-      .orderedList = {.isActive = orderedListActive, .depth = static_cast<int>(orderedListActive ? listDepth : 0)},
-  });
-}
-
-- (void)emitCaretRectChangeIfNeeded
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-
-  CGRect caretRect = [self computeCaretRect];
-
-  if (_prevCaretRect.has_value() && CGRectEqualToRect(_prevCaretRect.value(), caretRect)) {
-    return;
-  }
-
-  _prevCaretRect = caretRect;
-
-  emitter->onCaretRectChange({
-      .x = caretRect.origin.x,
-      .y = caretRect.origin.y,
-      .width = caretRect.size.width,
-      .height = caretRect.size.height,
-  });
-}
-
 - (NSArray<NSString *> *)contextMenuItemTexts
 {
   return _contextMenuItemTexts ?: @[];
@@ -1767,121 +1602,9 @@ using namespace facebook::react;
   return _formatMenuConfig;
 }
 
-- (void)emitContextMenuItemPress:(NSString *)itemText
+- (ENRMInputEventEmitter *)inputEventEmitter
 {
-  auto eventEmitter = [self getEventEmitter];
-  if (eventEmitter == nullptr) {
-    return;
-  }
-
-  NSRange selectedRange = _textView.selectedRange;
-  NSString *selectedText =
-      selectedRange.length > 0 ? [_textView.textStorage.string substringWithRange:selectedRange] : @"";
-
-  auto isActive = [&](ENRMInputStyleType type) -> BOOL {
-    if (selectedRange.length > 0) {
-      return [_formattingStore isStyleActive:type inRange:selectedRange];
-    }
-    return [self isEffectiveStyleActive:type atPosition:selectedRange.location];
-  };
-
-  BOOL boldActive = isActive(ENRMInputStyleTypeStrong);
-  BOOL italicActive = isActive(ENRMInputStyleTypeEmphasis);
-  BOOL underlineActive = isActive(ENRMInputStyleTypeUnderline);
-  BOOL strikethroughActive = isActive(ENRMInputStyleTypeStrikethrough);
-  BOOL spoilerActive = isActive(ENRMInputStyleTypeSpoiler);
-  BOOL linkActive = isActive(ENRMInputStyleTypeLink);
-  NSInteger headingLevel = [self headingLevelForCursorParagraph];
-  NSInteger listDepth = 0;
-  ENRMBlockRange *emitListBlock = [self listBlockForCursorParagraph];
-  BOOL unorderedListActive = emitListBlock != nil && emitListBlock.type == ENRMInputBlockTypeUnorderedListItem;
-  BOOL orderedListActive = emitListBlock != nil && emitListBlock.type == ENRMInputBlockTypeOrderedListItem;
-  if (emitListBlock != nil) {
-    listDepth = emitListBlock.level;
-  }
-
-  eventEmitter->onContextMenuItemPress({
-      .itemText = std::string(itemText.UTF8String),
-      .selectedText = std::string(selectedText.UTF8String),
-      .selectionStart = static_cast<int>(selectedRange.location),
-      .selectionEnd = static_cast<int>(NSMaxRange(selectedRange)),
-      .styleState =
-          {
-              .bold = {.isActive = boldActive},
-              .italic = {.isActive = italicActive},
-              .underline = {.isActive = underlineActive},
-              .strikethrough = {.isActive = strikethroughActive},
-              .spoiler = {.isActive = spoilerActive},
-              .link = {.isActive = linkActive},
-              .heading = {.isActive = headingLevel > 0, .level = static_cast<int>(headingLevel)},
-              .unorderedList = {.isActive = unorderedListActive,
-                                .depth = static_cast<int>(unorderedListActive ? listDepth : 0)},
-              .orderedList = {.isActive = orderedListActive,
-                              .depth = static_cast<int>(orderedListActive ? listDepth : 0)},
-          },
-  });
-}
-
-- (void)emitOnFocus
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-  emitter->onInputFocus({});
-}
-
-- (void)emitOnBlur
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-  emitter->onInputBlur({});
-}
-
-- (void)emitOnLinkDetectedWithText:(NSString *)text url:(NSString *)url range:(NSRange)range
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-  emitter->onLinkDetected({
-      .text = std::string([text UTF8String] ?: ""),
-      .url = std::string([url UTF8String] ?: ""),
-      .start = static_cast<int>(range.location),
-      .end = static_cast<int>(range.location + range.length),
-  });
-}
-
-- (void)emitOnStartMention:(NSString *)indicator
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-  emitter->onStartMention({.indicator = std::string([indicator UTF8String] ?: "")});
-}
-
-- (void)emitOnChangeMentionWithIndicator:(NSString *)indicator text:(NSString *)text
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-  emitter->onChangeMention({
-      .indicator = std::string([indicator UTF8String] ?: ""),
-      .text = std::string([text UTF8String] ?: ""),
-  });
-}
-
-- (void)emitOnEndMention:(NSString *)indicator
-{
-  auto emitter = [self getEventEmitter];
-  if (emitter == nullptr) {
-    return;
-  }
-  emitter->onEndMention({.indicator = std::string([indicator UTF8String] ?: "")});
+  return _inputEventEmitter;
 }
 
 #pragma mark - Text edit tracking
@@ -1967,11 +1690,11 @@ using namespace facebook::react;
   [_editPipeline detectLinksAtLocation:editLocation insertedLength:insertedLength];
 
   [self updatePlaceholderVisibility];
-  [self emitOnChangeText];
-  [self emitOnChangeSelection];
-  [self emitFormattingChanged];
+  [_inputEventEmitter emitOnChangeText];
+  [_inputEventEmitter emitOnChangeSelection];
+  [_inputEventEmitter emitFormattingChanged];
   [self updateActiveMention];
-  [self emitCaretRectChangeIfNeeded];
+  [_inputEventEmitter emitCaretRectChangeIfNeeded];
   [self requestHeightUpdate];
   [self scheduleRelayoutIfNeeded];
   [self updateEmptyBulletMarker];
@@ -2034,7 +1757,7 @@ using namespace facebook::react;
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text
 {
-  [self emitOnKeyPress:text];
+  [_inputEventEmitter emitOnKeyPress:text];
   if ([self deleteLinkForReplacementRange:range replacementText:text]) {
     return NO;
   }
@@ -2063,13 +1786,13 @@ using namespace facebook::react;
 
 - (void)textViewDidBeginEditing:(UITextView *)textView
 {
-  [self emitOnFocus];
+  [_inputEventEmitter emitOnFocus];
 }
 
 - (void)textViewDidEndEditing:(UITextView *)textView
 {
   [self clearActiveMention:nil];
-  [self emitOnBlur];
+  [_inputEventEmitter emitOnBlur];
 }
 
 - (void)textViewDidChangeSelection:(UITextView *)textView
@@ -2102,10 +1825,10 @@ using namespace facebook::react;
 
   [self manageSelectionBasedChanges];
 
-  [self emitOnChangeSelection];
+  [_inputEventEmitter emitOnChangeSelection];
   [self updateActiveMention];
-  [self emitOnChangeState];
-  [self emitCaretRectChangeIfNeeded];
+  [_inputEventEmitter emitOnChangeState];
+  [_inputEventEmitter emitCaretRectChangeIfNeeded];
   [self updateEmptyBulletMarker];
 }
 
@@ -2120,7 +1843,7 @@ using namespace facebook::react;
 
 - (void)textInputDidBeginEditing
 {
-  [self emitOnFocus];
+  [_inputEventEmitter emitOnFocus];
 }
 
 - (BOOL)textInputShouldEndEditing
@@ -2131,7 +1854,7 @@ using namespace facebook::react;
 - (void)textInputDidEndEditing
 {
   [self clearActiveMention:nil];
-  [self emitOnBlur];
+  [_inputEventEmitter emitOnBlur];
 }
 
 - (BOOL)textInputShouldReturn
@@ -2150,7 +1873,7 @@ using namespace facebook::react;
 
 - (nullable NSString *)textInputShouldChangeText:(NSString *)text inRange:(NSRange)range
 {
-  [self emitOnKeyPress:text];
+  [_inputEventEmitter emitOnKeyPress:text];
   if ([self deleteLinkForReplacementRange:range replacementText:text]) {
     return nil;
   }
@@ -2204,10 +1927,10 @@ using namespace facebook::react;
     [self resetPendingStylesForSelectionChange];
   }
 
-  [self emitOnChangeSelection];
+  [_inputEventEmitter emitOnChangeSelection];
   [self updateActiveMention];
-  [self emitOnChangeState];
-  [self emitCaretRectChangeIfNeeded];
+  [_inputEventEmitter emitOnChangeState];
+  [_inputEventEmitter emitCaretRectChangeIfNeeded];
 }
 
 // @required stubs for RCTBackedTextInputDelegate — RCTUITextView's internal adapter


### PR DESCRIPTION
### What/Why?
Move all event emission methods into a dedicated ENRMInputEventEmitter class with a data-source protocol, reducing the EnrichedMarkdownTextInput.mm.

### How?
- **New `ENRMInputEventEmitter` class** — owns all `emitOn*` methods, `requestMarkdown:`, `requestCaretRect:`, the `_prevState` dedup struct, and `_prevCaretRect`.
- **`ENRMInputEventEmitterDataSource` protocol** — the parent conforms to it, providing `fabricEventEmitter`, `plainText`, `selectedRange`, style/block queries, etc.
- **`EnrichedMarkdownTextInput.mm`** loses ~350 lines, gains a single `_inputEventEmitter` ivar initialized at construction.
- **`Internal.h`** exposes a readonly `inputEventEmitter` property so the ContextMenu category calls it directly.
- **`ENRM_GUARD_EMITTER` macro** eliminates repeated null-check boilerplate across all 16 emission methods.
- Added `invalidateCachedState` for explicit dedup-cache reset.

### Testing
- No behavioral changes - pure structural extraction.

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

