### PR TITLE
feat(ios): expose md4cFlags and add strikethrough/underline rendering

### DIFF
--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Extensions/ButtonStyle+Pill.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Extensions/ButtonStyle+Pill.swift
@@ -25,4 +25,8 @@ extension ButtonStyle where Self == PillButtonStyle {
     static var pillSecondary: PillButtonStyle {
         PillButtonStyle(foreground: .gray700, background: .gray200, fontSize: 13)
     }
+
+    static var pillSecondaryActive: PillButtonStyle {
+        PillButtonStyle(foreground: .brandNavy, background: .brandMint, fontSize: 13)
+    }
 }

--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundButton.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundButton.swift
@@ -5,13 +5,14 @@ struct PlaygroundButton: View {
 
     let label: String
     let accessibilityId: String
+    var isActive: Bool = false
     let action: () -> Void
 
     // MARK: - Views
 
     var body: some View {
         Button(label, action: action)
-            .buttonStyle(.pillSecondary)
+            .buttonStyle(isActive ? .pillSecondaryActive : .pillSecondary)
             .accessibilityIdentifier(accessibilityId)
     }
 }

--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
@@ -4,9 +4,10 @@ import SwiftUI
 struct PlaygroundScreen: View {
     // MARK: - Properties
 
-    @State private var markdown = ""
-    @State private var setMarkdownSheetVisible = false
-    @State private var rawInput = ""
+    @State private var markdown: String = ""
+    @State private var underlineEnabled: Bool = true
+    @State private var setMarkdownSheetVisible: Bool = false
+    @State private var rawInput: String = ""
     @State private var blockImageURI: String?
     @State private var inlineImageURI: String?
 
@@ -17,7 +18,13 @@ struct PlaygroundScreen: View {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 8) {
                     PlaygroundButton(label: "Blur", accessibilityId: "blur-button") {}
-                    PlaygroundButton(label: "Underline", accessibilityId: "underline-button") {}
+                    PlaygroundButton(
+                        label: "Underline",
+                        accessibilityId: "underline-button",
+                        isActive: underlineEnabled
+                    ) {
+                        underlineEnabled.toggle()
+                    }
                 }
 
                 HStack(spacing: 8) {
@@ -74,7 +81,7 @@ struct PlaygroundScreen: View {
                         .padding(14)
                         .accessibilityIdentifier("preview-empty")
                 } else {
-                    EnrichedMarkdownText(markdown)
+                    EnrichedMarkdownText(markdown, flags: Md4cFlags(underline: underlineEnabled))
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(14)
                         .accessibilityIdentifier("preview-text")

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
@@ -47,6 +47,10 @@ final class RendererFactory {
             return StrongRenderer(factory: self, config: config)
         case .emphasis:
             return EmphasisRenderer(factory: self, config: config)
+        case .strikethrough:
+            return StrikethroughRenderer(factory: self, config: config)
+        case .underline:
+            return UnderlineRenderer(factory: self, config: config)
         case .link:
             return LinkRenderer(factory: self, config: config)
         case .lineBreak:

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/StrikethroughRenderer.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/StrikethroughRenderer.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+final class StrikethroughRenderer: NodeRenderer {
+    private let factory: RendererFactory
+    private let config: MarkdownStyleConfig
+
+    init(factory: RendererFactory, config: MarkdownStyleConfig) {
+        self.factory = factory
+        self.config = config
+    }
+
+    func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
+        let start = output.length
+        factory.renderChildren(of: node, into: output, context: context)
+
+        let range = RenderContext.rangeForRenderedContent(in: output, start: start)
+        guard range.length > 0 else { return }
+
+        output.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+
+        guard let strikethroughColor = config.strikethrough.foregroundColor else { return }
+
+        output.enumerateAttributes(in: range, options: []) { attributes, subrange, _ in
+            guard !RenderContext.shouldPreserveColors(attributes) else { return }
+
+            let currentColor = attributes[.foregroundColor] as? UIColor
+            if currentColor != strikethroughColor {
+                output.addAttribute(.foregroundColor, value: strikethroughColor, range: subrange)
+            }
+        }
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/UnderlineRenderer.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/UnderlineRenderer.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+final class UnderlineRenderer: NodeRenderer {
+    private let factory: RendererFactory
+    private let config: MarkdownStyleConfig
+
+    init(factory: RendererFactory, config: MarkdownStyleConfig) {
+        self.factory = factory
+        self.config = config
+    }
+
+    func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
+        let start = output.length
+        factory.renderChildren(of: node, into: output, context: context)
+
+        let range = RenderContext.rangeForRenderedContent(in: output, start: start)
+        guard range.length > 0 else { return }
+
+        output.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+
+        guard let underlineColor = config.underline.foregroundColor else { return }
+
+        output.enumerateAttributes(in: range, options: []) { attributes, subrange, _ in
+            guard !RenderContext.shouldPreserveColors(attributes) else { return }
+
+            let currentColor = attributes[.foregroundColor] as? UIColor
+            if currentColor != underlineColor {
+                output.addAttribute(.foregroundColor, value: underlineColor, range: subrange)
+            }
+        }
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/DefaultMarkdownTheme.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/DefaultMarkdownTheme.swift
@@ -51,6 +51,8 @@ enum DefaultMarkdownTheme {
 
             Strong()
             Emphasis()
+            Strikethrough()
+            Underline()
 
             Code()
                 .fontDesign(.monospaced)

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/Elements/Strikethrough.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/Elements/Strikethrough.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+public struct Strikethrough: MarkdownThemeElement {
+    public var fontSpec: ThemeFontSpec?
+    public var fontWeight: Font.Weight?
+    public var fontDesign: Font.Design?
+    public var foregroundColorSpec: ThemeColorSpec?
+    public var marginTop: CGFloat?
+    public var marginBottom: CGFloat?
+    public var lineHeight: CGFloat?
+    public var textAlignment: TextAlignment?
+
+    public init() {}
+
+    public func apply(to config: inout MarkdownStyleConfig, traitCollection: UITraitCollection) {
+        applyElementStyle(to: &config.strikethrough, traitCollection: traitCollection)
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/Elements/Underline.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/Elements/Underline.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+public struct Underline: MarkdownThemeElement {
+    public var fontSpec: ThemeFontSpec?
+    public var fontWeight: Font.Weight?
+    public var fontDesign: Font.Design?
+    public var foregroundColorSpec: ThemeColorSpec?
+    public var marginTop: CGFloat?
+    public var marginBottom: CGFloat?
+    public var lineHeight: CGFloat?
+    public var textAlignment: TextAlignment?
+
+    public init() {}
+
+    public func apply(to config: inout MarkdownStyleConfig, traitCollection: UITraitCollection) {
+        applyElementStyle(to: &config.underline, traitCollection: traitCollection)
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
@@ -267,6 +267,8 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
     public var link: ElementStyle
     public var strong: ElementStyle
     public var emphasis: ElementStyle
+    public var strikethrough: ElementStyle
+    public var underline: ElementStyle
     public var code: ElementStyle
     public var image: ImageStyle
     public var inlineImage: InlineImageStyle
@@ -286,6 +288,8 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         link: ElementStyle = ElementStyle(),
         strong: ElementStyle = ElementStyle(),
         emphasis: ElementStyle = ElementStyle(),
+        strikethrough: ElementStyle = ElementStyle(),
+        underline: ElementStyle = ElementStyle(),
         code: ElementStyle = ElementStyle(),
         image: ImageStyle = ImageStyle(),
         inlineImage: InlineImageStyle = InlineImageStyle(),
@@ -304,6 +308,8 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         self.link = link
         self.strong = strong
         self.emphasis = emphasis
+        self.strikethrough = strikethrough
+        self.underline = underline
         self.code = code
         self.image = image
         self.inlineImage = inlineImage
@@ -324,6 +330,8 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         link.merge(other.link)
         strong.merge(other.strong)
         emphasis.merge(other.emphasis)
+        strikethrough.merge(other.strikethrough)
+        underline.merge(other.underline)
         code.merge(other.code)
         image.merge(other.image)
         inlineImage.merge(other.inlineImage)

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -3,6 +3,7 @@ import UIKit
 
 public struct EnrichedMarkdownText: View {
     private let markdown: String
+    private let flags: Md4cFlags
 
     @Environment(\.markdownThemeLayers) private var themeLayers
     @Environment(\.colorScheme) private var colorScheme
@@ -10,8 +11,9 @@ public struct EnrichedMarkdownText: View {
     @Environment(\.markdownLinkPressHandler) private var onLinkPress
     @StateObject private var renderStore = MarkdownRenderStore()
 
-    public init(_ markdown: String) {
+    public init(_ markdown: String, flags: Md4cFlags = .commonMark) {
         self.markdown = markdown
+        self.flags = flags
     }
 
     private var styleConfig: MarkdownStyleConfig {
@@ -30,13 +32,16 @@ public struct EnrichedMarkdownText: View {
         )
         .fixedSize(horizontal: false, vertical: true)
         .onAppear {
-            renderStore.schedule(markdown: markdown, config: styleConfig)
+            renderStore.schedule(markdown: markdown, config: styleConfig, flags: flags)
         }
         .onChange(of: markdown) { newValue in
-            renderStore.schedule(markdown: newValue, config: styleConfig)
+            renderStore.schedule(markdown: newValue, config: styleConfig, flags: flags)
         }
         .onChange(of: styleConfig) { newValue in
-            renderStore.schedule(markdown: markdown, config: newValue)
+            renderStore.schedule(markdown: markdown, config: newValue, flags: flags)
+        }
+        .onChange(of: flags) { newValue in
+            renderStore.schedule(markdown: markdown, config: styleConfig, flags: newValue)
         }
         .onDisappear {
             renderStore.invalidate()

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/InlineStyleRendererTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/InlineStyleRendererTests.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+final class InlineStyleRendererTests: XCTestCase {
+    private var config: MarkdownStyleConfig!
+
+    override func setUp() {
+        super.setUp()
+        config = MarkdownStyleConfig.baseline()
+    }
+
+    // MARK: - Strikethrough
+
+    func testStrikethroughAppliesStrikethroughStyle() {
+        let result = MarkdownRenderer.render("~~strike~~ plain", config: config)
+        XCTAssertTrue(result.string.contains("strike"))
+
+        assertLineStyle(.strikethroughStyle, in: result, onWord: "strike")
+        assertNoLineStyle(.strikethroughStyle, in: result, onWord: "plain")
+    }
+
+    func testStrikethroughColorOverride() {
+        var coloredConfig = config!
+        coloredConfig.strikethrough.foregroundColor = .systemRed
+
+        let result = MarkdownRenderer.render("~~strike~~", config: coloredConfig)
+
+        let range = rangeOfWord("strike", in: result)
+        let color = result.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? UIColor
+        XCTAssertEqual(color, .systemRed)
+    }
+
+    func testStrikethroughPreservesBoldTrait() {
+        let result = MarkdownRenderer.render("~~**both**~~", config: config)
+
+        let range = rangeOfWord("both", in: result)
+        let font = result.attribute(.font, at: range.location, effectiveRange: nil) as? UIFont
+        XCTAssertNotNil(font)
+        XCTAssertTrue(font?.fontDescriptor.symbolicTraits.contains(.traitBold) == true)
+        assertLineStyle(.strikethroughStyle, in: result, onWord: "both")
+    }
+
+    // MARK: - Underline
+
+    func testUnderscoreIsEmphasisWithoutUnderlineFlag() {
+        let result = MarkdownRenderer.render("_italic_", config: config)
+
+        let range = rangeOfWord("italic", in: result)
+        let font = result.attribute(.font, at: range.location, effectiveRange: nil) as? UIFont
+        XCTAssertTrue(font?.fontDescriptor.symbolicTraits.contains(.traitItalic) == true)
+        assertNoLineStyle(.underlineStyle, in: result, onWord: "italic")
+    }
+
+    func testUnderscoreRendersUnderlineWithFlag() {
+        let flags = Md4cFlags(underline: true)
+        let result = MarkdownRenderer.render("_under_", config: config, flags: flags)
+
+        let range = rangeOfWord("under", in: result)
+        let font = result.attribute(.font, at: range.location, effectiveRange: nil) as? UIFont
+        XCTAssertFalse(font?.fontDescriptor.symbolicTraits.contains(.traitItalic) == true)
+        assertLineStyle(.underlineStyle, in: result, onWord: "under")
+    }
+
+    func testDoubleUnderscoreRendersUnderlineNotBoldWithFlag() {
+        let flags = Md4cFlags(underline: true)
+        let result = MarkdownRenderer.render("__under__", config: config, flags: flags)
+
+        let range = rangeOfWord("under", in: result)
+        let font = result.attribute(.font, at: range.location, effectiveRange: nil) as? UIFont
+        XCTAssertFalse(font?.fontDescriptor.symbolicTraits.contains(.traitBold) == true)
+        assertLineStyle(.underlineStyle, in: result, onWord: "under")
+    }
+
+    func testParserEmitsUnderlineNodeOnlyWithFlag() {
+        let withFlag = Parser.shared.parseMarkdown("_under_", flags: Md4cFlags(underline: true))
+        XCTAssertNotNil(withFlag.first(ofType: .underline))
+        XCTAssertNil(withFlag.first(ofType: .emphasis))
+
+        let withoutFlag = Parser.shared.parseMarkdown("_under_")
+        XCTAssertNil(withoutFlag.first(ofType: .underline))
+        XCTAssertNotNil(withoutFlag.first(ofType: .emphasis))
+    }
+
+    // MARK: - Theme resolution
+
+    func testStrikethroughAndUnderlineThemeElementsResolve() {
+        let theme = MarkdownTheme {
+            Strikethrough()
+                .foregroundStyle(Color.red)
+            Underline()
+                .foregroundStyle(Color.blue)
+        }
+        let resolved = MarkdownStyleConfig.resolve(layers: [theme], traitCollection: .current)
+
+        XCTAssertNotNil(resolved.strikethrough.foregroundColor)
+        XCTAssertNotNil(resolved.underline.foregroundColor)
+    }
+
+    // MARK: - Helpers
+
+    private func rangeOfWord(_ word: String, in attributed: NSAttributedString) -> NSRange {
+        let range = (attributed.string as NSString).range(of: word)
+        XCTAssertNotEqual(range.location, NSNotFound, "expected '\(word)' in rendered output")
+        return range
+    }
+
+    private func assertLineStyle(
+        _ key: NSAttributedString.Key,
+        in attributed: NSAttributedString,
+        onWord word: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let range = rangeOfWord(word, in: attributed)
+        let value = attributed.attribute(key, at: range.location, effectiveRange: nil) as? Int
+        XCTAssertEqual(value, NSUnderlineStyle.single.rawValue, file: file, line: line)
+    }
+
+    private func assertNoLineStyle(
+        _ key: NSAttributedString.Key,
+        in attributed: NSAttributedString,
+        onWord word: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let range = rangeOfWord(word, in: attributed)
+        let value = attributed.attribute(key, at: range.location, effectiveRange: nil) as? Int
+        XCTAssertTrue(value == nil || value == 0, file: file, line: line)
+    }
+}


### PR DESCRIPTION
### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

