### PR TITLE
fix(android): commit font scaling settings to measurement store

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -137,6 +137,7 @@ class EnrichedMarkdown
 
     fun commitProps() {
       MeasurementStore.updateStreamingTableMode(id, tableStreamingMode)
+      MeasurementStore.updateFontScalingSettings(id, allowFontScaling, maxFontSizeMultiplier)
       if (renderPending) {
         renderPending = false
         scheduleRenderIfNeeded()

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -82,6 +82,7 @@ class EnrichedMarkdownManager :
     MeasurementStore.release(view.id)
     MeasurementStore.clearStreamingTableMode(view.id)
     MeasurementStore.clearBreakStrategy(view.id)
+    MeasurementStore.clearFontScalingSettings(view.id)
   }
 
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> = markdownEventTypeConstants()


### PR DESCRIPTION
### What/Why?

Fixes incorrect text measurement on Android when `allowFontScaling={false}` is set and the system font size is non-default.

`setAllowFontScaling()` registers the value in `MeasurementStore` by view ID, but runs before the React tag is assigned (`id = -1`). The measurement thread looks up the real ID, misses, and defaults to `allowFontScaling = true` — applying font scaling to the measurement while the view renders without it, causing height mismatch and overlapping text.

Fix: re-register font scaling settings in `commitProps()`, which runs after the view ID is assigned. iOS is not affected (reads the prop directly from the C++ props struct).

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

