### PR TITLE
feat: padding and broderradius for blockquotes

### DIFF
--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/Blockquote.stories.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/Blockquote.stories.tsx
@@ -67,6 +67,16 @@ const argTypes = {
     control: 'color',
     description: 'markdownStyle.blockquote.backgroundColor',
   },
+  borderRadius: numberControl('markdownStyle.blockquote.borderRadius', {
+    min: 0,
+    max: 16,
+    step: 1,
+  }),
+  padding: numberControl('markdownStyle.blockquote.padding', {
+    min: 0,
+    max: 32,
+    step: 2,
+  }),
 };
 
 function renderBlockquote(

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookMarkdownStyles.ts
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookMarkdownStyles.ts
@@ -71,6 +71,8 @@ export type BlockquoteStyleControls = {
   borderWidth: number;
   gapWidth: number;
   backgroundColor: string;
+  borderRadius: number;
+  padding: number;
 };
 
 export const blockquoteStyledDefaults: BlockquoteStyleControls = {
@@ -85,6 +87,8 @@ export const blockquoteStyledDefaults: BlockquoteStyleControls = {
   borderWidth: 4,
   gapWidth: 16,
   backgroundColor: '#eef2ff',
+  borderRadius: 0,
+  padding: 0,
 };
 
 export type CodeBlockStyleControls = {

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookStyleBuilders.ts
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/shared/storybookStyleBuilders.ts
@@ -104,6 +104,8 @@ export function toBlockquoteStyle(
     borderWidth: controls.borderWidth,
     gapWidth: controls.gapWidth,
     backgroundColor: controls.backgroundColor,
+    borderRadius: controls.borderRadius,
+    padding: controls.padding,
   };
 }
 

--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -149,6 +149,8 @@ The library provides sensible default styles for all Markdown elements out of th
       borderColor: '#007AFF',
       borderWidth: 3,
       backgroundColor: '#F0F8FF',
+      borderRadius: 8,
+      padding: 12,
       marginBottom: 12,
     },
     list: {
@@ -292,6 +294,8 @@ function App() {
 | `borderWidth` | `number` | Left border width |
 | `gapWidth` | `number` | Gap between border and text |
 | `backgroundColor` | `string` | Background color |
+| `borderRadius` | `number` | Corner radius of the background box; accent borders are clipped to the rounded shape, nested quotes rounding against their own box (default: `0`) |
+| `padding` | `number` | Inner top/bottom padding between the background edges and content, applied at every nesting level — also applies to the trailing edge on iOS and web (default: `0`) |
 
 ### List-specific
 

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
@@ -39,19 +39,40 @@ class BlockquoteRenderer(
     }
 
     if (builder.length == start) return
-    val end = builder.length
+    var end = builder.length
+    val padding = style.padding.toInt()
+
+    // Top padding uses a dedicated spacer line instead of growing the first content
+    // line's ascent. StaticLayout reuses one FontMetricsInt across the soft-wrapped
+    // lines of a paragraph, so inflating the first line's metrics corrupts its
+    // wrapped continuation lines (they inherit the padded metrics and the line-height
+    // clamp then skews them into overlap). A spacer sits in its own paragraph, so
+    // content-line metrics stay untouched. Bottom padding is applied to the last
+    // line's descent, which is safe because no later line inherits its metrics.
+    var contentStart = start
+    if (padding > 0) {
+      builder.insert(start, "\n")
+      builder.setSpan(
+        BlockquotePaddingSpacerSpan(padding),
+        start,
+        start + 1,
+        SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
+      )
+      contentStart = start + 1
+      end += 1
+    }
 
     // Find immediately nested quotes to exclude them from this level's line-height/margins
     val nestedRanges =
       builder
-        .getSpans(start, end, BlockquoteSpan::class.java)
+        .getSpans(contentStart, end, BlockquoteSpan::class.java)
         .filter { it.depth == depth + 1 }
         .map { builder.getSpanStart(it) to builder.getSpanEnd(it) }
         .sortedBy { it.first }
 
-    // The accent bar span covers the full range for visual continuity.
-    // SPAN_FLAGS_CONTAINER_BACKGROUND keeps the blockquote fill under any
-    // inline chip/pill backgrounds on the same line.
+    // The accent bar / background span covers the full box (incl. the top spacer)
+    // for visual continuity. SPAN_FLAGS_CONTAINER_BACKGROUND keeps the blockquote
+    // fill under any inline chip/pill backgrounds on the same line.
     builder.setSpan(
       BlockquoteSpan(style, depth, factory.context, factory.styleCache),
       start,
@@ -59,13 +80,14 @@ class BlockquoteRenderer(
       SPAN_FLAGS_CONTAINER_BACKGROUND,
     )
 
-    // Apply styling only to segments that are NOT nested quotes
-    applySpansExcludingNested(builder, nestedRanges, start, end, createLineHeightSpan(style.lineHeight))
+    // Apply styling only to content segments that are NOT nested quotes or the spacer
+    applySpansExcludingNested(builder, nestedRanges, contentStart, end, createLineHeightSpan(style.lineHeight))
 
-    if (style.padding > 0) {
+    // Bottom padding grows the last content line's descent to match web CSS
+    if (padding > 0) {
       builder.setSpan(
-        BlockquoteBoundaryPaddingSpan(style.padding.toInt()),
-        start,
+        BlockquoteBoundaryPaddingSpan(padding),
+        contentStart,
         end,
         SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
       )
@@ -78,6 +100,33 @@ class BlockquoteRenderer(
     }
   }
 
+  /**
+   * Spacer line occupying exactly [padding] px, used for a blockquote's top padding.
+   * Sets absolute metrics (independent of the surrounding font) so it stays fixed
+   * regardless of StaticLayout's cross-line FontMetricsInt reuse.
+   */
+  private class BlockquotePaddingSpacerSpan(
+    private val padding: Int,
+  ) : LineHeightSpan {
+    override fun chooseHeight(
+      text: CharSequence,
+      startLine: Int,
+      endLine: Int,
+      spanstartv: Int,
+      v: Int,
+      fm: Paint.FontMetricsInt,
+    ) {
+      fm.top = 0
+      fm.ascent = 0
+      fm.descent = padding
+      fm.bottom = padding
+    }
+  }
+
+  /**
+   * Grows the last content line's descent to create a blockquote's bottom padding.
+   * Top padding is handled separately by [BlockquotePaddingSpacerSpan].
+   */
   private class BlockquoteBoundaryPaddingSpan(
     private val padding: Int,
   ) : LineHeightSpan {
@@ -91,16 +140,13 @@ class BlockquoteRenderer(
     ) {
       if (text !is Spanned) return
 
-      val spanStart = text.getSpanStart(this)
-      val spanEnd = text.getSpanEnd(this)
-
-      if (startLine == spanStart) {
-        fm.ascent -= padding
-        fm.top -= padding
+      // The span can include trailing '\n'(s) that form no visible line, so the
+      // last drawn line ends before spanEnd; compare against visible content end.
+      var contentEnd = text.getSpanEnd(this)
+      while (contentEnd > 0 && text[contentEnd - 1] == '\n') {
+        contentEnd--
       }
-
-      val isLastLine = endLine == spanEnd || (spanEnd <= endLine && text[spanEnd - 1] == '\n')
-      if (isLastLine) {
+      if (endLine >= contentEnd) {
         fm.descent += padding
         fm.bottom += padding
       }

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
@@ -42,13 +42,6 @@ class BlockquoteRenderer(
     var end = builder.length
     val padding = style.padding.toInt()
 
-    // Top padding uses a dedicated spacer line instead of growing the first content
-    // line's ascent. StaticLayout reuses one FontMetricsInt across the soft-wrapped
-    // lines of a paragraph, so inflating the first line's metrics corrupts its
-    // wrapped continuation lines (they inherit the padded metrics and the line-height
-    // clamp then skews them into overlap). A spacer sits in its own paragraph, so
-    // content-line metrics stay untouched. Bottom padding is applied to the last
-    // line's descent, which is safe because no later line inherits its metrics.
     var contentStart = start
     if (padding > 0) {
       builder.insert(start, "\n")
@@ -70,9 +63,7 @@ class BlockquoteRenderer(
         .map { builder.getSpanStart(it) to builder.getSpanEnd(it) }
         .sortedBy { it.first }
 
-    // The accent bar / background span covers the full box (incl. the top spacer)
-    // for visual continuity. SPAN_FLAGS_CONTAINER_BACKGROUND keeps the blockquote
-    // fill under any inline chip/pill backgrounds on the same line.
+    // The accent bar / background span covers the full box, incl. the top spacer.
     builder.setSpan(
       BlockquoteSpan(style, depth, factory.context, factory.styleCache),
       start,
@@ -80,10 +71,8 @@ class BlockquoteRenderer(
       SPAN_FLAGS_CONTAINER_BACKGROUND,
     )
 
-    // Apply styling only to content segments that are NOT nested quotes or the spacer
     applySpansExcludingNested(builder, nestedRanges, contentStart, end, createLineHeightSpan(style.lineHeight))
 
-    // Bottom padding grows the last content line's descent to match web CSS
     if (padding > 0) {
       builder.setSpan(
         BlockquoteBoundaryPaddingSpan(padding),
@@ -101,9 +90,15 @@ class BlockquoteRenderer(
   }
 
   /**
-   * Spacer line occupying exactly [padding] px, used for a blockquote's top padding.
-   * Sets absolute metrics (independent of the surrounding font) so it stays fixed
-   * regardless of StaticLayout's cross-line FontMetricsInt reuse.
+   * A blockquote's top padding, rendered as a standalone spacer line of exactly
+   * [padding] px.
+   *
+   * Top padding cannot be added by growing the first content line's ascent:
+   * StaticLayout reuses one FontMetricsInt across a paragraph's soft-wrapped lines,
+   * so the inflated first-line metrics leak into the wrapped continuation line, where
+   * the line-height clamp then skews them into overlapping baselines. A spacer sits in
+   * its own paragraph, and setting absolute metrics keeps it fixed regardless of that
+   * reuse.
    */
   private class BlockquotePaddingSpacerSpan(
     private val padding: Int,
@@ -124,8 +119,12 @@ class BlockquoteRenderer(
   }
 
   /**
-   * Grows the last content line's descent to create a blockquote's bottom padding.
-   * Top padding is handled separately by [BlockquotePaddingSpacerSpan].
+   * A blockquote's bottom padding, grown onto the last content line's descent (safe
+   * because no later line inherits its metrics; top padding uses
+   * [BlockquotePaddingSpacerSpan]).
+   *
+   * The span range can include trailing '\n'(s) that form no visible line, so the last
+   * drawn line ends before getSpanEnd; the comparison uses the visible content end.
    */
   private class BlockquoteBoundaryPaddingSpan(
     private val padding: Int,
@@ -140,8 +139,6 @@ class BlockquoteRenderer(
     ) {
       if (text !is Spanned) return
 
-      // The span can include trailing '\n'(s) that form no visible line, so the
-      // last drawn line ends before spanEnd; compare against visible content end.
       var contentEnd = text.getSpanEnd(this)
       while (contentEnd > 0 && text[contentEnd - 1] == '\n') {
         contentEnd--

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
@@ -1,6 +1,9 @@
 package com.swmansion.enriched.markdown.renderer
 
+import android.graphics.Paint
 import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.LineHeightSpan
 import com.swmansion.enriched.markdown.parser.MarkdownASTNode
 import com.swmansion.enriched.markdown.spans.BlockquoteSpan
 import com.swmansion.enriched.markdown.utils.text.span.SPAN_FLAGS_CONTAINER_BACKGROUND
@@ -59,10 +62,57 @@ class BlockquoteRenderer(
     // Apply styling only to segments that are NOT nested quotes
     applySpansExcludingNested(builder, nestedRanges, start, end, createLineHeightSpan(style.lineHeight))
 
+    // Vertical padding applies at every nesting level so nested quotes pad
+    // their own box (matching web CSS padding); the spans stack at shared
+    // boundary lines just like nested element paddings do on web.
+    if (style.padding > 0) {
+      builder.setSpan(
+        BlockquoteBoundaryPaddingSpan(style.padding.toInt()),
+        start,
+        end,
+        SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
+      )
+    }
+
     // Margins are only applied by the outermost (root) quote
     if (depth == 0) {
       applyMarginTop(builder, start, style.marginTop)
       applyMarginBottom(builder, style.marginBottom)
+    }
+  }
+
+  /**
+   * Internal span to handle top/bottom padding by modifying font metrics.
+   * Same approach as the code block boundary padding span.
+   */
+  private class BlockquoteBoundaryPaddingSpan(
+    private val padding: Int,
+  ) : LineHeightSpan {
+    override fun chooseHeight(
+      text: CharSequence,
+      startLine: Int,
+      endLine: Int,
+      spanstartv: Int,
+      v: Int,
+      fm: Paint.FontMetricsInt,
+    ) {
+      if (text !is Spanned) return
+
+      val spanStart = text.getSpanStart(this)
+      val spanEnd = text.getSpanEnd(this)
+
+      // Adjust ascent/top for the first line to create internal top padding
+      if (startLine == spanStart) {
+        fm.ascent -= padding
+        fm.top -= padding
+      }
+
+      // Adjust descent/bottom for the last line (handling trailing newlines)
+      val isLastLine = endLine == spanEnd || (spanEnd <= endLine && text[spanEnd - 1] == '\n')
+      if (isLastLine) {
+        fm.descent += padding
+        fm.bottom += padding
+      }
     }
   }
 

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
@@ -62,9 +62,6 @@ class BlockquoteRenderer(
     // Apply styling only to segments that are NOT nested quotes
     applySpansExcludingNested(builder, nestedRanges, start, end, createLineHeightSpan(style.lineHeight))
 
-    // Vertical padding applies at every nesting level so nested quotes pad
-    // their own box (matching web CSS padding); the spans stack at shared
-    // boundary lines just like nested element paddings do on web.
     if (style.padding > 0) {
       builder.setSpan(
         BlockquoteBoundaryPaddingSpan(style.padding.toInt()),
@@ -81,10 +78,6 @@ class BlockquoteRenderer(
     }
   }
 
-  /**
-   * Internal span to handle top/bottom padding by modifying font metrics.
-   * Same approach as the code block boundary padding span.
-   */
   private class BlockquoteBoundaryPaddingSpan(
     private val padding: Int,
   ) : LineHeightSpan {
@@ -101,13 +94,11 @@ class BlockquoteRenderer(
       val spanStart = text.getSpanStart(this)
       val spanEnd = text.getSpanEnd(this)
 
-      // Adjust ascent/top for the first line to create internal top padding
       if (startLine == spanStart) {
         fm.ascent -= padding
         fm.top -= padding
       }
 
-      // Adjust descent/bottom for the last line (handling trailing newlines)
       val isLastLine = endLine == spanEnd || (spanEnd <= endLine && text[spanEnd - 1] == '\n')
       if (isLastLine) {
         fm.descent += padding

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
@@ -242,8 +242,14 @@ class BlockquoteSpan(
     lineEnd: Int,
     box: BlockquoteSpan,
   ): Boolean {
-    val boxEnd = text.getSpanEnd(box)
-    return lineEnd == boxEnd || (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+    // The span range can include trailing '\n'(s) that form no visible line
+    // (e.g. a paragraph break closing the quote), so the last drawn line ends
+    // before getSpanEnd. Compare against the end of visible content instead.
+    var boxEnd = text.getSpanEnd(box)
+    while (boxEnd > 0 && text[boxEnd - 1] == '\n') {
+      boxEnd--
+    }
+    return lineEnd >= boxEnd
   }
 
   private fun isBoundaryLine(

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
 import android.graphics.Typeface
 import android.text.Layout
 import android.text.Spanned
@@ -12,6 +14,7 @@ import android.text.TextPaint
 import android.text.style.LeadingMarginSpan
 import android.text.style.LineBackgroundSpan
 import android.text.style.MetricAffectingSpan
+import androidx.core.graphics.withSave
 import com.swmansion.enriched.markdown.renderer.BlockStyle
 import com.swmansion.enriched.markdown.renderer.SpanStyleCache
 import com.swmansion.enriched.markdown.styles.BlockquoteStyle
@@ -37,7 +40,17 @@ class BlockquoteSpan(
 
   // Cache for shouldSkipDrawing to avoid repeated getSpans() calls during draw passes
   private var cachedText: CharSequence? = null
-  private var cachedMaxDepthByPosition = mutableMapOf<Int, Int>()
+  private var cachedSpansByPosition = mutableMapOf<Int, Array<BlockquoteSpan>>()
+
+  // Horizontal box bounds captured during the background pass; Layout draws all
+  // line backgrounds before any leading margins, so the values are ready when
+  // the border stripes need clipping to the rounded box shape.
+  private var boxLeft = 0f
+  private var boxRight = 0f
+
+  private val path = Path()
+  private val rect = RectF()
+  private val radiiArray = FloatArray(8)
 
   override fun updateMeasureState(tp: TextPaint) = applyTextStyle(tp)
 
@@ -63,13 +76,48 @@ class BlockquoteSpan(
     if (shouldSkipDrawing(text, start)) return
 
     val borderPaint = configureBorderPaint()
-    val borderTop = top.toFloat()
-    val borderBottom = bottom.toFloat()
+    val radius = blockquoteStyle.borderRadius
+    val spanned = text as? Spanned
+
+    if (radius <= 0f || spanned == null || boxRight <= boxLeft) {
+      drawBorders(c, x, dir, top, bottom, borderPaint)
+      return
+    }
+
+    // Each level's stripe is clipped to its own quote's rounded box (mirroring
+    // per-element CSS border-radius on web); level 0 additionally rounds
+    // against the outermost box that also carries the background.
+    val rootSpan = spanAtMinDepth(spanned, start)
+    val rootBoundary = rootSpan != null && isBoundaryLine(spanned, start, end, rootSpan)
 
     for (level in 0..depth) {
       val borderX = x + (levelSpacing * level * dir)
       val borderRight = borderX + (blockquoteStyle.borderWidth * dir)
-      c.drawRect(minOf(borderX, borderRight), borderTop, maxOf(borderX, borderRight), borderBottom, borderPaint)
+      val stripeLeft = minOf(borderX, borderRight)
+      val stripeRight = maxOf(borderX, borderRight)
+
+      val levelSpan = if (level == 0) rootSpan else spanAtDepth(spanned, start, level)
+      val ownBoundary =
+        level > 0 && levelSpan != null && isBoundaryLine(spanned, start, end, levelSpan)
+
+      if (!rootBoundary && !ownBoundary) {
+        c.drawRect(stripeLeft, top.toFloat(), stripeRight, bottom.toFloat(), borderPaint)
+        continue
+      }
+
+      c.withSave {
+        if (rootBoundary) {
+          buildBoundaryPath(spanned, start, end, rootSpan!!, boxLeft, top.toFloat(), boxRight, bottom.toFloat())
+          clipPath(path)
+        }
+        if (ownBoundary) {
+          val clipLeft = if (dir >= 0) stripeLeft else boxLeft
+          val clipRight = if (dir >= 0) boxRight else stripeRight
+          buildBoundaryPath(spanned, start, end, levelSpan!!, clipLeft, top.toFloat(), clipRight, bottom.toFloat())
+          clipPath(path)
+        }
+        drawRect(stripeLeft, top.toFloat(), stripeRight, bottom.toFloat(), borderPaint)
+      }
     }
   }
 
@@ -87,7 +135,40 @@ class BlockquoteSpan(
     lineNum: Int,
   ) {
     if (shouldSkipDrawing(text, start)) return
-    drawBackground(canvas, left, top, bottom, right)
+
+    boxLeft = left.toFloat()
+    boxRight = right.toFloat()
+
+    val bgColor = blockquoteStyle.backgroundColor?.takeIf { it != Color.TRANSPARENT } ?: return
+    val backgroundPaint = configureBackgroundPaint(bgColor)
+    val radius = blockquoteStyle.borderRadius
+    val rootSpan = (text as? Spanned)?.let { spanAtMinDepth(it, start) }
+
+    if (radius <= 0f || rootSpan == null) {
+      canvas.drawRect(left.toFloat(), top.toFloat(), right.toFloat(), bottom.toFloat(), backgroundPaint)
+      return
+    }
+
+    buildBoundaryPath(text as Spanned, start, end, rootSpan, left.toFloat(), top.toFloat(), right.toFloat(), bottom.toFloat())
+    canvas.drawPath(path, backgroundPaint)
+  }
+
+  private fun drawBorders(
+    c: Canvas,
+    x: Int,
+    dir: Int,
+    top: Int,
+    bottom: Int,
+    borderPaint: Paint,
+  ) {
+    val borderTop = top.toFloat()
+    val borderBottom = bottom.toFloat()
+
+    for (level in 0..depth) {
+      val borderX = x + (levelSpacing * level * dir)
+      val borderRight = borderX + (blockquoteStyle.borderWidth * dir)
+      c.drawRect(minOf(borderX, borderRight), borderTop, maxOf(borderX, borderRight), borderBottom, borderPaint)
+    }
   }
 
   @SuppressLint("WrongConstant") // Result of mask is always valid: 0, 1, 2, or 3
@@ -118,35 +199,89 @@ class BlockquoteSpan(
       color = bgColor
     }
 
+  private fun spansAt(
+    text: Spanned,
+    start: Int,
+  ): Array<BlockquoteSpan> {
+    if (cachedText !== text) {
+      cachedText = text
+      cachedSpansByPosition.clear()
+    }
+    return cachedSpansByPosition.getOrPut(start) {
+      text.getSpans(start, start + 1, BlockquoteSpan::class.java)
+    }
+  }
+
   private fun shouldSkipDrawing(
     text: CharSequence?,
     start: Int,
   ): Boolean {
     if (text !is Spanned) return false
-
-    if (cachedText !== text) {
-      cachedText = text
-      cachedMaxDepthByPosition.clear()
-    }
-
-    val maxDepth =
-      cachedMaxDepthByPosition.getOrPut(start) {
-        val spans = text.getSpans(start, start + 1, BlockquoteSpan::class.java)
-        spans.maxOfOrNull { it.depth } ?: -1
-      }
-
+    val maxDepth = spansAt(text, start).maxOfOrNull { it.depth } ?: -1
     return maxDepth > depth
   }
 
-  private fun drawBackground(
-    c: Canvas,
-    left: Int,
-    top: Int,
-    bottom: Int,
-    right: Int,
+  // The outermost box (background + outer rounding) is the min-depth span at
+  // this position; each nested level's own box is the span with that depth.
+  private fun spanAtMinDepth(
+    text: Spanned,
+    start: Int,
+  ): BlockquoteSpan? = spansAt(text, start).minByOrNull { it.depth }
+
+  private fun spanAtDepth(
+    text: Spanned,
+    start: Int,
+    level: Int,
+  ): BlockquoteSpan? = spansAt(text, start).firstOrNull { it.depth == level }
+
+  private fun isBoundaryLine(
+    text: Spanned,
+    lineStart: Int,
+    lineEnd: Int,
+    box: BlockquoteSpan,
+  ): Boolean {
+    val boxStart = text.getSpanStart(box)
+    val boxEnd = text.getSpanEnd(box)
+    if (boxStart !in 0 until boxEnd) return false
+    return lineStart == boxStart ||
+      lineEnd == boxEnd ||
+      (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+  }
+
+  private fun buildBoundaryPath(
+    text: Spanned,
+    lineStart: Int,
+    lineEnd: Int,
+    box: BlockquoteSpan,
+    left: Float,
+    top: Float,
+    right: Float,
+    bottom: Float,
   ) {
-    val bgColor = blockquoteStyle.backgroundColor?.takeIf { it != Color.TRANSPARENT } ?: return
-    val backgroundPaint = configureBackgroundPaint(bgColor)
-    c.drawRect(left.toFloat(), top.toFloat(), right.toFloat(), bottom.toFloat(), backgroundPaint)
+    val boxStart = text.getSpanStart(box)
+    val boxEnd = text.getSpanEnd(box)
+
+    val isFirstLine = lineStart == boxStart
+    val isLastLine =
+      lineEnd == boxEnd || (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+
+    val radius = blockquoteStyle.borderRadius
+    radiiArray.fill(0f)
+    if (isFirstLine) {
+      radiiArray[0] = radius
+      radiiArray[1] = radius // Top-Left
+      radiiArray[2] = radius
+      radiiArray[3] = radius // Top-Right
+    }
+    if (isLastLine) {
+      radiiArray[4] = radius
+      radiiArray[5] = radius // Bottom-Right
+      radiiArray[6] = radius
+      radiiArray[7] = radius // Bottom-Left
+    }
+
+    rect.set(left, top, right, bottom)
+    path.reset()
+    path.addRoundRect(rect, radiiArray, Path.Direction.CW)
   }
 }

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
@@ -237,14 +237,16 @@ class BlockquoteSpan(
     level: Int,
   ): BlockquoteSpan? = spansAt(text, start).firstOrNull { it.depth == level }
 
+  /**
+   * The span range can include trailing '\n'(s) that form no visible line (e.g. a
+   * paragraph break closing the quote), so the last drawn line ends before getSpanEnd;
+   * this compares against the end of visible content instead.
+   */
   private fun isLastLineOf(
     text: Spanned,
     lineEnd: Int,
     box: BlockquoteSpan,
   ): Boolean {
-    // The span range can include trailing '\n'(s) that form no visible line
-    // (e.g. a paragraph break closing the quote), so the last drawn line ends
-    // before getSpanEnd. Compare against the end of visible content instead.
     var boxEnd = text.getSpanEnd(box)
     while (boxEnd > 0 && text[boxEnd - 1] == '\n') {
       boxEnd--

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
@@ -42,9 +42,6 @@ class BlockquoteSpan(
   private var cachedText: CharSequence? = null
   private var cachedSpansByPosition = mutableMapOf<Int, Array<BlockquoteSpan>>()
 
-  // Horizontal box bounds captured during the background pass; Layout draws all
-  // line backgrounds before any leading margins, so the values are ready when
-  // the border stripes need clipping to the rounded box shape.
   private var boxLeft = 0f
   private var boxRight = 0f
 
@@ -84,17 +81,10 @@ class BlockquoteSpan(
       return
     }
 
-    // Each level's stripe is clipped to its own quote's rounded box (mirroring
-    // per-element CSS border-radius on web); level 0 additionally rounds
-    // against the outermost box that also carries the background.
     val rootSpan = spanAtMinDepth(spanned, start)
     val clipToRoot =
       radius > 0f && boxRight > boxLeft && rootSpan != null && isBoundaryLine(spanned, start, end, rootSpan)
 
-    // Boundary paddings of every box starting/ending on this line stack into
-    // the same font metrics (outermost zone outermost). A level's stripe must
-    // stop at its own box edge, so inset it by the paddings of the shallower
-    // boxes whose zones lie beyond it on this line.
     val padding = blockquoteStyle.padding
     var topInset = 0f
     var bottomInset = 0f
@@ -236,8 +226,6 @@ class BlockquoteSpan(
     return maxDepth > depth
   }
 
-  // The outermost box (background + outer rounding) is the min-depth span at
-  // this position; each nested level's own box is the span with that depth.
   private fun spanAtMinDepth(
     text: Spanned,
     start: Int,

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
@@ -79,7 +79,7 @@ class BlockquoteSpan(
     val radius = blockquoteStyle.borderRadius
     val spanned = text as? Spanned
 
-    if (radius <= 0f || spanned == null || boxRight <= boxLeft) {
+    if (spanned == null) {
       drawBorders(c, x, dir, top, bottom, borderPaint)
       return
     }
@@ -88,35 +88,50 @@ class BlockquoteSpan(
     // per-element CSS border-radius on web); level 0 additionally rounds
     // against the outermost box that also carries the background.
     val rootSpan = spanAtMinDepth(spanned, start)
-    val rootBoundary = rootSpan != null && isBoundaryLine(spanned, start, end, rootSpan)
+    val clipToRoot =
+      radius > 0f && boxRight > boxLeft && rootSpan != null && isBoundaryLine(spanned, start, end, rootSpan)
+
+    // Boundary paddings of every box starting/ending on this line stack into
+    // the same font metrics (outermost zone outermost). A level's stripe must
+    // stop at its own box edge, so inset it by the paddings of the shallower
+    // boxes whose zones lie beyond it on this line.
+    val padding = blockquoteStyle.padding
+    var topInset = 0f
+    var bottomInset = 0f
 
     for (level in 0..depth) {
       val borderX = x + (levelSpacing * level * dir)
       val borderRight = borderX + (blockquoteStyle.borderWidth * dir)
       val stripeLeft = minOf(borderX, borderRight)
       val stripeRight = maxOf(borderX, borderRight)
+      val stripeTop = top.toFloat() + topInset
+      val stripeBottom = bottom.toFloat() - bottomInset
 
       val levelSpan = if (level == 0) rootSpan else spanAtDepth(spanned, start, level)
-      val ownBoundary =
-        level > 0 && levelSpan != null && isBoundaryLine(spanned, start, end, levelSpan)
+      val clipToOwn =
+        radius > 0f && level > 0 && levelSpan != null && isBoundaryLine(spanned, start, end, levelSpan)
 
-      if (!rootBoundary && !ownBoundary) {
-        c.drawRect(stripeLeft, top.toFloat(), stripeRight, bottom.toFloat(), borderPaint)
-        continue
+      if (!clipToRoot && !clipToOwn) {
+        c.drawRect(stripeLeft, stripeTop, stripeRight, stripeBottom, borderPaint)
+      } else {
+        c.withSave {
+          if (clipToRoot) {
+            buildBoundaryPath(spanned, start, end, rootSpan!!, boxLeft, top.toFloat(), boxRight, bottom.toFloat())
+            clipPath(path)
+          }
+          if (clipToOwn) {
+            val clipLeft = if (dir >= 0) stripeLeft else boxLeft
+            val clipRight = if (dir >= 0) boxRight else stripeRight
+            buildBoundaryPath(spanned, start, end, levelSpan!!, clipLeft, stripeTop, clipRight, stripeBottom)
+            clipPath(path)
+          }
+          drawRect(stripeLeft, stripeTop, stripeRight, stripeBottom, borderPaint)
+        }
       }
 
-      c.withSave {
-        if (rootBoundary) {
-          buildBoundaryPath(spanned, start, end, rootSpan!!, boxLeft, top.toFloat(), boxRight, bottom.toFloat())
-          clipPath(path)
-        }
-        if (ownBoundary) {
-          val clipLeft = if (dir >= 0) stripeLeft else boxLeft
-          val clipRight = if (dir >= 0) boxRight else stripeRight
-          buildBoundaryPath(spanned, start, end, levelSpan!!, clipLeft, top.toFloat(), clipRight, bottom.toFloat())
-          clipPath(path)
-        }
-        drawRect(stripeLeft, top.toFloat(), stripeRight, bottom.toFloat(), borderPaint)
+      if (padding > 0 && levelSpan != null) {
+        if (start == spanned.getSpanStart(levelSpan)) topInset += padding
+        if (isLastLineOf(spanned, end, levelSpan)) bottomInset += padding
       }
     }
   }
@@ -234,6 +249,15 @@ class BlockquoteSpan(
     level: Int,
   ): BlockquoteSpan? = spansAt(text, start).firstOrNull { it.depth == level }
 
+  private fun isLastLineOf(
+    text: Spanned,
+    lineEnd: Int,
+    box: BlockquoteSpan,
+  ): Boolean {
+    val boxEnd = text.getSpanEnd(box)
+    return lineEnd == boxEnd || (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+  }
+
   private fun isBoundaryLine(
     text: Spanned,
     lineStart: Int,
@@ -243,9 +267,7 @@ class BlockquoteSpan(
     val boxStart = text.getSpanStart(box)
     val boxEnd = text.getSpanEnd(box)
     if (boxStart !in 0 until boxEnd) return false
-    return lineStart == boxStart ||
-      lineEnd == boxEnd ||
-      (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+    return lineStart == boxStart || isLastLineOf(text, lineEnd, box)
   }
 
   private fun buildBoundaryPath(
@@ -259,11 +281,9 @@ class BlockquoteSpan(
     bottom: Float,
   ) {
     val boxStart = text.getSpanStart(box)
-    val boxEnd = text.getSpanEnd(box)
 
     val isFirstLine = lineStart == boxStart
-    val isLastLine =
-      lineEnd == boxEnd || (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+    val isLastLine = isLastLineOf(text, lineEnd, box)
 
     val radius = blockquoteStyle.borderRadius
     radiiArray.fill(0f)

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/styles/BlockquoteStyle.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/styles/BlockquoteStyle.kt
@@ -12,4 +12,6 @@ data class BlockquoteStyle(
   val borderWidth: Float,
   val gapWidth: Float,
   val backgroundColor: Int?,
+  val borderRadius: Float = 0f,
+  val padding: Float = 0f,
 ) : BaseBlockStyle

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/styles/DefaultStyles.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/styles/DefaultStyles.kt
@@ -106,8 +106,8 @@ internal object DefaultStyles {
           borderWidth = parser.toPixelFromDIP(3f),
           gapWidth = parser.toPixelFromDIP(16f),
           backgroundColor = parser.color("#F9FAFB"),
-          borderRadius = parser.toPixelFromDIP(0f),
-          padding = parser.toPixelFromDIP(0f),
+          borderRadius = 0f,
+          padding = 0f,
         ),
       listStyle =
         ListStyle(

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/styles/DefaultStyles.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/styles/DefaultStyles.kt
@@ -106,6 +106,8 @@ internal object DefaultStyles {
           borderWidth = parser.toPixelFromDIP(3f),
           gapWidth = parser.toPixelFromDIP(16f),
           backgroundColor = parser.color("#F9FAFB"),
+          borderRadius = parser.toPixelFromDIP(0f),
+          padding = parser.toPixelFromDIP(0f),
         ),
       listStyle =
         ListStyle(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
@@ -1,9 +1,13 @@
 package com.swmansion.enriched.markdown.renderer
 
+import android.graphics.Paint
 import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.LineHeightSpan
 import com.swmansion.enriched.markdown.parser.MarkdownASTNode
 import com.swmansion.enriched.markdown.spans.BlockquoteSpan
 import com.swmansion.enriched.markdown.utils.text.span.SPAN_FLAGS_CONTAINER_BACKGROUND
+import com.swmansion.enriched.markdown.utils.text.span.SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE
 import com.swmansion.enriched.markdown.utils.text.span.applyLineHeightSkippingImages
 import com.swmansion.enriched.markdown.utils.text.span.applyMarginBottom
 import com.swmansion.enriched.markdown.utils.text.span.applyMarginTop
@@ -63,10 +67,57 @@ class BlockquoteRenderer(
     // block images so their expanded line metrics aren't re-clamped
     applyLineHeightExcludingNested(builder, nestedRanges, start, end, style.lineHeight)
 
+    // Vertical padding applies at every nesting level so nested quotes pad
+    // their own box (matching web CSS padding); the spans stack at shared
+    // boundary lines just like nested element paddings do on web.
+    if (style.padding > 0) {
+      builder.setSpan(
+        BlockquoteBoundaryPaddingSpan(style.padding.toInt()),
+        start,
+        end,
+        SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
+      )
+    }
+
     // Margins are only applied by the outermost (root) quote
     if (depth == 0) {
       applyMarginTop(builder, start, style.marginTop)
       applyMarginBottom(builder, style.marginBottom)
+    }
+  }
+
+  /**
+   * Internal span to handle top/bottom padding by modifying font metrics.
+   * Same approach as the code block boundary padding span.
+   */
+  private class BlockquoteBoundaryPaddingSpan(
+    private val padding: Int,
+  ) : LineHeightSpan {
+    override fun chooseHeight(
+      text: CharSequence,
+      startLine: Int,
+      endLine: Int,
+      spanstartv: Int,
+      v: Int,
+      fm: Paint.FontMetricsInt,
+    ) {
+      if (text !is Spanned) return
+
+      val spanStart = text.getSpanStart(this)
+      val spanEnd = text.getSpanEnd(this)
+
+      // Adjust ascent/top for the first line to create internal top padding
+      if (startLine == spanStart) {
+        fm.ascent -= padding
+        fm.top -= padding
+      }
+
+      // Adjust descent/bottom for the last line (handling trailing newlines)
+      val isLastLine = endLine == spanEnd || (spanEnd <= endLine && text[spanEnd - 1] == '\n')
+      if (isLastLine) {
+        fm.descent += padding
+        fm.bottom += padding
+      }
     }
   }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
@@ -43,19 +43,40 @@ class BlockquoteRenderer(
     }
 
     if (builder.length == start) return
-    val end = builder.length
+    var end = builder.length
+    val padding = style.padding.toInt()
+
+    // Top padding uses a dedicated spacer line instead of growing the first content
+    // line's ascent. StaticLayout reuses one FontMetricsInt across the soft-wrapped
+    // lines of a paragraph, so inflating the first line's metrics corrupts its
+    // wrapped continuation lines (they inherit the padded metrics and the line-height
+    // clamp then skews them into overlap). A spacer sits in its own paragraph, so
+    // content-line metrics stay untouched. Bottom padding is applied to the last
+    // line's descent, which is safe because no later line inherits its metrics.
+    var contentStart = start
+    if (padding > 0) {
+      builder.insert(start, "\n")
+      builder.setSpan(
+        BlockquotePaddingSpacerSpan(padding),
+        start,
+        start + 1,
+        SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
+      )
+      contentStart = start + 1
+      end += 1
+    }
 
     // Find immediately nested quotes to exclude them from this level's line-height/margins
     val nestedRanges =
       builder
-        .getSpans(start, end, BlockquoteSpan::class.java)
+        .getSpans(contentStart, end, BlockquoteSpan::class.java)
         .filter { it.depth == depth + 1 }
         .map { builder.getSpanStart(it) to builder.getSpanEnd(it) }
         .sortedBy { it.first }
 
-    // The accent bar span covers the full range for visual continuity.
-    // SPAN_FLAGS_CONTAINER_BACKGROUND keeps the blockquote fill under any
-    // inline chip/pill backgrounds on the same line.
+    // The accent bar / background span covers the full box (incl. the top spacer)
+    // for visual continuity. SPAN_FLAGS_CONTAINER_BACKGROUND keeps the blockquote
+    // fill under any inline chip/pill backgrounds on the same line.
     builder.setSpan(
       BlockquoteSpan(style, depth, factory.context, factory.styleCache),
       start,
@@ -63,15 +84,15 @@ class BlockquoteRenderer(
       SPAN_FLAGS_CONTAINER_BACKGROUND,
     )
 
-    // Apply line height only to segments that are NOT nested quotes, skipping
-    // block images so their expanded line metrics aren't re-clamped
-    applyLineHeightExcludingNested(builder, nestedRanges, start, end, style.lineHeight)
+    // Apply line height only to content segments that are NOT nested quotes or the
+    // top spacer, skipping block images so their expanded line metrics aren't re-clamped
+    applyLineHeightExcludingNested(builder, nestedRanges, contentStart, end, style.lineHeight)
 
-    // Nested quotes pad their own box to match web CSS
-    if (style.padding > 0) {
+    // Bottom padding grows the last content line's descent to match web CSS
+    if (padding > 0) {
       builder.setSpan(
-        BlockquoteBoundaryPaddingSpan(style.padding.toInt()),
-        start,
+        BlockquoteBoundaryPaddingSpan(padding),
+        contentStart,
         end,
         SPAN_FLAGS_EXCLUSIVE_EXCLUSIVE,
       )
@@ -85,8 +106,31 @@ class BlockquoteRenderer(
   }
 
   /**
-   * Internal span to handle top/bottom padding by modifying font metrics.
-   * Same approach as the code block boundary padding span.
+   * Spacer line occupying exactly [padding] px, used for a blockquote's top padding.
+   * Sets absolute metrics (independent of the surrounding font) so it stays fixed
+   * regardless of StaticLayout's cross-line FontMetricsInt reuse.
+   */
+  private class BlockquotePaddingSpacerSpan(
+    private val padding: Int,
+  ) : LineHeightSpan {
+    override fun chooseHeight(
+      text: CharSequence,
+      startLine: Int,
+      endLine: Int,
+      spanstartv: Int,
+      v: Int,
+      fm: Paint.FontMetricsInt,
+    ) {
+      fm.top = 0
+      fm.ascent = 0
+      fm.descent = padding
+      fm.bottom = padding
+    }
+  }
+
+  /**
+   * Grows the last content line's descent to create a blockquote's bottom padding.
+   * Top padding is handled separately by [BlockquotePaddingSpacerSpan].
    */
   private class BlockquoteBoundaryPaddingSpan(
     private val padding: Int,
@@ -101,16 +145,13 @@ class BlockquoteRenderer(
     ) {
       if (text !is Spanned) return
 
-      val spanStart = text.getSpanStart(this)
-      val spanEnd = text.getSpanEnd(this)
-
-      if (startLine == spanStart) {
-        fm.ascent -= padding
-        fm.top -= padding
+      // The span can include trailing '\n'(s) that form no visible line, so the
+      // last drawn line ends before spanEnd; compare against visible content end.
+      var contentEnd = text.getSpanEnd(this)
+      while (contentEnd > 0 && text[contentEnd - 1] == '\n') {
+        contentEnd--
       }
-
-      val isLastLine = endLine == spanEnd || (spanEnd <= endLine && text[spanEnd - 1] == '\n')
-      if (isLastLine) {
+      if (endLine >= contentEnd) {
         fm.descent += padding
         fm.bottom += padding
       }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
@@ -67,9 +67,7 @@ class BlockquoteRenderer(
     // block images so their expanded line metrics aren't re-clamped
     applyLineHeightExcludingNested(builder, nestedRanges, start, end, style.lineHeight)
 
-    // Vertical padding applies at every nesting level so nested quotes pad
-    // their own box (matching web CSS padding); the spans stack at shared
-    // boundary lines just like nested element paddings do on web.
+    // Nested quotes pad their own box to match web CSS
     if (style.padding > 0) {
       builder.setSpan(
         BlockquoteBoundaryPaddingSpan(style.padding.toInt()),
@@ -106,13 +104,11 @@ class BlockquoteRenderer(
       val spanStart = text.getSpanStart(this)
       val spanEnd = text.getSpanEnd(this)
 
-      // Adjust ascent/top for the first line to create internal top padding
       if (startLine == spanStart) {
         fm.ascent -= padding
         fm.top -= padding
       }
 
-      // Adjust descent/bottom for the last line (handling trailing newlines)
       val isLastLine = endLine == spanEnd || (spanEnd <= endLine && text[spanEnd - 1] == '\n')
       if (isLastLine) {
         fm.descent += padding

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/renderer/BlockquoteRenderer.kt
@@ -46,13 +46,6 @@ class BlockquoteRenderer(
     var end = builder.length
     val padding = style.padding.toInt()
 
-    // Top padding uses a dedicated spacer line instead of growing the first content
-    // line's ascent. StaticLayout reuses one FontMetricsInt across the soft-wrapped
-    // lines of a paragraph, so inflating the first line's metrics corrupts its
-    // wrapped continuation lines (they inherit the padded metrics and the line-height
-    // clamp then skews them into overlap). A spacer sits in its own paragraph, so
-    // content-line metrics stay untouched. Bottom padding is applied to the last
-    // line's descent, which is safe because no later line inherits its metrics.
     var contentStart = start
     if (padding > 0) {
       builder.insert(start, "\n")
@@ -74,9 +67,7 @@ class BlockquoteRenderer(
         .map { builder.getSpanStart(it) to builder.getSpanEnd(it) }
         .sortedBy { it.first }
 
-    // The accent bar / background span covers the full box (incl. the top spacer)
-    // for visual continuity. SPAN_FLAGS_CONTAINER_BACKGROUND keeps the blockquote
-    // fill under any inline chip/pill backgrounds on the same line.
+    // The accent bar / background span covers the full box, incl. the top spacer.
     builder.setSpan(
       BlockquoteSpan(style, depth, factory.context, factory.styleCache),
       start,
@@ -84,11 +75,8 @@ class BlockquoteRenderer(
       SPAN_FLAGS_CONTAINER_BACKGROUND,
     )
 
-    // Apply line height only to content segments that are NOT nested quotes or the
-    // top spacer, skipping block images so their expanded line metrics aren't re-clamped
     applyLineHeightExcludingNested(builder, nestedRanges, contentStart, end, style.lineHeight)
 
-    // Bottom padding grows the last content line's descent to match web CSS
     if (padding > 0) {
       builder.setSpan(
         BlockquoteBoundaryPaddingSpan(padding),
@@ -106,9 +94,15 @@ class BlockquoteRenderer(
   }
 
   /**
-   * Spacer line occupying exactly [padding] px, used for a blockquote's top padding.
-   * Sets absolute metrics (independent of the surrounding font) so it stays fixed
-   * regardless of StaticLayout's cross-line FontMetricsInt reuse.
+   * A blockquote's top padding, rendered as a standalone spacer line of exactly
+   * [padding] px.
+   *
+   * Top padding cannot be added by growing the first content line's ascent:
+   * StaticLayout reuses one FontMetricsInt across a paragraph's soft-wrapped lines,
+   * so the inflated first-line metrics leak into the wrapped continuation line, where
+   * the line-height clamp then skews them into overlapping baselines. A spacer sits in
+   * its own paragraph, and setting absolute metrics keeps it fixed regardless of that
+   * reuse.
    */
   private class BlockquotePaddingSpacerSpan(
     private val padding: Int,
@@ -129,8 +123,12 @@ class BlockquoteRenderer(
   }
 
   /**
-   * Grows the last content line's descent to create a blockquote's bottom padding.
-   * Top padding is handled separately by [BlockquotePaddingSpacerSpan].
+   * A blockquote's bottom padding, grown onto the last content line's descent (safe
+   * because no later line inherits its metrics; top padding uses
+   * [BlockquotePaddingSpacerSpan]).
+   *
+   * The span range can include trailing '\n'(s) that form no visible line, so the last
+   * drawn line ends before getSpanEnd; the comparison uses the visible content end.
    */
   private class BlockquoteBoundaryPaddingSpan(
     private val padding: Int,
@@ -145,8 +143,6 @@ class BlockquoteRenderer(
     ) {
       if (text !is Spanned) return
 
-      // The span can include trailing '\n'(s) that form no visible line, so the
-      // last drawn line ends before spanEnd; compare against visible content end.
       var contentEnd = text.getSpanEnd(this)
       while (contentEnd > 0 && text[contentEnd - 1] == '\n') {
         contentEnd--

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
 import android.graphics.Typeface
 import android.text.Layout
 import android.text.Spanned
@@ -12,6 +14,7 @@ import android.text.TextPaint
 import android.text.style.LeadingMarginSpan
 import android.text.style.LineBackgroundSpan
 import android.text.style.MetricAffectingSpan
+import androidx.core.graphics.withSave
 import com.swmansion.enriched.markdown.renderer.BlockStyle
 import com.swmansion.enriched.markdown.renderer.SpanStyleCache
 import com.swmansion.enriched.markdown.styles.BlockquoteStyle
@@ -37,7 +40,17 @@ class BlockquoteSpan(
 
   // Cache for shouldSkipDrawing to avoid repeated getSpans() calls during draw passes
   private var cachedText: CharSequence? = null
-  private var cachedMaxDepthByPosition = mutableMapOf<Int, Int>()
+  private var cachedSpansByPosition = mutableMapOf<Int, Array<BlockquoteSpan>>()
+
+  // Horizontal box bounds captured during the background pass; Layout draws all
+  // line backgrounds before any leading margins, so the values are ready when
+  // the border stripes need clipping to the rounded box shape.
+  private var boxLeft = 0f
+  private var boxRight = 0f
+
+  private val path = Path()
+  private val rect = RectF()
+  private val radiiArray = FloatArray(8)
 
   override fun updateMeasureState(tp: TextPaint) = applyTextStyle(tp)
 
@@ -63,13 +76,48 @@ class BlockquoteSpan(
     if (shouldSkipDrawing(text, start)) return
 
     val borderPaint = configureBorderPaint()
-    val borderTop = top.toFloat()
-    val borderBottom = bottom.toFloat()
+    val radius = blockquoteStyle.borderRadius
+    val spanned = text as? Spanned
+
+    if (radius <= 0f || spanned == null || boxRight <= boxLeft) {
+      drawBorders(c, x, dir, top, bottom, borderPaint)
+      return
+    }
+
+    // Each level's stripe is clipped to its own quote's rounded box (mirroring
+    // per-element CSS border-radius on web); level 0 additionally rounds
+    // against the outermost box that also carries the background.
+    val rootSpan = spanAtMinDepth(spanned, start)
+    val rootBoundary = rootSpan != null && isBoundaryLine(spanned, start, end, rootSpan)
 
     for (level in 0..depth) {
       val borderX = x + (levelSpacing * level * dir)
       val borderRight = borderX + (blockquoteStyle.borderWidth * dir)
-      c.drawRect(minOf(borderX, borderRight), borderTop, maxOf(borderX, borderRight), borderBottom, borderPaint)
+      val stripeLeft = minOf(borderX, borderRight)
+      val stripeRight = maxOf(borderX, borderRight)
+
+      val levelSpan = if (level == 0) rootSpan else spanAtDepth(spanned, start, level)
+      val ownBoundary =
+        level > 0 && levelSpan != null && isBoundaryLine(spanned, start, end, levelSpan)
+
+      if (!rootBoundary && !ownBoundary) {
+        c.drawRect(stripeLeft, top.toFloat(), stripeRight, bottom.toFloat(), borderPaint)
+        continue
+      }
+
+      c.withSave {
+        if (rootBoundary) {
+          buildBoundaryPath(spanned, start, end, rootSpan!!, boxLeft, top.toFloat(), boxRight, bottom.toFloat())
+          clipPath(path)
+        }
+        if (ownBoundary) {
+          val clipLeft = if (dir >= 0) stripeLeft else boxLeft
+          val clipRight = if (dir >= 0) boxRight else stripeRight
+          buildBoundaryPath(spanned, start, end, levelSpan!!, clipLeft, top.toFloat(), clipRight, bottom.toFloat())
+          clipPath(path)
+        }
+        drawRect(stripeLeft, top.toFloat(), stripeRight, bottom.toFloat(), borderPaint)
+      }
     }
   }
 
@@ -87,7 +135,40 @@ class BlockquoteSpan(
     lineNum: Int,
   ) {
     if (shouldSkipDrawing(text, start)) return
-    drawBackground(canvas, left, top, bottom, right)
+
+    boxLeft = left.toFloat()
+    boxRight = right.toFloat()
+
+    val bgColor = blockquoteStyle.backgroundColor?.takeIf { it != Color.TRANSPARENT } ?: return
+    val backgroundPaint = configureBackgroundPaint(bgColor)
+    val radius = blockquoteStyle.borderRadius
+    val rootSpan = (text as? Spanned)?.let { spanAtMinDepth(it, start) }
+
+    if (radius <= 0f || rootSpan == null) {
+      canvas.drawRect(left.toFloat(), top.toFloat(), right.toFloat(), bottom.toFloat(), backgroundPaint)
+      return
+    }
+
+    buildBoundaryPath(text as Spanned, start, end, rootSpan, left.toFloat(), top.toFloat(), right.toFloat(), bottom.toFloat())
+    canvas.drawPath(path, backgroundPaint)
+  }
+
+  private fun drawBorders(
+    c: Canvas,
+    x: Int,
+    dir: Int,
+    top: Int,
+    bottom: Int,
+    borderPaint: Paint,
+  ) {
+    val borderTop = top.toFloat()
+    val borderBottom = bottom.toFloat()
+
+    for (level in 0..depth) {
+      val borderX = x + (levelSpacing * level * dir)
+      val borderRight = borderX + (blockquoteStyle.borderWidth * dir)
+      c.drawRect(minOf(borderX, borderRight), borderTop, maxOf(borderX, borderRight), borderBottom, borderPaint)
+    }
   }
 
   @SuppressLint("WrongConstant") // Result of mask is always valid: 0, 1, 2, or 3
@@ -118,35 +199,89 @@ class BlockquoteSpan(
       color = bgColor
     }
 
+  private fun spansAt(
+    text: Spanned,
+    start: Int,
+  ): Array<BlockquoteSpan> {
+    if (cachedText !== text) {
+      cachedText = text
+      cachedSpansByPosition.clear()
+    }
+    return cachedSpansByPosition.getOrPut(start) {
+      text.getSpans(start, start + 1, BlockquoteSpan::class.java)
+    }
+  }
+
   private fun shouldSkipDrawing(
     text: CharSequence?,
     start: Int,
   ): Boolean {
     if (text !is Spanned) return false
-
-    if (cachedText !== text) {
-      cachedText = text
-      cachedMaxDepthByPosition.clear()
-    }
-
-    val maxDepth =
-      cachedMaxDepthByPosition.getOrPut(start) {
-        val spans = text.getSpans(start, start + 1, BlockquoteSpan::class.java)
-        spans.maxOfOrNull { it.depth } ?: -1
-      }
-
+    val maxDepth = spansAt(text, start).maxOfOrNull { it.depth } ?: -1
     return maxDepth > depth
   }
 
-  private fun drawBackground(
-    c: Canvas,
-    left: Int,
-    top: Int,
-    bottom: Int,
-    right: Int,
+  // The outermost box (background + outer rounding) is the min-depth span at
+  // this position; each nested level's own box is the span with that depth.
+  private fun spanAtMinDepth(
+    text: Spanned,
+    start: Int,
+  ): BlockquoteSpan? = spansAt(text, start).minByOrNull { it.depth }
+
+  private fun spanAtDepth(
+    text: Spanned,
+    start: Int,
+    level: Int,
+  ): BlockquoteSpan? = spansAt(text, start).firstOrNull { it.depth == level }
+
+  private fun isBoundaryLine(
+    text: Spanned,
+    lineStart: Int,
+    lineEnd: Int,
+    box: BlockquoteSpan,
+  ): Boolean {
+    val boxStart = text.getSpanStart(box)
+    val boxEnd = text.getSpanEnd(box)
+    if (boxStart !in 0 until boxEnd) return false
+    return lineStart == boxStart ||
+      lineEnd == boxEnd ||
+      (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+  }
+
+  private fun buildBoundaryPath(
+    text: Spanned,
+    lineStart: Int,
+    lineEnd: Int,
+    box: BlockquoteSpan,
+    left: Float,
+    top: Float,
+    right: Float,
+    bottom: Float,
   ) {
-    val bgColor = blockquoteStyle.backgroundColor?.takeIf { it != Color.TRANSPARENT } ?: return
-    val backgroundPaint = configureBackgroundPaint(bgColor)
-    c.drawRect(left.toFloat(), top.toFloat(), right.toFloat(), bottom.toFloat(), backgroundPaint)
+    val boxStart = text.getSpanStart(box)
+    val boxEnd = text.getSpanEnd(box)
+
+    val isFirstLine = lineStart == boxStart
+    val isLastLine =
+      lineEnd == boxEnd || (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+
+    val radius = blockquoteStyle.borderRadius
+    radiiArray.fill(0f)
+    if (isFirstLine) {
+      radiiArray[0] = radius
+      radiiArray[1] = radius // Top-Left
+      radiiArray[2] = radius
+      radiiArray[3] = radius // Top-Right
+    }
+    if (isLastLine) {
+      radiiArray[4] = radius
+      radiiArray[5] = radius // Bottom-Right
+      radiiArray[6] = radius
+      radiiArray[7] = radius // Bottom-Left
+    }
+
+    rect.set(left, top, right, bottom)
+    path.reset()
+    path.addRoundRect(rect, radiiArray, Path.Direction.CW)
   }
 }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
@@ -41,10 +41,6 @@ class BlockquoteSpan(
   // Cache for shouldSkipDrawing to avoid repeated getSpans() calls during draw passes
   private var cachedText: CharSequence? = null
   private var cachedSpansByPosition = mutableMapOf<Int, Array<BlockquoteSpan>>()
-
-  // Horizontal box bounds captured during the background pass; Layout draws all
-  // line backgrounds before any leading margins, so the values are ready when
-  // the border stripes need clipping to the rounded box shape.
   private var boxLeft = 0f
   private var boxRight = 0f
 
@@ -84,17 +80,10 @@ class BlockquoteSpan(
       return
     }
 
-    // Each level's stripe is clipped to its own quote's rounded box (mirroring
-    // per-element CSS border-radius on web); level 0 additionally rounds
-    // against the outermost box that also carries the background.
     val rootSpan = spanAtMinDepth(spanned, start)
     val clipToRoot =
       radius > 0f && boxRight > boxLeft && rootSpan != null && isBoundaryLine(spanned, start, end, rootSpan)
 
-    // Boundary paddings of every box starting/ending on this line stack into
-    // the same font metrics (outermost zone outermost). A level's stripe must
-    // stop at its own box edge, so inset it by the paddings of the shallower
-    // boxes whose zones lie beyond it on this line.
     val padding = blockquoteStyle.padding
     var topInset = 0f
     var bottomInset = 0f
@@ -236,8 +225,6 @@ class BlockquoteSpan(
     return maxDepth > depth
   }
 
-  // The outermost box (background + outer rounding) is the min-depth span at
-  // this position; each nested level's own box is the span with that depth.
   private fun spanAtMinDepth(
     text: Spanned,
     start: Int,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
@@ -241,8 +241,14 @@ class BlockquoteSpan(
     lineEnd: Int,
     box: BlockquoteSpan,
   ): Boolean {
-    val boxEnd = text.getSpanEnd(box)
-    return lineEnd == boxEnd || (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+    // The span range can include trailing '\n'(s) that form no visible line
+    // (e.g. a paragraph break closing the quote), so the last drawn line ends
+    // before getSpanEnd. Compare against the end of visible content instead.
+    var boxEnd = text.getSpanEnd(box)
+    while (boxEnd > 0 && text[boxEnd - 1] == '\n') {
+      boxEnd--
+    }
+    return lineEnd >= boxEnd
   }
 
   private fun isBoundaryLine(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
@@ -236,14 +236,16 @@ class BlockquoteSpan(
     level: Int,
   ): BlockquoteSpan? = spansAt(text, start).firstOrNull { it.depth == level }
 
+  /**
+   * The span range can include trailing '\n'(s) that form no visible line (e.g. a
+   * paragraph break closing the quote), so the last drawn line ends before getSpanEnd;
+   * this compares against the end of visible content instead.
+   */
   private fun isLastLineOf(
     text: Spanned,
     lineEnd: Int,
     box: BlockquoteSpan,
   ): Boolean {
-    // The span range can include trailing '\n'(s) that form no visible line
-    // (e.g. a paragraph break closing the quote), so the last drawn line ends
-    // before getSpanEnd. Compare against the end of visible content instead.
     var boxEnd = text.getSpanEnd(box)
     while (boxEnd > 0 && text[boxEnd - 1] == '\n') {
       boxEnd--

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BlockquoteSpan.kt
@@ -79,7 +79,7 @@ class BlockquoteSpan(
     val radius = blockquoteStyle.borderRadius
     val spanned = text as? Spanned
 
-    if (radius <= 0f || spanned == null || boxRight <= boxLeft) {
+    if (spanned == null) {
       drawBorders(c, x, dir, top, bottom, borderPaint)
       return
     }
@@ -88,35 +88,50 @@ class BlockquoteSpan(
     // per-element CSS border-radius on web); level 0 additionally rounds
     // against the outermost box that also carries the background.
     val rootSpan = spanAtMinDepth(spanned, start)
-    val rootBoundary = rootSpan != null && isBoundaryLine(spanned, start, end, rootSpan)
+    val clipToRoot =
+      radius > 0f && boxRight > boxLeft && rootSpan != null && isBoundaryLine(spanned, start, end, rootSpan)
+
+    // Boundary paddings of every box starting/ending on this line stack into
+    // the same font metrics (outermost zone outermost). A level's stripe must
+    // stop at its own box edge, so inset it by the paddings of the shallower
+    // boxes whose zones lie beyond it on this line.
+    val padding = blockquoteStyle.padding
+    var topInset = 0f
+    var bottomInset = 0f
 
     for (level in 0..depth) {
       val borderX = x + (levelSpacing * level * dir)
       val borderRight = borderX + (blockquoteStyle.borderWidth * dir)
       val stripeLeft = minOf(borderX, borderRight)
       val stripeRight = maxOf(borderX, borderRight)
+      val stripeTop = top.toFloat() + topInset
+      val stripeBottom = bottom.toFloat() - bottomInset
 
       val levelSpan = if (level == 0) rootSpan else spanAtDepth(spanned, start, level)
-      val ownBoundary =
-        level > 0 && levelSpan != null && isBoundaryLine(spanned, start, end, levelSpan)
+      val clipToOwn =
+        radius > 0f && level > 0 && levelSpan != null && isBoundaryLine(spanned, start, end, levelSpan)
 
-      if (!rootBoundary && !ownBoundary) {
-        c.drawRect(stripeLeft, top.toFloat(), stripeRight, bottom.toFloat(), borderPaint)
-        continue
+      if (!clipToRoot && !clipToOwn) {
+        c.drawRect(stripeLeft, stripeTop, stripeRight, stripeBottom, borderPaint)
+      } else {
+        c.withSave {
+          if (clipToRoot) {
+            buildBoundaryPath(spanned, start, end, rootSpan!!, boxLeft, top.toFloat(), boxRight, bottom.toFloat())
+            clipPath(path)
+          }
+          if (clipToOwn) {
+            val clipLeft = if (dir >= 0) stripeLeft else boxLeft
+            val clipRight = if (dir >= 0) boxRight else stripeRight
+            buildBoundaryPath(spanned, start, end, levelSpan!!, clipLeft, stripeTop, clipRight, stripeBottom)
+            clipPath(path)
+          }
+          drawRect(stripeLeft, stripeTop, stripeRight, stripeBottom, borderPaint)
+        }
       }
 
-      c.withSave {
-        if (rootBoundary) {
-          buildBoundaryPath(spanned, start, end, rootSpan!!, boxLeft, top.toFloat(), boxRight, bottom.toFloat())
-          clipPath(path)
-        }
-        if (ownBoundary) {
-          val clipLeft = if (dir >= 0) stripeLeft else boxLeft
-          val clipRight = if (dir >= 0) boxRight else stripeRight
-          buildBoundaryPath(spanned, start, end, levelSpan!!, clipLeft, top.toFloat(), clipRight, bottom.toFloat())
-          clipPath(path)
-        }
-        drawRect(stripeLeft, top.toFloat(), stripeRight, bottom.toFloat(), borderPaint)
+      if (padding > 0 && levelSpan != null) {
+        if (start == spanned.getSpanStart(levelSpan)) topInset += padding
+        if (isLastLineOf(spanned, end, levelSpan)) bottomInset += padding
       }
     }
   }
@@ -234,6 +249,15 @@ class BlockquoteSpan(
     level: Int,
   ): BlockquoteSpan? = spansAt(text, start).firstOrNull { it.depth == level }
 
+  private fun isLastLineOf(
+    text: Spanned,
+    lineEnd: Int,
+    box: BlockquoteSpan,
+  ): Boolean {
+    val boxEnd = text.getSpanEnd(box)
+    return lineEnd == boxEnd || (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+  }
+
   private fun isBoundaryLine(
     text: Spanned,
     lineStart: Int,
@@ -243,9 +267,7 @@ class BlockquoteSpan(
     val boxStart = text.getSpanStart(box)
     val boxEnd = text.getSpanEnd(box)
     if (boxStart !in 0 until boxEnd) return false
-    return lineStart == boxStart ||
-      lineEnd == boxEnd ||
-      (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+    return lineStart == boxStart || isLastLineOf(text, lineEnd, box)
   }
 
   private fun buildBoundaryPath(
@@ -259,11 +281,9 @@ class BlockquoteSpan(
     bottom: Float,
   ) {
     val boxStart = text.getSpanStart(box)
-    val boxEnd = text.getSpanEnd(box)
 
     val isFirstLine = lineStart == boxStart
-    val isLastLine =
-      lineEnd == boxEnd || (boxEnd <= lineEnd && (boxEnd == text.length || text[boxEnd - 1] == '\n'))
+    val isLastLine = isLastLineOf(text, lineEnd, box)
 
     val radius = blockquoteStyle.borderRadius
     radiiArray.fill(0f)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/BlockquoteStyle.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/BlockquoteStyle.kt
@@ -14,6 +14,8 @@ data class BlockquoteStyle(
   val borderWidth: Float,
   val gapWidth: Float,
   val backgroundColor: Int?,
+  val borderRadius: Float,
+  val padding: Float,
 ) : BaseBlockStyle {
   companion object {
     fun fromReadableMap(
@@ -32,6 +34,8 @@ data class BlockquoteStyle(
       val borderWidth = parser.toPixelFromDIP(map.getDouble("borderWidth").toFloat())
       val gapWidth = parser.toPixelFromDIP(map.getDouble("gapWidth").toFloat())
       val backgroundColor = parser.parseOptionalColor(map, "backgroundColor")
+      val borderRadius = parser.toPixelFromDIP(map.getDouble("borderRadius").toFloat())
+      val padding = parser.toPixelFromDIP(map.getDouble("padding").toFloat())
 
       return BlockquoteStyle(
         fontSize,
@@ -45,6 +49,8 @@ data class BlockquoteStyle(
         borderWidth,
         gapWidth,
         backgroundColor,
+        borderRadius,
+        padding,
       )
     }
   }

--- a/packages/react-native-enriched-markdown/ios/internals/MeasurementCache.h
+++ b/packages/react-native-enriched-markdown/ios/internals/MeasurementCache.h
@@ -113,7 +113,7 @@ template <typename StyleStruct> inline size_t computeStyleFingerprint(const Styl
   hashFields(s.h6.textAlign);
 
   hashTextLayout(s.blockquote);
-  hashFields(s.blockquote.borderWidth, s.blockquote.gapWidth);
+  hashFields(s.blockquote.borderWidth, s.blockquote.gapWidth, s.blockquote.padding, s.blockquote.borderRadius);
 
   hashTextLayout(s.list);
   hashFields(s.list.bulletSize, s.list.markerMinWidth, s.list.markerFontWeight, s.list.gapWidth, s.list.marginLeft,

--- a/packages/react-native-enriched-markdown/ios/renderer/AttributedRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/AttributedRenderer.m
@@ -1,4 +1,5 @@
 #import "AttributedRenderer.h"
+#import "BlockquoteBorder.h"
 #import "CodeBlockBackground.h"
 #import "LastElementUtils.h"
 #import "MarkdownASTNode.h"
@@ -110,6 +111,14 @@
   // 2. Trim trailing characters
   NSUInteger logicalEnd = NSMaxRange(lastContent);
   BOOL isCodeBlock = isLastBlockACodeBlock(output);
+  // A padded blockquote tail needs the same trailing-newline treatment as a
+  // code block: its bottom padding spacer must stay an interior line fragment
+  // (followed by a 1pt tail newline outside the blockquote range) or iOS
+  // excludes its fixed-height line from measurement and the box gets cut off.
+  BOOL isPaddedBlockquote = !isCodeBlock && [_config blockquotePadding] > 0 &&
+                            [output attribute:BlockquoteDepthAttributeName
+                                       atIndex:lastContent.location
+                                effectiveRange:NULL] != nil;
   NSRange codeRange = NSMakeRange(0, 0);
   if (isCodeBlock) {
     [output attribute:CodeBlockAttributeName
@@ -121,15 +130,30 @@
       [output appendAttributedString:kNewlineAttributedString];
     }
     logicalEnd = codeEnd + 1;
+  } else if (isPaddedBlockquote) {
+    // The depth attribute runs may alternate values for nested quotes; scan to
+    // the end of the contiguous attributed region (which includes the spacer).
+    NSUInteger blockquoteEnd = NSMaxRange(lastContent);
+    while (blockquoteEnd < output.length && [output attribute:BlockquoteDepthAttributeName
+                                                       atIndex:blockquoteEnd
+                                                effectiveRange:NULL] != nil) {
+      blockquoteEnd++;
+    }
+    if (blockquoteEnd >= output.length) {
+      [output appendAttributedString:kNewlineAttributedString];
+    }
+    logicalEnd = blockquoteEnd + 1;
   }
 
   if (logicalEnd < output.length) {
     [output deleteCharactersInRange:NSMakeRange(logicalEnd, output.length - logicalEnd)];
   }
 
-  if (isCodeBlock && NSMaxRange(codeRange) < output.length) {
-    NSUInteger tailIdx = NSMaxRange(codeRange);
+  if ((isCodeBlock && NSMaxRange(codeRange) < output.length) || isPaddedBlockquote) {
+    NSUInteger tailIdx = isCodeBlock ? NSMaxRange(codeRange) : logicalEnd - 1;
     [output removeAttribute:CodeBlockAttributeName range:NSMakeRange(tailIdx, 1)];
+    [output removeAttribute:BlockquoteDepthAttributeName range:NSMakeRange(tailIdx, 1)];
+    [output removeAttribute:BlockquoteBackgroundColorAttributeName range:NSMakeRange(tailIdx, 1)];
     NSParagraphStyle *style = [output attribute:NSParagraphStyleAttributeName atIndex:tailIdx effectiveRange:NULL];
     NSMutableParagraphStyle *mutableStyle = style ? [style mutableCopy] : [[NSMutableParagraphStyle alloc] init];
     mutableStyle.paragraphSpacing = 0;

--- a/packages/react-native-enriched-markdown/ios/renderer/AttributedRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/AttributedRenderer.m
@@ -111,10 +111,6 @@
   // 2. Trim trailing characters
   NSUInteger logicalEnd = NSMaxRange(lastContent);
   BOOL isCodeBlock = isLastBlockACodeBlock(output);
-  // A padded blockquote tail needs the same trailing-newline treatment as a
-  // code block: its bottom padding spacer must stay an interior line fragment
-  // (followed by a 1pt tail newline outside the blockquote range) or iOS
-  // excludes its fixed-height line from measurement and the box gets cut off.
   BOOL isPaddedBlockquote = !isCodeBlock && [_config blockquotePadding] > 0 &&
                             [output attribute:BlockquoteDepthAttributeName
                                        atIndex:lastContent.location
@@ -131,8 +127,6 @@
     }
     logicalEnd = codeEnd + 1;
   } else if (isPaddedBlockquote) {
-    // The depth attribute runs may alternate values for nested quotes; scan to
-    // the end of the contiguous attributed region (which includes the spacer).
     NSUInteger blockquoteEnd = NSMaxRange(lastContent);
     while (blockquoteEnd < output.length && [output attribute:BlockquoteDepthAttributeName
                                                        atIndex:blockquoteEnd

--- a/packages/react-native-enriched-markdown/ios/renderer/BlockquoteRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/BlockquoteRenderer.m
@@ -5,6 +5,7 @@
 #import "ListItemRenderer.h"
 #import "MarkdownASTNode.h"
 #import "ParagraphStyleUtils.h"
+#import "RenderContext.h"
 #import "RendererFactory.h"
 #import "StyleConfig.h"
 
@@ -42,7 +43,7 @@ static NSString *const kNestedInfoRangeKey = @"range";
     return;
   }
 
-  [self applyStylingAndSpacing:output start:start end:end currentDepth:currentDepth];
+  [self applyStylingAndSpacing:output start:start end:end currentDepth:currentDepth context:context];
 }
 
 #pragma mark - Styling and Spacing
@@ -51,19 +52,49 @@ static NSString *const kNestedInfoRangeKey = @"range";
                          start:(NSUInteger)start
                            end:(NSUInteger)end
                   currentDepth:(NSInteger)currentDepth
+                       context:(RenderContext *)context
 {
   NSUInteger contentStart = start;
   if (currentDepth == 0) {
     contentStart += applyBlockSpacingBefore(output, start, [_config blockquoteMarginTop]);
   }
 
-  NSRange blockquoteRange = NSMakeRange(contentStart, end - start);
+  // Vertical padding: spacer lines inside the background area, applied at every
+  // nesting level so nested quotes pad their own box (matching web CSS padding).
+  // Mirrors CodeBlockRenderer's approach so measurement accounts for the padding.
+  // Spacers carry BlockquoteSpacerAttributeName so ancestor quotes skip them
+  // when stamping paragraph styles (their fixed height must survive).
+  CGFloat padding = [_config blockquotePadding];
+  NSUInteger topPadLength = 0;
+  NSUInteger bottomPadLength = 0;
+  if (padding > 0) {
+    NSMutableParagraphStyle *topSpacerStyle = [context spacerStyleWithHeight:padding spacing:0];
+    NSAttributedString *topSpacer = [[NSAttributedString alloc]
+        initWithString:@"\n"
+            attributes:@{NSParagraphStyleAttributeName : topSpacerStyle, BlockquoteSpacerAttributeName : @YES}];
+    [output insertAttributedString:topSpacer atIndex:contentStart];
+    topPadLength = 1;
+
+    NSUInteger bottomSpacerLocation = output.length;
+    [output appendAttributedString:kNewlineAttributedString];
+    NSMutableParagraphStyle *bottomSpacerStyle = [context spacerStyleWithHeight:padding spacing:0];
+    [output addAttributes:@{NSParagraphStyleAttributeName : bottomSpacerStyle, BlockquoteSpacerAttributeName : @YES}
+                    range:NSMakeRange(bottomSpacerLocation, 1)];
+    bottomPadLength = 1;
+  }
+
+  // The box range includes the padding spacers so the background covers them;
+  // paragraph stamping is restricted to the inner range so the spacers keep
+  // their fixed height instead of being clamped to the blockquote line height.
+  NSRange blockquoteRange = NSMakeRange(contentStart, (end - start) + topPadLength + bottomPadLength);
+  NSRange innerRange = NSMakeRange(contentStart + topPadLength, end - start);
   CGFloat levelSpacing = [_config blockquoteBorderWidth] + [_config blockquoteGapWidth];
-  NSArray<NSDictionary *> *nestedInfo = [self collectNestedBlockquotes:output range:blockquoteRange depth:currentDepth];
+  NSArray<NSDictionary *> *nestedInfo = [self collectNestedBlockquotes:output range:innerRange depth:currentDepth];
 
   // Apply base styling (indentation, depth, background, line height)
   [self applyBaseBlockquoteStyle:output
-                           range:blockquoteRange
+                        boxRange:blockquoteRange
+                      innerRange:innerRange
                            depth:currentDepth
                     levelSpacing:levelSpacing
                  backgroundColor:[_config blockquoteBackgroundColor]
@@ -102,30 +133,36 @@ static NSString *const kNestedInfoRangeKey = @"range";
 }
 
 - (void)applyBaseBlockquoteStyle:(NSMutableAttributedString *)output
-                           range:(NSRange)blockquoteRange
+                        boxRange:(NSRange)boxRange
+                      innerRange:(NSRange)innerRange
                            depth:(NSInteger)currentDepth
                     levelSpacing:(CGFloat)levelSpacing
                  backgroundColor:(RCTUIColor *)backgroundColor
                       lineHeight:(CGFloat)lineHeight
 {
   CGFloat totalIndent = blockquoteIndentForDepth(currentDepth + 1, levelSpacing);
+  CGFloat padding = [_config blockquotePadding];
 
-  // Depth and background cover the whole range so the border renders behind list content.
+  // Depth and background cover the whole box (incl. padding spacers) so the
+  // border and background render behind list content and the padding rows.
   NSMutableDictionary *depthAttributes =
       [NSMutableDictionary dictionaryWithObjectsAndKeys:@(currentDepth), BlockquoteDepthAttributeName, nil];
   if (backgroundColor) {
     depthAttributes[BlockquoteBackgroundColorAttributeName] = backgroundColor;
   }
-  [output addAttributes:depthAttributes range:blockquoteRange];
+  [output addAttributes:depthAttributes range:boxRange];
 
   // List items bake the blockquote indent into their own paragraph style; only non-list content is stamped here.
   [self enumerateNonListRangesIn:output
-                           range:blockquoteRange
+                           range:innerRange
                       usingBlock:^(NSRange nonListRange) {
                         NSMutableParagraphStyle *paragraphStyle =
                             getOrCreateParagraphStyle(output, nonListRange.location);
                         paragraphStyle.firstLineHeadIndent = totalIndent;
                         paragraphStyle.headIndent = totalIndent;
+                        if (padding > 0) {
+                          paragraphStyle.tailIndent = -padding;
+                        }
                         [output addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:nonListRange];
                         applyLineHeight(output, nonListRange, lineHeight);
                       }];
@@ -137,6 +174,7 @@ static NSString *const kNestedInfoRangeKey = @"range";
 {
   // Re-apply indentation to nested blockquotes since applyBaseBlockquoteStyle
   // overwrote them with the parent's indentation
+  CGFloat padding = [_config blockquotePadding];
   for (NSDictionary *info in nestedInfo) {
     NSRange nestedRange = [info[kNestedInfoRangeKey] rangeValue];
     NSInteger nestedDepth = [info[kNestedInfoDepthKey] integerValue];
@@ -150,7 +188,7 @@ static NSString *const kNestedInfoRangeKey = @"range";
                           NSMutableParagraphStyle *style = getOrCreateParagraphStyle(output, nonListRange.location);
                           style.firstLineHeadIndent = indent;
                           style.headIndent = indent;
-                          style.tailIndent = 0;
+                          style.tailIndent = padding > 0 ? -padding : 0;
                           [output addAttribute:NSParagraphStyleAttributeName value:style range:nonListRange];
                         }];
   }
@@ -175,6 +213,7 @@ static NSString *const kNestedInfoRangeKey = @"range";
   };
   collectRanges(ListDepthAttribute);
   collectRanges(CodeBlockIndentAttributeName);
+  collectRanges(BlockquoteSpacerAttributeName);
   [listRanges sortUsingComparator:^NSComparisonResult(NSValue *a, NSValue *b) {
     NSUInteger la = [a rangeValue].location;
     NSUInteger lb = [b rangeValue].location;

--- a/packages/react-native-enriched-markdown/ios/renderer/BlockquoteRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/BlockquoteRenderer.m
@@ -59,11 +59,7 @@ static NSString *const kNestedInfoRangeKey = @"range";
     contentStart += applyBlockSpacingBefore(output, start, [_config blockquoteMarginTop]);
   }
 
-  // Vertical padding: spacer lines inside the background area, applied at every
-  // nesting level so nested quotes pad their own box (matching web CSS padding).
-  // Mirrors CodeBlockRenderer's approach so measurement accounts for the padding.
-  // Spacers carry BlockquoteSpacerAttributeName so ancestor quotes skip them
-  // when stamping paragraph styles (their fixed height must survive).
+  // nested quotes pad their own box (matching web CSS padding)
   CGFloat padding = [_config blockquotePadding];
   NSUInteger topPadLength = 0;
   NSUInteger bottomPadLength = 0;
@@ -83,9 +79,6 @@ static NSString *const kNestedInfoRangeKey = @"range";
     bottomPadLength = 1;
   }
 
-  // The box range includes the padding spacers so the background covers them;
-  // paragraph stamping is restricted to the inner range so the spacers keep
-  // their fixed height instead of being clamped to the blockquote line height.
   NSRange blockquoteRange = NSMakeRange(contentStart, (end - start) + topPadLength + bottomPadLength);
   NSRange innerRange = NSMakeRange(contentStart + topPadLength, end - start);
   CGFloat levelSpacing = [_config blockquoteBorderWidth] + [_config blockquoteGapWidth];

--- a/packages/react-native-enriched-markdown/ios/renderer/BlockquoteRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/BlockquoteRenderer.m
@@ -159,6 +159,33 @@ static NSString *const kNestedInfoRangeKey = @"range";
                         [output addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:nonListRange];
                         applyLineHeight(output, nonListRange, lineHeight);
                       }];
+
+  if (padding > 0) {
+    [self applyTailIndent:-padding toListRangesIn:output range:innerRange];
+  }
+}
+
+- (void)applyTailIndent:(CGFloat)tailIndent toListRangesIn:(NSMutableAttributedString *)output range:(NSRange)range
+{
+  [output enumerateAttribute:ListDepthAttribute
+                     inRange:range
+                     options:0
+                  usingBlock:^(id value, NSRange listRange, BOOL *stop) {
+                    if (!value) {
+                      return;
+                    }
+                    [output enumerateAttribute:NSParagraphStyleAttributeName
+                                       inRange:listRange
+                                       options:0
+                                    usingBlock:^(NSParagraphStyle *style, NSRange styleRange, BOOL *innerStop) {
+                                      NSMutableParagraphStyle *mutableStyle =
+                                          style ? [style mutableCopy] : [[NSMutableParagraphStyle alloc] init];
+                                      mutableStyle.tailIndent = tailIndent;
+                                      [output addAttribute:NSParagraphStyleAttributeName
+                                                     value:mutableStyle
+                                                     range:styleRange];
+                                    }];
+                  }];
 }
 
 - (void)reapplyNestedStyles:(NSMutableAttributedString *)output

--- a/packages/react-native-enriched-markdown/ios/styles/StyleConfig.h
+++ b/packages/react-native-enriched-markdown/ios/styles/StyleConfig.h
@@ -249,6 +249,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setBlockquoteGapWidth:(CGFloat)newValue;
 - (RCTUIColor *)blockquoteBackgroundColor;
 - (void)setBlockquoteBackgroundColor:(RCTUIColor *)newValue;
+- (CGFloat)blockquoteBorderRadius;
+- (void)setBlockquoteBorderRadius:(CGFloat)newValue;
+- (CGFloat)blockquotePadding;
+- (void)setBlockquotePadding:(CGFloat)newValue;
 // List style properties (combined for both ordered and unordered lists)
 - (CGFloat)listStyleFontSize;
 - (void)setListStyleFontSize:(CGFloat)newValue;

--- a/packages/react-native-enriched-markdown/ios/styles/StyleConfig.mm
+++ b/packages/react-native-enriched-markdown/ios/styles/StyleConfig.mm
@@ -155,6 +155,8 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   CGFloat _blockquoteBorderWidth;
   CGFloat _blockquoteGapWidth;
   RCTUIColor *_blockquoteBackgroundColor;
+  CGFloat _blockquoteBorderRadius;
+  CGFloat _blockquotePadding;
   ENRMFontSlot *_blockquoteFont;
   // List style properties (combined for both ordered and unordered lists)
   CGFloat _listStyleFontSize;
@@ -432,6 +434,8 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
   copy->_blockquoteBorderWidth = _blockquoteBorderWidth;
   copy->_blockquoteGapWidth = _blockquoteGapWidth;
   copy->_blockquoteBackgroundColor = [_blockquoteBackgroundColor copy];
+  copy->_blockquoteBorderRadius = _blockquoteBorderRadius;
+  copy->_blockquotePadding = _blockquotePadding;
   copy->_listStyleFontSize = _listStyleFontSize;
   copy->_listStyleFontFamily = [_listStyleFontFamily copy];
   copy->_listStyleFontWeight = [_listStyleFontWeight copy];
@@ -1727,6 +1731,26 @@ static inline NSString *normalizedFontWeight(NSString *fontWeight)
 - (void)setBlockquoteBackgroundColor:(RCTUIColor *)newValue
 {
   _blockquoteBackgroundColor = newValue;
+}
+
+- (CGFloat)blockquoteBorderRadius
+{
+  return _blockquoteBorderRadius;
+}
+
+- (void)setBlockquoteBorderRadius:(CGFloat)newValue
+{
+  _blockquoteBorderRadius = newValue;
+}
+
+- (CGFloat)blockquotePadding
+{
+  return _blockquotePadding;
+}
+
+- (void)setBlockquotePadding:(CGFloat)newValue
+{
+  _blockquotePadding = newValue;
 }
 
 // List style properties (combined for both ordered and unordered lists)

--- a/packages/react-native-enriched-markdown/ios/utils/BlockquoteBorder.h
+++ b/packages/react-native-enriched-markdown/ios/utils/BlockquoteBorder.h
@@ -6,6 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const BlockquoteDepthAttributeName;
 extern NSString *const BlockquoteBackgroundColorAttributeName;
+extern NSString *const BlockquoteSpacerAttributeName;
 
 static inline CGFloat blockquoteIndentForDepth(NSInteger depth, CGFloat levelSpacing)
 {

--- a/packages/react-native-enriched-markdown/ios/utils/BlockquoteBorder.m
+++ b/packages/react-native-enriched-markdown/ios/utils/BlockquoteBorder.m
@@ -5,6 +5,7 @@
 // Attribute constants for identifying blockquote segments in text storage
 NSString *const BlockquoteDepthAttributeName = @"BlockquoteDepth";
 NSString *const BlockquoteBackgroundColorAttributeName = @"BlockquoteBackgroundColor";
+NSString *const BlockquoteSpacerAttributeName = @"BlockquoteSpacer";
 
 @implementation BlockquoteBorder {
   StyleConfig *_config;
@@ -20,7 +21,11 @@ NSString *const BlockquoteBackgroundColorAttributeName = @"BlockquoteBackgroundC
 
 /**
  * Main drawing entry point called by the LayoutManager.
- * Iterates through line fragments to draw backgrounds and borders for nested blockquotes.
+ * Collects contiguous blockquote regions and draws each as one rounded box:
+ * background fill first, then the vertical borders clipped to the box shape.
+ * When a border radius is set, each nested quote's stripes are additionally
+ * clipped to that quote's own rounded box, mirroring per-element CSS
+ * border-radius on web.
  */
 - (void)drawBordersForGlyphRange:(NSRange)glyphsToShow
                    layoutManager:(NSLayoutManager *)layoutManager
@@ -32,66 +37,235 @@ NSString *const BlockquoteBackgroundColorAttributeName = @"BlockquoteBackgroundC
     return;
   }
 
+  NSRange charRange = [layoutManager characterRangeForGlyphRange:glyphsToShow actualGlyphRange:NULL];
+
+  // Enumerate over the full storage range so each blockquote's full rect is
+  // drawn; restricting to charRange would produce partial rects per draw pass
+  // and stacked corner shapes when the border radius is large. The graphics
+  // context clip ensures only the visible portion is painted. Attribute runs
+  // split at nesting depth changes are merged back into contiguous regions.
+  NSMutableArray<NSValue *> *regions = [NSMutableArray array];
+  __block NSRange currentRegion = NSMakeRange(NSNotFound, 0);
+  [textStorage enumerateAttribute:BlockquoteDepthAttributeName
+                          inRange:NSMakeRange(0, textStorage.length)
+                          options:0
+                       usingBlock:^(id value, NSRange range, BOOL *stop) {
+                         if (!value) {
+                           if (currentRegion.location != NSNotFound) {
+                             [regions addObject:[NSValue valueWithRange:currentRegion]];
+                             currentRegion = NSMakeRange(NSNotFound, 0);
+                           }
+                           return;
+                         }
+                         currentRegion =
+                             currentRegion.location == NSNotFound ? range : NSUnionRange(currentRegion, range);
+                       }];
+  if (currentRegion.location != NSNotFound) {
+    [regions addObject:[NSValue valueWithRange:currentRegion]];
+  }
+
+  for (NSValue *value in regions) {
+    NSRange region = value.rangeValue;
+    if (NSIntersectionRange(region, charRange).length == 0) {
+      continue;
+    }
+    [self drawBlockquoteRegion:region layoutManager:layoutManager textContainer:textContainer atPoint:origin];
+  }
+}
+
+/**
+ * Groups the depth runs of a region into nested quote boxes: for each level
+ * >= 1, a box is a maximal contiguous stretch where depth >= level (a nested
+ * quote's own range). Outputs parallel arrays of ranges and levels.
+ */
+static void collectNestedBoxes(NSArray<NSValue *> *runRanges, NSArray<NSNumber *> *runDepths,
+                               NSMutableArray<NSValue *> *boxRanges, NSMutableArray<NSNumber *> *boxLevels)
+{
+  NSInteger maxDepth = 0;
+  for (NSNumber *depth in runDepths) {
+    maxDepth = MAX(maxDepth, depth.integerValue);
+  }
+
+  for (NSInteger level = 1; level <= maxDepth; level++) {
+    NSRange current = NSMakeRange(NSNotFound, 0);
+    for (NSUInteger i = 0; i < runRanges.count; i++) {
+      if (runDepths[i].integerValue >= level) {
+        NSRange runRange = runRanges[i].rangeValue;
+        current = current.location == NSNotFound ? runRange : NSUnionRange(current, runRange);
+      } else if (current.location != NSNotFound) {
+        [boxRanges addObject:[NSValue valueWithRange:current]];
+        [boxLevels addObject:@(level)];
+        current = NSMakeRange(NSNotFound, 0);
+      }
+    }
+    if (current.location != NSNotFound) {
+      [boxRanges addObject:[NSValue valueWithRange:current]];
+      [boxLevels addObject:@(level)];
+    }
+  }
+}
+
+- (void)drawBlockquoteRegion:(NSRange)region
+               layoutManager:(NSLayoutManager *)layoutManager
+               textContainer:(NSTextContainer *)textContainer
+                     atPoint:(CGPoint)origin
+{
+  NSTextStorage *textStorage = layoutManager.textStorage;
+
   // Cache configuration values to minimize pointer chasing and method lookups in the loop
   StyleConfig *c = _config;
   CGFloat borderWidth = c.blockquoteBorderWidth;
   CGFloat gapWidth = c.blockquoteGapWidth;
   CGFloat levelSpacing = borderWidth + gapWidth;
+  CGFloat borderRadius = c.blockquoteBorderRadius;
   CGFloat containerWidth = textContainer.size.width;
   RCTUIColor *defaultBgColor = c.blockquoteBackgroundColor;
   RCTUIColor *borderColor = c.blockquoteBorderColor;
 
-  UIBezierPath *borderPath = [UIBezierPath bezierPath];
-
-  [layoutManager
-      enumerateLineFragmentsForGlyphRange:glyphsToShow
-                               usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer *container,
-                                            NSRange glyphRange, BOOL *stop) {
-                                 // Map the glyph range back to character indices to retrieve attributes
-                                 NSRange charRange = [layoutManager characterRangeForGlyphRange:glyphRange
-                                                                               actualGlyphRange:NULL];
-                                 if (charRange.location == NSNotFound || charRange.length == 0) {
-                                   return;
-                                 }
-
-                                 // Perform a single attribute lookup for the current line fragment
-                                 NSDictionary *attrs = [textStorage attributesAtIndex:charRange.location
-                                                                       effectiveRange:NULL];
-                                 NSNumber *depthNum = attrs[BlockquoteDepthAttributeName];
-
-                                 // If no depth is found, this fragment is not part of a blockquote
-                                 if (!depthNum) {
-                                   return;
-                                 }
-
-                                 NSInteger depth = [depthNum integerValue];
-                                 CGFloat baseY = origin.y + rect.origin.y;
-                                 BOOL isRTL = ENRMParagraphIsRTL(attrs[NSParagraphStyleAttributeName]);
-
-                                 // 1. Draw Background (Painter's algorithm: draw backgrounds before borders)
-                                 RCTUIColor *bgColor = attrs[BlockquoteBackgroundColorAttributeName] ?: defaultBgColor;
-                                 if (bgColor && bgColor != [RCTUIColor clearColor]) {
-                                   CGContextRef ctx = UIGraphicsGetCurrentContext();
-                                   [bgColor setFill];
-                                   CGContextFillRect(ctx,
-                                                     CGRectMake(origin.x, baseY, containerWidth, rect.size.height));
-                                 }
-
-                                 // 2. Aggregate vertical borders into the batch path
-                                 for (NSInteger level = 0; level <= depth; level++) {
-                                   CGFloat borderX =
-                                       isRTL ? origin.x + containerWidth - borderWidth - (levelSpacing * level)
-                                             : origin.x + (levelSpacing * level);
-                                   CGRect borderRect = CGRectMake(borderX, baseY, borderWidth, rect.size.height);
-                                   UIBezierPathAppendPath(borderPath, [UIBezierPath bezierPathWithRect:borderRect]);
-                                 }
-                               }];
-
-  // 3. Perform a single batch fill for all borders
-  if (!borderPath.isEmpty) {
-    [borderColor setFill];
-    [borderPath fill];
+  NSRange glyphRange = [layoutManager glyphRangeForCharacterRange:region actualCharacterRange:NULL];
+  CGRect blockRect = [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:textContainer];
+  if (CGRectIsEmpty(blockRect)) {
+    return;
   }
+
+  blockRect.origin.x = origin.x;
+  blockRect.origin.y += origin.y;
+  blockRect.size.width = containerWidth;
+
+  // A trailing padding spacer at the very end of the storage lays out as the
+  // extra line fragment, which boundingRectForGlyphRange excludes; extend the
+  // rect manually so the bottom padding stays covered.
+  BOOL isLastBlockquote = (NSMaxRange(region) == textStorage.length);
+  if (isLastBlockquote) {
+    blockRect.size.height += c.blockquotePadding;
+  }
+
+  // Nested boxes only matter when their stripes need rounded clipping.
+  NSMutableArray<NSValue *> *boxRanges = [NSMutableArray array];
+  NSMutableArray<NSNumber *> *boxLevels = [NSMutableArray array];
+  NSMutableArray<UIBezierPath *> *boxStripePaths = [NSMutableArray array];
+  if (borderRadius > 0) {
+    NSMutableArray<NSValue *> *runRanges = [NSMutableArray array];
+    NSMutableArray<NSNumber *> *runDepths = [NSMutableArray array];
+    [textStorage enumerateAttribute:BlockquoteDepthAttributeName
+                            inRange:region
+                            options:0
+                         usingBlock:^(id value, NSRange range, BOOL *stop) {
+                           if (!value) {
+                             return;
+                           }
+                           [runRanges addObject:[NSValue valueWithRange:range]];
+                           [runDepths addObject:value];
+                         }];
+    collectNestedBoxes(runRanges, runDepths, boxRanges, boxLevels);
+    for (NSUInteger i = 0; i < boxRanges.count; i++) {
+      [boxStripePaths addObject:[UIBezierPath bezierPath]];
+    }
+  }
+
+  CGContextRef ctx = UIGraphicsGetCurrentContext();
+  CGContextSaveGState(ctx);
+  {
+    UIBezierPath *boxPath = UIBezierPathWithRoundedRect(blockRect, MAX(0, borderRadius));
+    [boxPath addClip];
+
+    // 1. Draw Background (Painter's algorithm: draw backgrounds before borders)
+    RCTUIColor *bgColor = [textStorage attribute:BlockquoteBackgroundColorAttributeName
+                                         atIndex:region.location
+                                  effectiveRange:NULL]
+                              ?: defaultBgColor;
+    if (bgColor && bgColor != [RCTUIColor clearColor]) {
+      [bgColor setFill];
+      CGContextFillRect(ctx, blockRect);
+    }
+
+    // 2. Aggregate vertical borders into batch paths; level-0 stripes are
+    // rounded by the region clip, nested stripes by their own box clip below
+    UIBezierPath *borderPath = [UIBezierPath bezierPath];
+    [layoutManager
+        enumerateLineFragmentsForGlyphRange:glyphRange
+                                 usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer *container,
+                                              NSRange lineGlyphRange, BOOL *stop) {
+                                   // Map the glyph range back to character indices to retrieve attributes
+                                   NSRange lineCharRange = [layoutManager characterRangeForGlyphRange:lineGlyphRange
+                                                                                     actualGlyphRange:NULL];
+                                   if (lineCharRange.location == NSNotFound || lineCharRange.length == 0) {
+                                     return;
+                                   }
+
+                                   // Perform a single attribute lookup for the current line fragment
+                                   NSDictionary *attrs = [textStorage attributesAtIndex:lineCharRange.location
+                                                                         effectiveRange:NULL];
+                                   NSNumber *depthNum = attrs[BlockquoteDepthAttributeName];
+
+                                   // If no depth is found, this fragment is not part of a blockquote
+                                   if (!depthNum) {
+                                     return;
+                                   }
+
+                                   NSInteger depth = [depthNum integerValue];
+                                   CGFloat baseY = origin.y + rect.origin.y;
+                                   CGFloat lineHeight = rect.size.height;
+                                   BOOL isLastLine = NSMaxRange(lineGlyphRange) == NSMaxRange(glyphRange);
+                                   if (isLastBlockquote && isLastLine) {
+                                     lineHeight += c.blockquotePadding;
+                                   }
+                                   BOOL isRTL = ENRMParagraphIsRTL(attrs[NSParagraphStyleAttributeName]);
+
+                                   for (NSInteger level = 0; level <= depth; level++) {
+                                     CGFloat borderX =
+                                         isRTL ? origin.x + containerWidth - borderWidth - (levelSpacing * level)
+                                               : origin.x + (levelSpacing * level);
+                                     CGRect borderRect = CGRectMake(borderX, baseY, borderWidth, lineHeight);
+
+                                     UIBezierPath *target = borderPath;
+                                     for (NSUInteger b = 0; b < boxRanges.count; b++) {
+                                       if (boxLevels[b].integerValue == level &&
+                                           NSLocationInRange(lineCharRange.location, boxRanges[b].rangeValue)) {
+                                         target = boxStripePaths[b];
+                                         break;
+                                       }
+                                     }
+                                     UIBezierPathAppendPath(target, [UIBezierPath bezierPathWithRect:borderRect]);
+                                   }
+                                 }];
+
+    // 3. Perform a single batch fill for the root-level borders
+    if (!borderPath.isEmpty) {
+      [borderColor setFill];
+      [borderPath fill];
+    }
+
+    // 4. Nested stripes: clip each to its own quote's rounded box (the clips
+    // compose with the still-active region clip)
+    for (NSUInteger b = 0; b < boxRanges.count; b++) {
+      UIBezierPath *stripes = boxStripePaths[b];
+      if (stripes.isEmpty) {
+        continue;
+      }
+
+      NSRange boxRange = boxRanges[b].rangeValue;
+      NSRange boxGlyphRange = [layoutManager glyphRangeForCharacterRange:boxRange actualCharacterRange:NULL];
+      CGRect boxRect = [layoutManager boundingRectForGlyphRange:boxGlyphRange inTextContainer:textContainer];
+      if (CGRectIsEmpty(boxRect)) {
+        continue;
+      }
+
+      NSDictionary *boxAttrs = [textStorage attributesAtIndex:boxRange.location effectiveRange:NULL];
+      BOOL boxRTL = ENRMParagraphIsRTL(boxAttrs[NSParagraphStyleAttributeName]);
+      CGFloat leadingInset = levelSpacing * boxLevels[b].integerValue;
+      boxRect.origin.x = boxRTL ? origin.x : origin.x + leadingInset;
+      boxRect.origin.y += origin.y;
+      boxRect.size.width = containerWidth - leadingInset;
+
+      CGContextSaveGState(ctx);
+      [UIBezierPathWithRoundedRect(boxRect, borderRadius) addClip];
+      [borderColor setFill];
+      [stripes fill];
+      CGContextRestoreGState(ctx);
+    }
+  }
+  CGContextRestoreGState(ctx);
 }
 
 @end

--- a/packages/react-native-enriched-markdown/ios/utils/BlockquoteBorder.m
+++ b/packages/react-native-enriched-markdown/ios/utils/BlockquoteBorder.m
@@ -39,11 +39,6 @@ NSString *const BlockquoteSpacerAttributeName = @"BlockquoteSpacer";
 
   NSRange charRange = [layoutManager characterRangeForGlyphRange:glyphsToShow actualGlyphRange:NULL];
 
-  // Enumerate over the full storage range so each blockquote's full rect is
-  // drawn; restricting to charRange would produce partial rects per draw pass
-  // and stacked corner shapes when the border radius is large. The graphics
-  // context clip ensures only the visible portion is painted. Attribute runs
-  // split at nesting depth changes are merged back into contiguous regions.
   NSMutableArray<NSValue *> *regions = [NSMutableArray array];
   __block NSRange currentRegion = NSMakeRange(NSNotFound, 0);
   [textStorage enumerateAttribute:BlockquoteDepthAttributeName
@@ -132,15 +127,11 @@ static void collectNestedBoxes(NSArray<NSValue *> *runRanges, NSArray<NSNumber *
   blockRect.origin.y += origin.y;
   blockRect.size.width = containerWidth;
 
-  // A trailing padding spacer at the very end of the storage lays out as the
-  // extra line fragment, which boundingRectForGlyphRange excludes; extend the
-  // rect manually so the bottom padding stays covered.
   BOOL isLastBlockquote = (NSMaxRange(region) == textStorage.length);
   if (isLastBlockquote) {
     blockRect.size.height += c.blockquotePadding;
   }
 
-  // Nested boxes only matter when their stripes need rounded clipping.
   NSMutableArray<NSValue *> *boxRanges = [NSMutableArray array];
   NSMutableArray<NSNumber *> *boxLevels = [NSMutableArray array];
   NSMutableArray<UIBezierPath *> *boxStripePaths = [NSMutableArray array];
@@ -186,19 +177,16 @@ static void collectNestedBoxes(NSArray<NSValue *> *runRanges, NSArray<NSNumber *
         enumerateLineFragmentsForGlyphRange:glyphRange
                                  usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer *container,
                                               NSRange lineGlyphRange, BOOL *stop) {
-                                   // Map the glyph range back to character indices to retrieve attributes
                                    NSRange lineCharRange = [layoutManager characterRangeForGlyphRange:lineGlyphRange
                                                                                      actualGlyphRange:NULL];
                                    if (lineCharRange.location == NSNotFound || lineCharRange.length == 0) {
                                      return;
                                    }
 
-                                   // Perform a single attribute lookup for the current line fragment
                                    NSDictionary *attrs = [textStorage attributesAtIndex:lineCharRange.location
                                                                          effectiveRange:NULL];
                                    NSNumber *depthNum = attrs[BlockquoteDepthAttributeName];
 
-                                   // If no depth is found, this fragment is not part of a blockquote
                                    if (!depthNum) {
                                      return;
                                    }

--- a/packages/react-native-enriched-markdown/ios/utils/BlockquoteBorder.m
+++ b/packages/react-native-enriched-markdown/ios/utils/BlockquoteBorder.m
@@ -26,6 +26,10 @@ NSString *const BlockquoteSpacerAttributeName = @"BlockquoteSpacer";
  * When a border radius is set, each nested quote's stripes are additionally
  * clipped to that quote's own rounded box, mirroring per-element CSS
  * border-radius on web.
+ * Regions are discovered by scanning only the drawn character range; regions
+ * touching its edges are extended run-by-run to their true boundaries, so the
+ * cost scales with the visible text plus the intersecting quotes rather than
+ * the whole document.
  */
 - (void)drawBordersForGlyphRange:(NSRange)glyphsToShow
                    layoutManager:(NSLayoutManager *)layoutManager
@@ -38,11 +42,14 @@ NSString *const BlockquoteSpacerAttributeName = @"BlockquoteSpacer";
   }
 
   NSRange charRange = [layoutManager characterRangeForGlyphRange:glyphsToShow actualGlyphRange:NULL];
+  if (charRange.location == NSNotFound || charRange.length == 0) {
+    return;
+  }
 
   NSMutableArray<NSValue *> *regions = [NSMutableArray array];
   __block NSRange currentRegion = NSMakeRange(NSNotFound, 0);
   [textStorage enumerateAttribute:BlockquoteDepthAttributeName
-                          inRange:NSMakeRange(0, textStorage.length)
+                          inRange:charRange
                           options:0
                        usingBlock:^(id value, NSRange range, BOOL *stop) {
                          if (!value) {
@@ -59,12 +66,40 @@ NSString *const BlockquoteSpacerAttributeName = @"BlockquoteSpacer";
     [regions addObject:[NSValue valueWithRange:currentRegion]];
   }
 
-  for (NSValue *value in regions) {
-    NSRange region = value.rangeValue;
-    if (NSIntersectionRange(region, charRange).length == 0) {
-      continue;
+  if (regions.count == 0) {
+    return;
+  }
+
+  NSRange firstRegion = regions.firstObject.rangeValue;
+  if (firstRegion.location == charRange.location) {
+    while (firstRegion.location > 0) {
+      NSRange runRange;
+      if (![textStorage attribute:BlockquoteDepthAttributeName
+                          atIndex:firstRegion.location - 1
+                   effectiveRange:&runRange]) {
+        break;
+      }
+      firstRegion = NSUnionRange(firstRegion, runRange);
     }
-    [self drawBlockquoteRegion:region layoutManager:layoutManager textContainer:textContainer atPoint:origin];
+    regions[0] = [NSValue valueWithRange:firstRegion];
+  }
+
+  NSRange lastRegion = regions.lastObject.rangeValue;
+  if (NSMaxRange(lastRegion) == NSMaxRange(charRange)) {
+    while (NSMaxRange(lastRegion) < textStorage.length) {
+      NSRange runRange;
+      if (![textStorage attribute:BlockquoteDepthAttributeName
+                          atIndex:NSMaxRange(lastRegion)
+                   effectiveRange:&runRange]) {
+        break;
+      }
+      lastRegion = NSUnionRange(lastRegion, runRange);
+    }
+    regions[regions.count - 1] = [NSValue valueWithRange:lastRegion];
+  }
+
+  for (NSValue *value in regions) {
+    [self drawBlockquoteRegion:value.rangeValue layoutManager:layoutManager textContainer:textContainer atPoint:origin];
   }
 }
 

--- a/packages/react-native-enriched-markdown/ios/utils/StylePropsUtils.h
+++ b/packages/react-native-enriched-markdown/ios/utils/StylePropsUtils.h
@@ -480,6 +480,16 @@ BOOL applyMarkdownStyleToConfig(StyleConfig *config, const MarkdownStyle &newSty
     changed = YES;
   }
 
+  if (newStyle.blockquote.borderRadius != oldStyle.blockquote.borderRadius) {
+    [config setBlockquoteBorderRadius:newStyle.blockquote.borderRadius];
+    changed = YES;
+  }
+
+  if (newStyle.blockquote.padding != oldStyle.blockquote.padding) {
+    [config setBlockquotePadding:newStyle.blockquote.padding];
+    changed = YES;
+  }
+
   // ── Link ───────────────────────────────────────────────────────────────────
 
   if (newStyle.link.fontFamily != oldStyle.link.fontFamily) {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
@@ -29,6 +29,8 @@ interface BlockquoteStyleInternal extends BaseBlockStyleInternal {
   borderWidth: CodegenTypes.Float;
   gapWidth: CodegenTypes.Float;
   backgroundColor: ColorValue;
+  borderRadius: CodegenTypes.Float;
+  padding: CodegenTypes.Float;
 }
 
 interface ListStyleInternal extends BaseBlockStyleInternal {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
@@ -29,6 +29,8 @@ interface BlockquoteStyleInternal extends BaseBlockStyleInternal {
   borderWidth: CodegenTypes.Float;
   gapWidth: CodegenTypes.Float;
   backgroundColor: ColorValue;
+  borderRadius: CodegenTypes.Float;
+  padding: CodegenTypes.Float;
 }
 
 interface ListStyleInternal extends BaseBlockStyleInternal {

--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.ts
@@ -106,6 +106,8 @@ const DEFAULT_NORMALIZED_STYLE = Object.freeze({
     borderWidth: 3,
     gapWidth: 16,
     backgroundColor: normalizeColor('#F9FAFB')!,
+    borderRadius: 0,
+    padding: 0,
   },
   list: {
     fontSize: 16,

--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.web.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.web.ts
@@ -92,6 +92,8 @@ const DEFAULT_NORMALIZED_STYLE: MarkdownStyleInternal = Object.freeze({
     borderWidth: 3,
     gapWidth: 16,
     backgroundColor: '#F9FAFB',
+    borderRadius: 0,
+    padding: 0,
   },
   list: {
     fontSize: 16,

--- a/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
@@ -25,21 +25,7 @@ interface BlockquoteStyle extends BaseBlockStyle {
   borderWidth?: number;
   gapWidth?: number;
   backgroundColor?: string;
-  /**
-   * Corner radius of the blockquote background box. The accent stripe is
-   * clipped to the rounded shape; each nested quote's stripe is rounded
-   * against its own box, matching per-element border-radius on web.
-   * @default 0
-   */
   borderRadius?: number;
-  /**
-   * Inner spacing between the background box edges and the quote content,
-   * applied to the top and bottom (and the trailing edge on iOS and web).
-   * Each nesting level pads its own box, so nested quotes stack paddings
-   * at shared boundaries just like nested elements on web.
-   * Leading-edge spacing is still controlled by `borderWidth` + `gapWidth`.
-   * @default 0
-   */
   padding?: number;
 }
 

--- a/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
@@ -25,6 +25,22 @@ interface BlockquoteStyle extends BaseBlockStyle {
   borderWidth?: number;
   gapWidth?: number;
   backgroundColor?: string;
+  /**
+   * Corner radius of the blockquote background box. The accent stripe is
+   * clipped to the rounded shape; each nested quote's stripe is rounded
+   * against its own box, matching per-element border-radius on web.
+   * @default 0
+   */
+  borderRadius?: number;
+  /**
+   * Inner spacing between the background box edges and the quote content,
+   * applied to the top and bottom (and the trailing edge on iOS and web).
+   * Each nesting level pads its own box, so nested quotes stack paddings
+   * at shared boundaries just like nested elements on web.
+   * Leading-edge spacing is still controlled by `borderWidth` + `gapWidth`.
+   * @default 0
+   */
+  padding?: number;
 }
 
 interface ListStyle extends BaseBlockStyle {

--- a/packages/react-native-enriched-markdown/src/types/MarkdownStyleInternal.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownStyleInternal.ts
@@ -42,6 +42,8 @@ interface BlockquoteStyleInternal extends BaseBlockStyleInternal {
   borderWidth: number;
   gapWidth: number;
   backgroundColor: string;
+  borderRadius: number;
+  padding: number;
 }
 
 interface ListStyleInternal extends BaseBlockStyleInternal {

--- a/packages/react-native-enriched-markdown/src/web/styles.ts
+++ b/packages/react-native-enriched-markdown/src/web/styles.ts
@@ -126,7 +126,11 @@ function blockquoteStyle(style: MarkdownStyleInternal): CSSProperties {
     marginInlineStart: 0, // reset UA default (40px in LTR, auto in RTL)
     marginInlineEnd: 0,
     paddingInlineStart: blockquote.gapWidth,
+    paddingInlineEnd: blockquote.padding,
+    paddingTop: blockquote.padding,
+    paddingBottom: blockquote.padding,
     borderInlineStart: `${blockquote.borderWidth}px solid ${blockquote.borderColor}`,
+    borderRadius: blockquote.borderRadius,
     backgroundColor: blockquote.backgroundColor,
   };
 }


### PR DESCRIPTION
### What/Why?
 
Closes #103.

Adds `padding` and `borderRadius` options to `markdownStyle.blockquote`, implemented the same way as the code block background.

- `borderRadius` (default `0`) - rounds the full-width blockquote background box. The accent stripe is clipped to the rounded shape, and each nested quote's stripe rounds against its own box, matching per-element `border-radius` on web.
- `padding` (default `0`) - inner top/bottom spacing between the background box edges and the quote content (also applies to the trailing edge on iOS and web, same platform behavior as `codeBlock.padding`). Applied at every nesting level, so nested quotes pad their own box and paddings stack at shared boundaries like nested elements on web. Leading-edge spacing is still `borderWidth` + `gapWidth`.

### Testing
Example app / storybook - Blockquote stories with the new `borderRadius` and `padding` controls, on iOS and Android - including nested quotes, quote as the last document element, and defaults left at `0` (unchanged rendering).

#### Screenshots

| | iOS | Android |
| - | - | - |
| Default (before) | <img width="300" alt="image" src="https://github.com/user-attachments/assets/48c84e8d-cf2f-4052-a0a6-6259e2a06089" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/1f2655b6-98cf-4cc0-89da-1a3d978f374b" /> |
| `Padding: 10, borderRadius: 10` | <img width="300" alt="image" src="https://github.com/user-attachments/assets/2d043652-7aed-4192-99c4-22078ed0628b" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/b65cbdf7-8232-4625-ac4b-59a0e1413907" /> |

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

