### PR TITLE
fix(input): align bullet marker shapes with EnrichedMarkdownText

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/spans/InputBulletSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/spans/InputBulletSpan.kt
@@ -9,7 +9,7 @@ import com.swmansion.enriched.markdown.input.formatting.MarkdownSpan
 
 /**
  * Bullet list item span: reserves a per-depth leading margin and draws the marker
- * glyph (dot / ring / square, cycling by `depth % 3`) on the item's first line.
+ * glyph (dot / ring / square, capped at square for depth 2+) on the item's first line.
  * Mirrors the readonly renderer's bullet. Tagged [MarkdownSpan] for formatter
  * cleanup.
  */
@@ -51,7 +51,7 @@ class InputBulletSpan(
 
     val originalStyle = paint.style
     val originalStrokeWidth = paint.strokeWidth
-    when (depth % 3) {
+    when (if (depth >= 2) 2 else depth) {
       0 -> {
         paint.style = Paint.Style.FILL
         canvas.drawCircle(centerX, centerY, radius, paint)

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.mm
@@ -81,7 +81,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
   CGRect bulletRect = CGRectMake(markerX - size / 2.0, centerY - size / 2.0, size, size);
 
   CGContextSaveGState(ctx);
-  NSInteger style = ((depth % 3) + 3) % 3;
+  NSInteger style = depth >= 2 ? 2 : depth;
   switch (style) {
     case 0:
       [color setFill];


### PR DESCRIPTION
### What/Why?
Align input bullet marker shapes with the web standard and EnrichedMarkdownText. Previously the input cycled shapes (disc → ring → square) every 3 depth levels; now it caps at filled square for depth 2+, matching CSS list-style-type defaults.

### Testing


<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

