### PR TITLE
feat: expose insert text method

### DIFF
--- a/apps/react-native-example/.rnstorybook/index.ts
+++ b/apps/react-native-example/.rnstorybook/index.ts
@@ -3,7 +3,13 @@ import { LiteUI } from '@storybook/react-native-ui-lite';
 
 import { view } from './storybook.requires';
 
+// Without hasStoryWrapper: false, storybook wraps every story in a View whose
+// onStartShouldSetResponder calls Keyboard.dismiss() on every touch start.
+// That breaks text selection inside EnrichedMarkdownTextInput stories: tapping
+// a selection handle dismisses the keyboard, the input resigns focus and the
+// selection collapses (double-tap selection also gets flaky).
 const StorybookUIRoot = view.getStorybookUI({
+  hasStoryWrapper: false,
   shouldPersistSelection: true,
   storage: {
     getItem: AsyncStorage.getItem,

--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/methods/InsertText.stories.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownTextInput/methods/InsertText.stories.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  EnrichedMarkdownTextInput,
+  type EnrichedMarkdownTextInputInstance,
+} from 'react-native-enriched-markdown';
+import { storyMeta } from '../shared/storyMeta';
+import type { InputStory } from '../shared/storyTypes';
+
+const SAMPLE_MARKDOWN =
+  'Place the cursor anywhere in this text, or select a fragment, then insert below.';
+
+const SNIPPETS = [
+  { label: 'Insert plain text', markdown: 'inserted text' },
+  {
+    label: 'Insert inline markdown',
+    markdown: '**bold**, *italic* and a [link](https://swmansion.com)',
+  },
+  {
+    label: 'Insert a list',
+    markdown: '\n- first item\n- second item\n',
+  },
+] as const;
+
+export default storyMeta('Methods', 'InsertText');
+
+function InsertTextDemo() {
+  const inputRef = useRef<EnrichedMarkdownTextInputInstance>(null);
+
+  useEffect(() => {
+    inputRef.current?.setValue(SAMPLE_MARKDOWN);
+  }, []);
+
+  return (
+    <ScrollView
+      contentContainerStyle={styles.container}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text style={styles.title}>insertText()</Text>
+      <Text style={styles.description}>
+        Ref method that parses the given string as Markdown and inserts it
+        literally at the current cursor position, replacing the selection if
+        there is one. Leading and trailing newlines are preserved, so wrap block
+        content (lists, headings) in newlines to keep it on its own lines when
+        inserting mid-paragraph.
+      </Text>
+
+      <View style={styles.block}>
+        <Text style={styles.label}>Input</Text>
+        <View style={styles.editorContainer}>
+          <EnrichedMarkdownTextInput
+            ref={inputRef}
+            placeholder="Type markdown here..."
+            placeholderTextColor="#9CA3AF"
+            style={styles.input}
+          />
+        </View>
+        {SNIPPETS.map(({ label, markdown }) => (
+          <TouchableOpacity
+            key={label}
+            style={styles.actionButton}
+            onPress={() => inputRef.current?.insertText(markdown)}
+          >
+            <Text style={styles.actionButtonText}>{label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+export const Default: InputStory = {
+  render: () => <InsertTextDemo />,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    gap: 8,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  description: {
+    fontSize: 14,
+    color: '#555',
+    marginBottom: 4,
+  },
+  block: {
+    paddingVertical: 8,
+    gap: 8,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#888',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  editorContainer: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    overflow: 'hidden',
+    backgroundColor: '#fff',
+  },
+  input: {
+    minHeight: 120,
+    maxHeight: 200,
+    fontSize: 15,
+    color: '#111827',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  actionButton: {
+    paddingVertical: 10,
+    borderRadius: 8,
+    backgroundColor: '#BEEBD0',
+    alignItems: 'center',
+  },
+  actionButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#001A72',
+  },
+});

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1000,6 +1000,10 @@ Inserts a link with the given text and URL at the current cursor position. Usefu
 
 Removes the link from the current selection.
 
+### `insertText(text: string)`
+
+Parses the given string as Markdown and inserts it literally at the current cursor position, replacing the selection if there is one. Leading and trailing newlines are preserved, so wrap block content (lists, headings) in newlines to keep it on its own lines when inserting mid-paragraph — `insertText('\n- item\n')` in the middle of `test` yields `te`, a `- item` bullet, and `st` on separate lines. Calling it with an empty string is a no-op.
+
 ### `copyToClipboard()`
 
 Copies the input's full content to the system clipboard, matching the result of selecting all text and pressing the context menu's copy action. The selection is left unchanged, and calling it on an empty input is a no-op.

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
@@ -465,6 +465,15 @@ class EnrichedMarkdownTextInputManager :
     }
   }
 
+  override fun insertText(
+    view: EnrichedMarkdownTextInputView?,
+    text: String?,
+  ) {
+    if (text != null) {
+      view?.insertTextAtCursor(text)
+    }
+  }
+
   override fun insertMention(
     view: EnrichedMarkdownTextInputView?,
     displayText: String?,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -691,24 +691,37 @@ class EnrichedMarkdownTextInputView(
   /**
    * Replaces the selection with parsed markdown, importing its inline formatting
    * and block ranges (headings etc.) into the stores — mirrors iOS pasteMarkdown.
+   *
+   * Insertion is literal: the string's characters land at the cursor exactly as
+   * given. Markdown parsing consumes leading and trailing newlines as block
+   * structure, so they are split off before the parse and re-attached verbatim;
+   * without this, insertText("\n- item\n") mid-paragraph would merge the list
+   * line with the surrounding text. Callers decide separation by including (or
+   * omitting) newlines in the string.
    */
   fun pasteMarkdown(markdown: String) {
     val editable = text ?: return
-    val parsed = InputParser.parseToPlainTextAndRanges(markdown)
+    val prefix = markdown.takeWhile { it == '\n' }
+    val suffix = if (markdown.length > prefix.length) markdown.takeLastWhile { it == '\n' } else ""
+    val core = markdown.substring(prefix.length, markdown.length - suffix.length)
+    val parsed = InputParser.parseToPlainTextAndRanges(core)
     val selStart = selectionStart.coerceIn(0, editable.length)
     val selEnd = selectionEnd.coerceIn(selStart, editable.length)
 
-    replaceTextInRange(selStart, selEnd, parsed.plainText) { editable ->
+    val plainText = prefix + parsed.plainText + suffix
+    val contentStart = selStart + prefix.length
+
+    replaceTextInRange(selStart, selEnd, plainText) { editable ->
       for (range in parsed.formattingRanges) {
         formattingStore.addRange(
-          FormattingRange(range.type, range.start + selStart, range.end + selStart, range.url),
+          FormattingRange(range.type, range.start + contentStart, range.end + contentStart, range.url),
         )
       }
       for (block in parsed.blockRanges) {
-        blockStore.setBlock(block.type, block.level, block.start + selStart, block.end + selStart, editable)
+        blockStore.setBlock(block.type, block.level, block.start + contentStart, block.end + contentStart, editable)
       }
-      setSelection(selStart + parsed.plainText.length)
-      detectorPipeline.processTextChange(editable, editable.toString(), selStart, parsed.plainText.length)
+      setSelection(selStart + plainText.length)
+      detectorPipeline.processTextChange(editable, editable.toString(), selStart, plainText.length)
     }
   }
 
@@ -777,6 +790,12 @@ class EnrichedMarkdownTextInputView(
     if (selStart == selEnd) return
     linkCoordinator.setLinkForRange(url, selStart, selEnd, text)
     applyFormattingAndEmit()
+  }
+
+  /** Parses the given markdown and inserts it at the cursor, replacing any selection. */
+  fun insertTextAtCursor(markdown: String) {
+    if (markdown.isEmpty()) return
+    pasteMarkdown(markdown)
   }
 
   fun insertLinkAtCursor(

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -732,14 +732,54 @@ using namespace facebook::react;
   [self replaceTextInRange:_textView.selectedRange withText:text formattingRanges:ranges];
 }
 
+/// Insertion is literal: the string's characters land at the cursor exactly as
+/// given. Markdown parsing consumes leading and trailing newlines as block
+/// structure, so they are split off before the parse and re-attached verbatim;
+/// without this, inserting "\n- item\n" mid-paragraph would merge the list line
+/// with the surrounding text. Callers decide separation by including (or
+/// omitting) newlines in the string.
 - (void)pasteMarkdown:(NSString *)markdown
 {
+  NSUInteger lead = 0;
+  while (lead < markdown.length && [markdown characterAtIndex:lead] == '\n') {
+    lead++;
+  }
+  NSUInteger trail = 0;
+  while (lead + trail < markdown.length && [markdown characterAtIndex:markdown.length - 1 - trail] == '\n') {
+    trail++;
+  }
+  NSString *core = [markdown substringWithRange:NSMakeRange(lead, markdown.length - lead - trail)];
+
   ENRMInputParser *parser = [[ENRMInputParser alloc] init];
-  ENRMParseResult *parsed = [parser parseToPlainTextAndRanges:markdown];
+  ENRMParseResult *parsed = [parser parseToPlainTextAndRanges:core];
+
+  if (lead == 0 && trail == 0) {
+    [self replaceTextInRange:_textView.selectedRange
+                    withText:parsed.plainText
+            formattingRanges:parsed.formattingRanges
+                 blockRanges:parsed.blockRanges];
+    return;
+  }
+
+  NSString *prefix = [@"" stringByPaddingToLength:lead withString:@"\n" startingAtIndex:0];
+  NSString *suffix = [@"" stringByPaddingToLength:trail withString:@"\n" startingAtIndex:0];
+  NSString *plainText = [NSString stringWithFormat:@"%@%@%@", prefix, parsed.plainText, suffix];
+
+  NSMutableArray<ENRMFormattingRange *> *formattingRanges =
+      [NSMutableArray arrayWithCapacity:parsed.formattingRanges.count];
+  for (ENRMFormattingRange *range in parsed.formattingRanges) {
+    NSRange shifted = NSMakeRange(range.range.location + lead, range.range.length);
+    [formattingRanges addObject:[ENRMFormattingRange rangeWithType:range.type range:shifted url:range.url]];
+  }
+  NSMutableArray<ENRMBlockRange *> *blockRanges = [NSMutableArray arrayWithCapacity:parsed.blockRanges.count];
+  for (ENRMBlockRange *block in parsed.blockRanges) {
+    NSRange shifted = NSMakeRange(block.range.location + lead, block.range.length);
+    [blockRanges addObject:[ENRMBlockRange rangeWithType:block.type range:shifted level:block.level]];
+  }
   [self replaceTextInRange:_textView.selectedRange
-                  withText:parsed.plainText
-          formattingRanges:parsed.formattingRanges
-               blockRanges:parsed.blockRanges];
+                  withText:plainText
+          formattingRanges:formattingRanges
+               blockRanges:blockRanges];
 }
 
 #pragma mark - Formatting
@@ -1238,6 +1278,14 @@ using namespace facebook::react;
                                                             range:linkRange
                                                               url:[_linkCoordinator sanitizeURL:url]];
   [self replaceSelectedTextWith:displayText formattingRanges:@[ range ]];
+}
+
+- (void)insertText:(NSString *)text
+{
+  if (text.length == 0) {
+    return;
+  }
+  [self pasteMarkdown:text];
 }
 
 - (void)startMention:(NSString *)indicator

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -152,6 +152,7 @@ export interface EnrichedMarkdownTextInputInstance {
   outdentList: () => void;
   setLink: (url: string) => void;
   insertLink: (text: string, url: string) => void;
+  insertText: (text: string) => void;
   insertMention: (displayText: string, url: string) => void;
   startMention: (indicator: string) => void;
   removeLink: () => void;
@@ -611,6 +612,7 @@ export const EnrichedMarkdownTextInput = ({
       outdentList: () => Commands.outdentList(commandRef),
       setLink: (url) => Commands.setLink(commandRef, url),
       insertLink: (text, url) => Commands.insertLink(commandRef, text, url),
+      insertText: (text) => Commands.insertText(commandRef, text),
       insertMention: (displayText, url) =>
         Commands.insertMention(commandRef, displayText, url),
       startMention: (indicator) => Commands.startMention(commandRef, indicator),

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInputNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInputNativeComponent.ts
@@ -337,6 +337,7 @@ interface NativeCommands {
     text: string,
     url: string
   ) => void;
+  insertText: (viewRef: React.ElementRef<ComponentType>, text: string) => void;
   insertMention: (
     viewRef: React.ElementRef<ComponentType>,
     displayText: string,
@@ -376,6 +377,7 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
     'outdentList',
     'setLink',
     'insertLink',
+    'insertText',
     'insertMention',
     'startMention',
     'removeLink',


### PR DESCRIPTION
### What/Why?
Closes #286.

Adds an `insertText(text)` imperative method to `EnrichedMarkdownTextInput` that parses the given string as Markdown and inserts it literally at the current cursor position (replacing the selection if there is one). Previously the only way to insert text programmatically was the `getMarkdown` + splice + `setValue` workaround, which reparses the whole document and loses line breaks.

Implementation reuses the existing paste pipeline on both platforms (`pasteMarkdown`), so inline formatting, block ranges, auto-link detection, undo and event emission all come from battle-tested code:

- **Spec/TS**: new `insertText` command in `EnrichedMarkdownTextInputNativeComponent.ts`, exposed on `EnrichedMarkdownTextInputInstance`.
- **iOS**: `insertText:` delegates to `pasteMarkdown:` (empty string is a no-op).
- **Android**: `insertTextAtCursor()` wrapper over `pasteMarkdown()` plus the `insertText` manager override.

While testing, this surfaced a bug in `pasteMarkdown` on both platforms: md4c consumes leading/trailing newlines as block structure, so inserting `'\n- item\n'` mid-word merged the list line with the surrounding text (`te|st` became a `- tefirst item` bullet). The newline runs are now split off before the parse and re-attached verbatim, making insertion fully literal — the caller controls separation. This also fixes clipboard paste of markdown that starts/ends with block content.

Also fixes text selection inside storybook stories: the storybook story wrapper calls `Keyboard.dismiss()` on every touch start, which collapsed selections and broke double-tap selection. Disabled via `hasStoryWrapper: false` in `.rnstorybook/index.ts`.

### Testing
New `Methods/InsertText` storybook story with three snippets (plain text, inline markdown, a newline-wrapped list). Manually verified on iOS simulator and Android emulator:

- Cursor mid-word: inserted text lands exactly at the cursor (`lore<text>|m ipsum`), cursor after the inserted text.
- Active selection: replaced by the inserted content.
- `'**bold**, *italic* and a [link](...)'` renders formatted; `getMarkdown()` round-trips.
- `'\n- first item\n- second item\n'` at `te|st` yields `te` / two bullets / `st` on separate lines.
- `insertText('')` with an active selection is a no-op.

### Screenshots

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

