### PR TITLE
fix(ios): apply formatting when setting text via ref setValue

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -670,14 +670,14 @@ using namespace facebook::react;
   [_blockStore setRanges:parsed.blockRanges];
   _lastTextLength = parsed.plainText.length;
   _lastSelectedRange = _textView.selectedRange;
+
+  [_editSession exitPhase];
   [self applyFormatting];
   [self updatePlaceholderVisibility];
 
   if (parsed.plainText.length == 0) {
     [self resetBaseTypingAttributes];
   }
-
-  [_editSession exitPhase];
 }
 
 - (void)replaceTextInRange:(NSRange)selection


### PR DESCRIPTION
### What/Why?
The ENRMEditSession suppressed formatting inside importMarkdown because applyFormatting ran while the phase was still ENRMEditPhaseImporting. Exit the importing phase before applying formatting so attributed-string attributes are actually written.

Fixes #616

### Testing
<!-- How to test changed code? What testing has been done? -->



 #### Screenshots
<!-- If you attach screenshots, please use <img src="" width=200/> -->

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/e7aa8098-ba0c-4254-9c50-8976ea035fbf" width=300 /> | <video src="https://github.com/user-attachments/assets/3b8dd42e-c79e-4273-934f-1686664f0643" width=300 /> |

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

