### PR TITLE
fix(input): support macOS text input with correct typing attributes and list markers

### DIFF
--- a/apps/react-native-macos-example/src/InputScreen.tsx
+++ b/apps/react-native-macos-example/src/InputScreen.tsx
@@ -207,7 +207,12 @@ export default function InputScreen() {
         </ScrollView>
 
         {/* Formatting toolbar */}
-        <View style={styles.toolbar}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.toolbarScroll}
+          contentContainerStyle={styles.toolbar}
+        >
           {(
             [
               { label: 'B', style: 'bold', action: 'toggleBold' },
@@ -263,7 +268,80 @@ export default function InputScreen() {
               Link
             </Text>
           </Pressable>
-        </View>
+
+          <View style={styles.toolbarSeparator} />
+
+          {([1, 2, 3, 4, 5, 6] as const).map((level) => (
+            <Pressable
+              key={`h${level}`}
+              style={[
+                styles.toolbarButton,
+                state?.heading.isActive &&
+                  state.heading.level === level &&
+                  styles.toolbarButtonActive,
+              ]}
+              onPress={() => inputRef.current?.toggleHeading(level)}
+            >
+              <Text
+                style={[
+                  styles.toolbarButtonText,
+                  state?.heading.isActive &&
+                    state.heading.level === level &&
+                    styles.toolbarButtonTextActive,
+                ]}
+              >
+                {`H${level}`}
+              </Text>
+            </Pressable>
+          ))}
+
+          <View style={styles.toolbarSeparator} />
+
+          <Pressable
+            style={[
+              styles.toolbarButton,
+              state?.unorderedList.isActive && styles.toolbarButtonActive,
+            ]}
+            onPress={() => inputRef.current?.toggleUnorderedList()}
+          >
+            <Text
+              style={[
+                styles.toolbarButtonText,
+                state?.unorderedList.isActive && styles.toolbarButtonTextActive,
+              ]}
+            >
+              •
+            </Text>
+          </Pressable>
+          <Pressable
+            style={[
+              styles.toolbarButton,
+              state?.orderedList.isActive && styles.toolbarButtonActive,
+            ]}
+            onPress={() => inputRef.current?.toggleOrderedList()}
+          >
+            <Text
+              style={[
+                styles.toolbarButtonText,
+                state?.orderedList.isActive && styles.toolbarButtonTextActive,
+              ]}
+            >
+              1.
+            </Text>
+          </Pressable>
+          <Pressable
+            style={styles.toolbarButton}
+            onPress={() => inputRef.current?.outdentList()}
+          >
+            <Text style={styles.toolbarButtonText}>⇤</Text>
+          </Pressable>
+          <Pressable
+            style={styles.toolbarButton}
+            onPress={() => inputRef.current?.indentList()}
+          >
+            <Text style={styles.toolbarButtonText}>⇥</Text>
+          </Pressable>
+        </ScrollView>
 
         {/* Input row */}
         <View style={styles.inputRow}>
@@ -420,22 +498,32 @@ const styles = StyleSheet.create({
   bubbleTimeOther: {
     color: '#9CA3AF',
   },
-  toolbar: {
-    flexDirection: 'row',
-    gap: 4,
-    paddingHorizontal: 12,
-    paddingTop: 8,
-    paddingBottom: 4,
+  toolbarScroll: {
+    flexGrow: 0,
     backgroundColor: '#F9FAFB',
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: '#E5E7EB',
   },
+  toolbar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  toolbarSeparator: {
+    width: StyleSheet.hairlineWidth,
+    height: 18,
+    backgroundColor: '#D1D5DB',
+    marginHorizontal: 4,
+  },
   toolbarButton: {
-    width: 30,
+    minWidth: 30,
     height: 26,
     borderRadius: 5,
     justifyContent: 'center',
     alignItems: 'center',
+    paddingHorizontal: 4,
   },
   toolbarButtonActive: {
     backgroundColor: '#DBEAFE',

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputDecorationDrawer.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputDecorationDrawer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#import <UIKit/UIKit.h>
+#import "ENRMUIKit.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #import "ENRMInputDecorationDrawer.h"
-#import <UIKit/UIKit.h>
+#import "ENRMUIKit.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) NSInteger emptyBulletOrdinal;
 @property (nonatomic, assign) NSUInteger emptyBulletLocation;
 @property (nonatomic, strong, nullable) UIFont *emptyBulletFont;
-@property (nonatomic, strong, nullable) UIColor *emptyBulletColor;
+@property (nonatomic, strong, nullable) RCTUIColor *emptyBulletColor;
 @property (nonatomic, assign) BOOL emptyBulletRTL;
 @property (nonatomic, assign) CGFloat listItemSpacing;
 

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputListMarkerDrawer.mm
@@ -7,9 +7,9 @@ static UIFont *ENRMFallbackFont(void)
   return [UIFont systemFontOfSize:16];
 }
 
-static UIColor *ENRMFallbackColor(void)
+static RCTUIColor *ENRMFallbackColor(void)
 {
-  return [UIColor labelColor];
+  return [RCTUIColor labelColor];
 }
 
 static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, CGFloat leadingOffset)
@@ -70,7 +70,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
               centerY:(CGFloat)centerY
                 depth:(NSInteger)depth
                  font:(UIFont *)font
-                color:(UIColor *)color
+                color:(RCTUIColor *)color
 {
   CGContextRef ctx = UIGraphicsGetCurrentContext();
   if (!ctx || isnan(markerX) || isnan(centerY)) {
@@ -106,7 +106,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
                          baselineY:(CGFloat)baselineY
                            ordinal:(NSInteger)ordinal
                               font:(UIFont *)font
-                             color:(UIColor *)color
+                             color:(RCTUIColor *)color
 {
   NSString *label = [NSString stringWithFormat:@"%ld.", (long)MAX(ordinal, (NSInteger)1)];
   NSDictionary *attrs = @{NSFontAttributeName : font, NSForegroundColorAttributeName : color};
@@ -118,7 +118,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
                            baselineY:(CGFloat)baselineY
                              ordinal:(NSInteger)ordinal
                                 font:(UIFont *)font
-                               color:(UIColor *)color
+                               color:(RCTUIColor *)color
 {
   NSString *label = [NSString stringWithFormat:@".%ld", (long)MAX(ordinal, (NSInteger)1)];
   NSDictionary *attrs = @{NSFontAttributeName : font, NSForegroundColorAttributeName : color};
@@ -136,7 +136,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
                      usedRect:(CGRect)usedRect
                     container:(NSTextContainer *)container
                          font:(UIFont *)font
-                        color:(UIColor *)color
+                        color:(RCTUIColor *)color
 {
   CGFloat leadingOffset = container.lineFragmentPadding + (depth + 1) * kENRMListIndentPerDepth;
 
@@ -187,13 +187,13 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
 }
 
 - (void)resolveMarkerFont:(out UIFont **)outFont
-                    color:(out UIColor **)outColor
+                    color:(out RCTUIColor **)outColor
                   atIndex:(NSUInteger)charIndex
                   storage:(NSTextStorage *)storage
           isEmptyListLine:(BOOL)isEmptyListLine
 {
   UIFont *font = nil;
-  UIColor *color = nil;
+  RCTUIColor *color = nil;
 
   if (isEmptyListLine) {
     font = self.emptyBulletFont;
@@ -257,7 +257,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
   [_drawnParagraphLocations addObject:@(paraRange.location)];
 
   UIFont *font;
-  UIColor *color;
+  RCTUIColor *color;
   [self resolveMarkerFont:&font
                     color:&color
                   atIndex:charRange.location
@@ -312,7 +312,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
   if (self.emptyBulletDepth >= 0 && self.emptyBulletLocation >= storage.length &&
       layoutManager.extraLineFragmentTextContainer != nil) {
     UIFont *font = self.emptyBulletFont ?: ENRMFallbackFont();
-    UIColor *color = self.emptyBulletColor ?: ENRMFallbackColor();
+    RCTUIColor *color = self.emptyBulletColor ?: ENRMFallbackColor();
     CGRect used = layoutManager.extraLineFragmentUsedRect;
     CGFloat baselineY = origin.y + used.origin.y + font.ascender;
     [self drawListMarkerOrdered:self.emptyBulletOrdered
@@ -336,7 +336,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
   }
 
   UIFont *font = self.emptyBulletFont ?: ENRMFallbackFont();
-  UIColor *color = self.emptyBulletColor ?: ENRMFallbackColor();
+  RCTUIColor *color = self.emptyBulletColor ?: ENRMFallbackColor();
   NSTextContainer *container = layoutManager.textContainers.firstObject;
   BOOL isRTL = self.emptyBulletRTL && container != nil;
 
@@ -371,7 +371,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
   }
 
   UIFont *font = self.emptyBulletFont ?: ENRMFallbackFont();
-  UIColor *color = self.emptyBulletColor ?: ENRMFallbackColor();
+  RCTUIColor *color = self.emptyBulletColor ?: ENRMFallbackColor();
 
   CGRect usedRect = CGRectMake(_trailingBulletHeadIndent, 0, 0, bounds.size.height);
   CGPoint origin = CGPointMake(_trailingBulletInsetLeft, 0);
@@ -394,7 +394,7 @@ static CGFloat ENRMTrailingMarkerX(CGPoint origin, NSTextContainer *container, C
 {
   if (!_trailingBulletView) {
     _trailingBulletView = [[ENRMTrailingBulletView alloc] init];
-    _trailingBulletView.backgroundColor = [UIColor clearColor];
+    _trailingBulletView.backgroundColor = [RCTUIColor clearColor];
     _trailingBulletView.opaque = NO;
     _trailingBulletView.userInteractionEnabled = NO;
   }

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputTextView.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputTextView.mm
@@ -3,6 +3,9 @@
 #import "EnrichedMarkdownTextInput+Internal.h"
 #import "EnrichedMarkdownTextInput.h"
 #import "PasteboardUtils.h"
+#if TARGET_OS_OSX
+#import <objc/message.h>
+#endif
 
 NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-markdown.markdown";
 
@@ -211,6 +214,15 @@ NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-markdown.
   return menu;
 }
 
+- (void)setTypingAttributes:(NSDictionary *)typingAttributes
+{
+  // RCTUITextView's override discards the value and always resets to
+  // defaultTextAttributes.  We need the actual value (e.g. list paragraph
+  // indent) to reach NSTextView so the caret positions correctly.
+  struct objc_super superSuper = {self, [NSTextView class]};
+  ((void (*)(struct objc_super *, SEL, NSDictionary *))objc_msgSendSuper)(&superSuper, _cmd, typingAttributes);
+}
+
 - (void)layout
 {
   [super layout];
@@ -218,6 +230,19 @@ NSString *const kENRMMarkdownPasteboardType = @"com.swmansion.enriched-markdown.
   if (self.markdownTextInput != nil && fabs(currentWidth - _lastLayoutWidth) > 0.5) {
     _lastLayoutWidth = currentWidth;
     [self.markdownTextInput scheduleRelayoutIfNeeded];
+  }
+}
+
+- (void)drawRect:(NSRect)rect
+{
+  [super drawRect:rect];
+  if (self.string.length == 0) {
+    NSLayoutManager *lm = self.layoutManager;
+    if ([lm isKindOfClass:[ENRMInputLayoutManager class]]) {
+      NSEdgeInsets insets = self.textContainerInsets;
+      insets.left += self.textContainer.lineFragmentPadding;
+      [(ENRMInputLayoutManager *)lm drawEmptyEditorDecorationsWithInset:insets];
+    }
   }
 }
 

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -221,6 +221,8 @@ using namespace facebook::react;
   ENRMInputTextView *inputTextView = [[ENRMInputTextView alloc] initWithFrame:CGRectZero textContainer:textContainer];
 #else
   ENRMInputTextView *inputTextView = [[ENRMInputTextView alloc] initWithFrame:CGRectZero];
+  _layoutManager = [[ENRMInputLayoutManager alloc] init];
+  [inputTextView.textContainer replaceLayoutManager:_layoutManager];
 #endif
   inputTextView.markdownTextInput = self;
   _textView = inputTextView;


### PR DESCRIPTION
### What/Why?
RCTUITextView's setTypingAttributes: override silently discards values, preventing paragraph styles (list indent) from reaching NSTextView. Bypass it via objc_msgSendSuper to call NSTextView directly.

Also wire the custom ENRMInputLayoutManager on macOS so list markers draw, fix UIKit imports for macOS compatibility (ENRMUIKit.h, RCTUIColor), add empty-editor bullet drawing via drawRect:, and enhance the macOS example toolbar with heading/list controls.



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

