### PR TITLE
fix(android): inline code drawing range calculations

### DIFF
--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/CodeBackgroundSpan.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/spans/CodeBackgroundSpan.kt
@@ -7,6 +7,7 @@ import android.graphics.RectF
 import android.text.Spanned
 import android.text.StaticLayout
 import android.text.TextPaint
+import android.text.style.LeadingMarginSpan
 import android.text.style.LineBackgroundSpan
 import com.swmansion.enriched.markdown.styles.StyleConfig
 import kotlin.math.max
@@ -58,8 +59,9 @@ class CodeBackgroundSpan(
 
     // 2. Calculate coordinates
     val finalBottom = adjustBottomForMargin(text, end, bottom)
-    val startX = if (isFirst) getHorizontalOffset(text, start, end, spanStart, p) + left else left.toFloat()
-    val endX = if (isLast) getHorizontalOffset(text, start, end, spanEnd, p) + left else right.toFloat()
+    val leadingMargin = leadingMarginAt(text, start)
+    val startX = if (isFirst) getHorizontalOffset(text, start, end, spanStart, p, leadingMargin) + left else left.toFloat() + leadingMargin
+    val endX = if (isLast) getHorizontalOffset(text, start, end, spanEnd, p, leadingMargin) + left else right.toFloat()
 
     rect.set(min(startX, endX), top.toFloat(), max(startX, endX), finalBottom.toFloat())
 
@@ -71,14 +73,23 @@ class CodeBackgroundSpan(
     drawShapes(canvas, isFirst, isLast)
   }
 
+  /**
+   * Returns the x position of [index] relative to the line's left edge, including any
+   * leading margin. The measuring StaticLayout is built from a subSequence that keeps
+   * all spans, so LeadingMarginSpans (lists, blockquotes) are already applied to
+   * getPrimaryHorizontal; adding the margin again on top would shift the background
+   * right by the indent. The margin is only added explicitly in the early-return case,
+   * where no layout is built.
+   */
   private fun getHorizontalOffset(
     text: CharSequence,
     lineStart: Int,
     lineEnd: Int,
     index: Int,
     paint: Paint,
+    leadingMargin: Int,
   ): Float {
-    if (index <= lineStart) return 0f
+    if (index <= lineStart) return leadingMargin.toFloat()
     val lineText = text.subSequence(lineStart, lineEnd)
     val textPaint = paint as? TextPaint ?: TextPaint(paint)
     val layout = StaticLayout.Builder.obtain(lineText, 0, lineText.length, textPaint, 10000).build()
@@ -162,6 +173,19 @@ class CodeBackgroundSpan(
     else -> {
       floatArrayOf(0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f)
     }
+  }
+
+  private fun leadingMarginAt(
+    text: Spanned,
+    lineStart: Int,
+  ): Int {
+    if (lineStart >= text.length) return 0
+    val spans = text.getSpans(lineStart, lineStart + 1, LeadingMarginSpan::class.java)
+    var margin = 0
+    for (span in spans) {
+      margin += span.getLeadingMargin(false)
+    }
+    return margin
   }
 
   private fun adjustBottomForMargin(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/CodeBackgroundSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/CodeBackgroundSpan.kt
@@ -60,8 +60,8 @@ class CodeBackgroundSpan(
     // 2. Calculate coordinates
     val finalBottom = adjustBottomForMargin(text, end, bottom)
     val leadingMargin = leadingMarginAt(text, start)
-    val startX = if (isFirst) getHorizontalOffset(text, start, end, spanStart, p) + left + leadingMargin else left.toFloat() + leadingMargin
-    val endX = if (isLast) getHorizontalOffset(text, start, end, spanEnd, p) + left + leadingMargin else right.toFloat()
+    val startX = if (isFirst) getHorizontalOffset(text, start, end, spanStart, p, leadingMargin) + left else left.toFloat() + leadingMargin
+    val endX = if (isLast) getHorizontalOffset(text, start, end, spanEnd, p, leadingMargin) + left else right.toFloat()
 
     rect.set(min(startX, endX), top.toFloat(), max(startX, endX), finalBottom.toFloat())
 
@@ -73,14 +73,23 @@ class CodeBackgroundSpan(
     drawShapes(canvas, isFirst, isLast)
   }
 
+  /**
+   * Returns the x position of [index] relative to the line's left edge, including any
+   * leading margin. The measuring StaticLayout is built from a subSequence that keeps
+   * all spans, so LeadingMarginSpans (lists, blockquotes) are already applied to
+   * getPrimaryHorizontal; adding the margin again on top would shift the background
+   * right by the indent. The margin is only added explicitly in the early-return case,
+   * where no layout is built.
+   */
   private fun getHorizontalOffset(
     text: CharSequence,
     lineStart: Int,
     lineEnd: Int,
     index: Int,
     paint: Paint,
+    leadingMargin: Int,
   ): Float {
-    if (index <= lineStart) return 0f
+    if (index <= lineStart) return leadingMargin.toFloat()
     val lineText = text.subSequence(lineStart, lineEnd)
     val textPaint = paint as? TextPaint ?: TextPaint(paint)
     val layout = StaticLayout.Builder.obtain(lineText, 0, lineText.length, textPaint, 10000).build()


### PR DESCRIPTION
### What/Why?
`CodeBackgroundSpan` measures character positions by building a throwaway `StaticLayout` from `text.subSequence(lineStart, lineEnd)`. That subsequence keeps all spans, including `LeadingMarginSpan`s (`BaseListSpan`, `BlockquoteSpan`), so the measuring layout already applies the list indent to `getPrimaryHorizontal`. `drawBackground` then added `leadingMargin` on top of that, shifting the box right by exactly the marker indent.

The fix trusts the measuring layout's margin for measured offsets and only adds `leadingMargin` explicitly in the branches where no layout is built (span starting at line start, continuation lines). Applied to both Android source trees:

- `packages/react-native-enriched-markdown/.../CodeBackgroundSpan.kt` -  fixes the rightward shift in lists
- `packages/android-enriched-markdown/.../CodeBackgroundSpan.kt` - this copy had no margin handling at all, so continuation lines of a wrapped code span were missing the indent

### Testing

In the example app (`apps/react-native-example`), open the **Text** screen and scroll to the any codeblock should hug the text exactly. Also verified in the **Playground** preview with inline code in a nested list (two stacked leading margins), in a plain paragraph, and inside a blockquote.

| Before | After |
| - | - |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/b2d66878-fc80-4548-8009-9dd7198cdcfe" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/6c1dd7f5-1bdf-411b-8a50-82c117a5b018" /> |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/d7a0fa8f-57cb-4418-a202-83768dd1caaf" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/4942a064-768a-498c-8fce-ffaa25e244f9" /> |

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

