### PR TITLE
feat: add `hardSoftBreaks` md4cFlags option

### DIFF
--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/props/Md4cFlags.stories.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/props/Md4cFlags.stories.tsx
@@ -13,6 +13,7 @@ type Md4cFlagsStoryExtra = {
   subscript: boolean;
   highlight: boolean;
   latexMath: boolean;
+  hardSoftBreaks: boolean;
   flavor: MarkdownFlavor;
 };
 
@@ -24,7 +25,11 @@ text~subscript~
 
 ==highlight==
 
-$E = mc^2$`;
+$E = mc^2$
+
+Line one
+Line two
+Line three`;
 
 const argTypes = {
   underline: {
@@ -49,6 +54,11 @@ const argTypes = {
     control: 'boolean',
     description: 'md4cFlags.latexMath — $...$ and $$...$$ math parsing.',
   },
+  hardSoftBreaks: {
+    control: 'boolean',
+    description:
+      'md4cFlags.hardSoftBreaks — treat single newlines as hard line breaks.',
+  },
   ...githubFlavorArgTypes('LaTeX math requires flavor="github".'),
 };
 
@@ -63,6 +73,7 @@ export const Default: TextStory<Md4cFlagsStoryExtra> = {
     subscript: true,
     highlight: true,
     latexMath: true,
+    hardSoftBreaks: false,
     flavor: 'github',
   },
   argTypes,
@@ -72,13 +83,21 @@ export const Default: TextStory<Md4cFlagsStoryExtra> = {
     subscript,
     highlight,
     latexMath,
+    hardSoftBreaks,
     ...args
   }) => (
     <EnrichedMarkdownTextStory
       title="Md4c-Flags"
       description="Cross-cutting md4cFlags demo. Individual inline/block stories also expose the minimum flag each syntax needs."
       {...args}
-      md4cFlags={{ underline, superscript, subscript, highlight, latexMath }}
+      md4cFlags={{
+        underline,
+        superscript,
+        subscript,
+        highlight,
+        latexMath,
+        hardSoftBreaks,
+      }}
     />
   ),
 };

--- a/apps/react-native-example/ios/Podfile.lock
+++ b/apps/react-native-example/ios/Podfile.lock
@@ -2557,7 +2557,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EnrichedMarkdownCore: 33ec2bafbc265cfe76df3095fb21522440dd0a30
+  EnrichedMarkdownCore: 35aa4b07e4f23204609527c0e2440bbded65f23d
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
   hermes-engine: 4a0ceceb51f483aef72bfeb288e965aff6defa54
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
@@ -2634,7 +2634,7 @@ SPEC CHECKSUMS:
   ReactCodegen: cd296de5e1c422deebafff34134d1721b5c29704
   ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
-  ReactNativeEnrichedMarkdown: 8fdbb85501737cd593fb175119b5cdac14f559a7
+  ReactNativeEnrichedMarkdown: ce3cfb1d3b552afdfda70c226fe3e2e58ff35e52
   RNCAsyncStorage: 7d913885caaae13f5fb62dd0bd04c674ea8bf97b
   RNDateTimePicker: afe0288e6c7855994f7f2617b7b2c05799fea7f3
   RNGestureHandler: 7b07d9192bc65c6883fb37fdecc05dc6b61c814f
@@ -2644,6 +2644,6 @@ SPEC CHECKSUMS:
   RNWorklets: ae7f2b95d75b903387e6359583f2fd67bc9a93ff
   Yoga: c30c859b7e9b75e547b600b486fe33165f60de00
 
-PODFILE CHECKSUM: 306ff178f59196793233813f74f8b3930c3ac6ed
+PODFILE CHECKSUM: ef24009d29b47aa09e94351250ad7451d534a441
 
 COCOAPODS: 1.16.2

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -127,7 +127,7 @@ Configuration for md4c parser extension flags.
 
 | Type          | Default Value            | Platform |
 | ------------- | ------------------------ | -------- |
-| `Md4cFlags`   | `{ underline: false, superscript: false, subscript: false, highlight: false, latexMath: true }` | Both |
+| `Md4cFlags`   | `{ underline: false, superscript: false, subscript: false, highlight: false, latexMath: true, hardSoftBreaks: false }` | Both |
 
 **Properties:**
 
@@ -136,6 +136,7 @@ Configuration for md4c parser extension flags.
 - **`subscript`**: When `true`, parses `~text~` as subscript. When disabled, single and double tildes remain strikethrough markers. Visual appearance can be tuned with the `subscript` style prop — see [Subscript-specific](./STYLES.md#subscript-specific).
 - **`highlight`**: When `true`, parses `==text==` as highlighted spans. When disabled, double equals signs are treated as plain text. Visual appearance can be tuned with the `highlight` style prop — see [Highlight-specific](./STYLES.md#highlight-specific).
 - **`latexMath`**: When `true`, parses `$...$` and `$$...$$` as LaTeX math spans.
+- **`hardSoftBreaks`**: When `true`, treats single newlines (soft breaks) as hard breaks, rendering them as visible line breaks instead of collapsing them to spaces. Useful when displaying content authored in `EnrichedMarkdownTextInput`, where pressing Enter produces a single newline. See [Line Breaks](./ELEMENTS_STRUCTURE.md#line-breaks) for details.
 
 **Example:**
 
@@ -149,6 +150,12 @@ Configuration for md4c parser extension flags.
 <EnrichedMarkdownText
   markdown="This is _underlined_ and *italic* text"
   md4cFlags={{ underline: true }}
+/>
+
+// Preserve single newlines as visible line breaks
+<EnrichedMarkdownText
+  markdown={markdownFromInput}
+  md4cFlags={{ hardSoftBreaks: true }}
 />
 ```
 

--- a/docs/ELEMENTS_STRUCTURE.md
+++ b/docs/ELEMENTS_STRUCTURE.md
@@ -112,7 +112,7 @@ Inline elements modify text within blocks and apply additional styling on top of
 
 ## Line Breaks
 
-Newlines follow standard CommonMark semantics:
+Newlines follow standard CommonMark semantics by default:
 
 - **Blank line**: Starts a new paragraph.
 - **Single newline (soft break)**: Renders as a space — consecutive lines flow together into one wrapped paragraph, matching how GitHub and other CommonMark renderers display Markdown.
@@ -128,6 +128,19 @@ Two trailing spaces
 or a trailing backslash\
 force a line break within the paragraph.
 ```
+
+### Preserving single newlines
+
+When displaying content authored in `EnrichedMarkdownTextInput`, pressing Enter produces a single newline in the serialized markdown. By default, `EnrichedMarkdownText` collapses these to spaces (per CommonMark). To preserve them as visible line breaks, enable the `hardSoftBreaks` flag:
+
+```tsx
+<EnrichedMarkdownText
+  markdown={markdownFromInput}
+  md4cFlags={{ hardSoftBreaks: true }}
+/>
+```
+
+This forces the parser to treat every soft break as a hard break, so single newlines render as line breaks on all platforms.
 
 ## Images: Block vs Inline
 

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -11,7 +11,7 @@ All core `EnrichedMarkdownText` features are supported on web, including:
 - Full GFM: tables (with horizontal scroll), task lists (with checkbox interaction), strikethrough, links, images (block and inline), code blocks, LaTeX math (block and inline)
 - All `markdownStyle` customisation options
 - `onLinkPress`, `onLinkLongPress` (mapped to `contextmenu` event), `onTaskListItemPress` callbacks
-- `allowTrailingMargin`, `containerStyle`, `selectable`, `selectionColor`, `md4cFlags` (`underline`, `superscript`, `subscript`, `latexMath`)
+- `allowTrailingMargin`, `containerStyle`, `selectable`, `selectionColor`, `md4cFlags` (`underline`, `superscript`, `subscript`, `latexMath`, `highlight`, `hardSoftBreaks`)
 - RTL support via the `dir` prop (CSS logical properties automatically flip blockquote borders, list indentation, etc.)
 
 ### Accessibility

--- a/packages/android-enriched-markdown/parser/src/main/cpp/jni/ParserJni.cpp
+++ b/packages/android-enriched-markdown/parser/src/main/cpp/jni/ParserJni.cpp
@@ -68,6 +68,7 @@ Md4cFlags JMd4cFlags::toCppFlags() const {
   static const auto subscriptField = javaClassStatic()->getField<jboolean>("subscript");
   static const auto highlightField = javaClassStatic()->getField<jboolean>("highlight");
   static const auto permissiveAutolinksField = javaClassStatic()->getField<jboolean>("permissiveAutolinks");
+  static const auto hardSoftBreaksField = javaClassStatic()->getField<jboolean>("hardSoftBreaks");
 
   Md4cFlags flags;
   flags.underline = getFieldValue(underlineField) == JNI_TRUE;
@@ -76,6 +77,7 @@ Md4cFlags JMd4cFlags::toCppFlags() const {
   flags.subscript = getFieldValue(subscriptField) == JNI_TRUE;
   flags.highlight = getFieldValue(highlightField) == JNI_TRUE;
   flags.permissiveAutolinks = getFieldValue(permissiveAutolinksField) == JNI_TRUE;
+  flags.hardSoftBreaks = getFieldValue(hardSoftBreaksField) == JNI_TRUE;
   return flags;
 }
 

--- a/packages/android-enriched-markdown/parser/src/main/java/com/swmansion/enriched/markdown/parser/Parser.kt
+++ b/packages/android-enriched-markdown/parser/src/main/java/com/swmansion/enriched/markdown/parser/Parser.kt
@@ -9,6 +9,7 @@ data class Md4cFlags(
   val subscript: Boolean = false,
   val highlight: Boolean = false,
   val permissiveAutolinks: Boolean = true,
+  val hardSoftBreaks: Boolean = false,
 ) {
   companion object {
     val DEFAULT = Md4cFlags()

--- a/packages/core/cpp/parser/MD4CParser.cpp
+++ b/packages/core/cpp/parser/MD4CParser.cpp
@@ -608,6 +608,9 @@ std::shared_ptr<MarkdownASTNode> MD4CParser::parse(const std::string &markdown, 
   if (md4cFlags.highlight) {
     flags |= MD_FLAG_HIGHLIGHT;
   }
+  if (md4cFlags.hardSoftBreaks) {
+    flags |= MD_FLAG_HARD_SOFT_BREAKS;
+  }
 
   // Configure MD4C parser with callbacks
   MD_PARSER parser = {

--- a/packages/core/cpp/parser/MD4CParser.hpp
+++ b/packages/core/cpp/parser/MD4CParser.hpp
@@ -13,6 +13,7 @@ struct Md4cFlags {
     bool subscript = false;
     bool highlight = false;
     bool permissiveAutolinks = true;
+    bool hardSoftBreaks = false;
 };
 
 class MD4CParser {

--- a/packages/core/cpp/wasm/md4c_wasm.cpp
+++ b/packages/core/cpp/wasm/md4c_wasm.cpp
@@ -18,10 +18,11 @@ extern "C" {
  * @param superscript 1 → enable ^superscript^ spans; 0 → disable.
  * @param subscript  1 → enable ~subscript~ spans; 0 → disable.
  * @param highlight  1 → enable ==highlight== spans; 0 → disable.
+ * @param hardSoftBreaks 1 → treat soft breaks as hard breaks; 0 → collapse to space.
  * @return           Null-terminated UTF-8 JSON string, valid until the next call.
  */
 const char *parseMarkdown(const char *markdown, int underline, int latexMath, int superscript, int subscript,
-                          int highlight) {
+                          int highlight, int hardSoftBreaks) {
   if (!markdown) {
     g_resultBuffer = "{\"type\":\"Document\"}";
     return g_resultBuffer.c_str();
@@ -33,6 +34,7 @@ const char *parseMarkdown(const char *markdown, int underline, int latexMath, in
   flags.superscript = (superscript != 0);
   flags.subscript = (subscript != 0);
   flags.highlight = (highlight != 0);
+  flags.hardSoftBreaks = (hardSoftBreaks != 0);
 
   Markdown::MD4CParser parser;
   auto root = parser.parse(std::string(markdown), flags);

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Parser/MarkdownParserBridge.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Parser/MarkdownParserBridge.swift
@@ -15,6 +15,7 @@ enum MarkdownParserBridge {
                 flags.superscript ? 1 : 0,
                 flags.subscript ? 1 : 0,
                 flags.highlight ? 1 : 0,
+                flags.hardSoftBreaks ? 1 : 0,
                 flags.permissiveAutolinks ? 1 : 0
             ) else {
                 return MarkdownASTNode(type: .document)

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Parser/Md4cFlags.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Parser/Md4cFlags.swift
@@ -4,6 +4,7 @@ public struct Md4cFlags: Sendable, Equatable {
     public var superscript: Bool
     public var `subscript`: Bool
     public var highlight: Bool
+    public var hardSoftBreaks: Bool
     public var permissiveAutolinks: Bool
 
     public init(
@@ -12,6 +13,7 @@ public struct Md4cFlags: Sendable, Equatable {
         superscript: Bool = false,
         subscript subscriptEnabled: Bool = false,
         highlight: Bool = false,
+        hardSoftBreaks: Bool = false,
         permissiveAutolinks: Bool = true
     ) {
         self.underline = underline
@@ -19,6 +21,7 @@ public struct Md4cFlags: Sendable, Equatable {
         self.superscript = superscript
         self.subscript = subscriptEnabled
         self.highlight = highlight
+        self.hardSoftBreaks = hardSoftBreaks
         self.permissiveAutolinks = permissiveAutolinks
     }
 

--- a/packages/ios-enriched-markdown/cpp/SwiftParserCAPI.h
+++ b/packages/ios-enriched-markdown/cpp/SwiftParserCAPI.h
@@ -9,7 +9,7 @@ extern "C" {
 typedef struct EMCParseResult EMCParseResult;
 
 EMCParseResult *em_parse_markdown(const char *markdown, int underline, int latexMath, int superscript, int subscript,
-                                  int highlight, int permissiveAutolinks);
+                                  int highlight, int hardSoftBreaks, int permissiveAutolinks);
 
 void em_parse_result_release(EMCParseResult *result);
 

--- a/packages/ios-enriched-markdown/cpp/SwiftParserShim.cpp
+++ b/packages/ios-enriched-markdown/cpp/SwiftParserShim.cpp
@@ -29,7 +29,7 @@ const Markdown::MarkdownASTNode *asNode(const void *node) {
 extern "C" {
 
 EMCParseResult *em_parse_markdown(const char *markdown, int underline, int latexMath, int superscript, int subscript,
-                                  int highlight, int permissiveAutolinks) {
+                                  int highlight, int hardSoftBreaks, int permissiveAutolinks) {
   auto *result = new (std::nothrow) EMCParseResult();
   if (!result) {
     return nullptr;
@@ -41,6 +41,7 @@ EMCParseResult *em_parse_markdown(const char *markdown, int underline, int latex
   flags.superscript = superscript != 0;
   flags.subscript = subscript != 0;
   flags.highlight = highlight != 0;
+  flags.hardSoftBreaks = hardSoftBreaks != 0;
   flags.permissiveAutolinks = permissiveAutolinks != 0;
 
   Markdown::MD4CParser parser;

--- a/packages/react-native-enriched-markdown/android/src/main/cpp/jni-adapter.cpp
+++ b/packages/react-native-enriched-markdown/android/src/main/cpp/jni-adapter.cpp
@@ -233,6 +233,10 @@ JNIEXPORT jobject JNICALL Java_com_swmansion_enriched_markdown_parser_Parser_nat
         if (permissiveAutolinksField) {
           md4cFlags.permissiveAutolinks = env->GetBooleanField(flags, permissiveAutolinksField) == JNI_TRUE;
         }
+        jfieldID hardSoftBreaksField = env->GetFieldID(flagsClass, "hardSoftBreaks", "Z");
+        if (hardSoftBreaksField) {
+          md4cFlags.hardSoftBreaks = env->GetBooleanField(flags, hardSoftBreaksField) == JNI_TRUE;
+        }
         env->DeleteLocalRef(flagsClass);
       }
     }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -305,6 +305,7 @@ object MeasurementStore {
         superscript = props.getMapOrNull("md4cFlags").getBooleanOrDefault("superscript", false),
         subscript = props.getMapOrNull("md4cFlags").getBooleanOrDefault("subscript", false),
         highlight = props.getMapOrNull("md4cFlags").getBooleanOrDefault("highlight", false),
+        hardSoftBreaks = props.getMapOrNull("md4cFlags").getBooleanOrDefault("hardSoftBreaks", false),
       )
 
     val fontSize = getInitialFontSize(styleMap, context, allowFontScaling, fontScale, maxFontSizeMultiplier)
@@ -387,6 +388,7 @@ object MeasurementStore {
         superscript = props.getMapOrNull("md4cFlags").getBooleanOrDefault("superscript", false),
         subscript = props.getMapOrNull("md4cFlags").getBooleanOrDefault("subscript", false),
         highlight = props.getMapOrNull("md4cFlags").getBooleanOrDefault("highlight", false),
+        hardSoftBreaks = props.getMapOrNull("md4cFlags").getBooleanOrDefault("hardSoftBreaks", false),
       )
     val allowTrailingMargin = props.getBooleanOrDefault("allowTrailingMargin", false)
     val fontSize = getInitialFontSize(styleMap, context, allowFontScaling, fontScale, maxFontSizeMultiplier)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/parser/Parser.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/parser/Parser.kt
@@ -10,6 +10,7 @@ data class Md4cFlags(
   val subscript: Boolean = false,
   val highlight: Boolean = false,
   val permissiveAutolinks: Boolean = true,
+  val hardSoftBreaks: Boolean = false,
 ) {
   companion object {
     val DEFAULT = Md4cFlags()

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MarkdownViewManagerUtils.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MarkdownViewManagerUtils.kt
@@ -87,6 +87,7 @@ fun parseMd4cFlags(flags: ReadableMap?): Md4cFlags =
     superscript = flags?.getBoolean("superscript") ?: false,
     subscript = flags?.getBoolean("subscript") ?: false,
     highlight = flags?.getBoolean("highlight") ?: false,
+    hardSoftBreaks = flags?.getBoolean("hardSoftBreaks") ?: false,
   )
 
 fun parseContextMenuItems(value: ReadableArray?): List<String> =

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -137,6 +137,7 @@ static char kENRMSegmentFadeAnimatorKey;
   flags.subscript = props.subscript;
   flags.latexMath = props.latexMath;
   flags.highlight = props.highlight;
+  flags.hardSoftBreaks = props.hardSoftBreaks;
   return flags;
 }
 
@@ -913,7 +914,8 @@ static char kENRMSegmentFadeAnimatorKey;
       newViewProps.md4cFlags.superscript != oldViewProps.md4cFlags.superscript ||
       newViewProps.md4cFlags.subscript != oldViewProps.md4cFlags.subscript ||
       newViewProps.md4cFlags.latexMath != oldViewProps.md4cFlags.latexMath ||
-      newViewProps.md4cFlags.highlight != oldViewProps.md4cFlags.highlight) {
+      newViewProps.md4cFlags.highlight != oldViewProps.md4cFlags.highlight ||
+      newViewProps.md4cFlags.hardSoftBreaks != oldViewProps.md4cFlags.hardSoftBreaks) {
     _md4cFlags = [EnrichedMarkdown flagsFromProps:newViewProps.md4cFlags];
     _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
   }

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -130,6 +130,7 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   flags.subscript = props.subscript;
   flags.latexMath = props.latexMath;
   flags.highlight = props.highlight;
+  flags.hardSoftBreaks = props.hardSoftBreaks;
   return flags;
 }
 
@@ -552,7 +553,8 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
       newViewProps.md4cFlags.superscript != oldViewProps.md4cFlags.superscript ||
       newViewProps.md4cFlags.subscript != oldViewProps.md4cFlags.subscript ||
       newViewProps.md4cFlags.latexMath != oldViewProps.md4cFlags.latexMath ||
-      newViewProps.md4cFlags.highlight != oldViewProps.md4cFlags.highlight) {
+      newViewProps.md4cFlags.highlight != oldViewProps.md4cFlags.highlight ||
+      newViewProps.md4cFlags.hardSoftBreaks != oldViewProps.md4cFlags.hardSoftBreaks) {
     _md4cFlags = [EnrichedMarkdownText flagsFromProps:newViewProps.md4cFlags];
     _forceHeightUpdateOnNextRender = YES;
     _dirtyFlags |= ENRMDirtyRender;

--- a/packages/react-native-enriched-markdown/ios/internals/ENRMViewFreeMeasurement.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ENRMViewFreeMeasurement.h
@@ -86,6 +86,7 @@ template <typename Md4cFlagsT> static inline ENRMMd4cFlags *ENRMMd4cFlagsFromPro
   flags.subscript = props.subscript;
   flags.latexMath = props.latexMath;
   flags.highlight = props.highlight;
+  flags.hardSoftBreaks = props.hardSoftBreaks;
   return flags;
 }
 

--- a/packages/react-native-enriched-markdown/ios/internals/MeasurementCache.h
+++ b/packages/react-native-enriched-markdown/ios/internals/MeasurementCache.h
@@ -40,6 +40,7 @@ struct MeasurementCacheKey {
   bool md4cFlagsSubscript;
   bool md4cFlagsHighlight;
   bool md4cFlagsLatexMath;
+  bool md4cFlagsHardSoftBreaks;
   size_t styleFingerprint;
   CGFloat fontScale;
   MarkdownFlavor flavor;
@@ -50,12 +51,13 @@ struct MeasurementCacheKey {
   {
     return std::tie(markdown, maxWidth, allowTrailingMargin, allowFontScaling, maxFontSizeMultiplier,
                     md4cFlagsUnderline, md4cFlagsSuperscript, md4cFlagsSubscript, md4cFlagsHighlight,
-                    md4cFlagsLatexMath, styleFingerprint, fontScale, flavor, lineBreakStrategyIOS, writingDirection) ==
+                    md4cFlagsLatexMath, md4cFlagsHardSoftBreaks, styleFingerprint, fontScale, flavor,
+                    lineBreakStrategyIOS, writingDirection) ==
            std::tie(other.markdown, other.maxWidth, other.allowTrailingMargin, other.allowFontScaling,
                     other.maxFontSizeMultiplier, other.md4cFlagsUnderline, other.md4cFlagsSuperscript,
                     other.md4cFlagsSubscript, other.md4cFlagsHighlight, other.md4cFlagsLatexMath,
-                    other.styleFingerprint, other.fontScale, other.flavor, other.lineBreakStrategyIOS,
-                    other.writingDirection);
+                    other.md4cFlagsHardSoftBreaks, other.styleFingerprint, other.fontScale, other.flavor,
+                    other.lineBreakStrategyIOS, other.writingDirection);
   }
 };
 
@@ -73,6 +75,7 @@ struct MeasurementCacheKeyHash {
     HashUtils::hash_one(h, key.md4cFlagsSubscript);
     HashUtils::hash_one(h, key.md4cFlagsHighlight);
     HashUtils::hash_one(h, key.md4cFlagsLatexMath);
+    HashUtils::hash_one(h, key.md4cFlagsHardSoftBreaks);
     HashUtils::hash_one(h, key.styleFingerprint);
     HashUtils::hash_one(h, key.fontScale);
     HashUtils::hash_one(h, static_cast<uint8_t>(key.flavor));
@@ -157,6 +160,7 @@ inline MeasurementCacheKey buildMeasurementCacheKey(const PropsType &props, CGFl
       .md4cFlagsSubscript = props.md4cFlags.subscript,
       .md4cFlagsHighlight = props.md4cFlags.highlight,
       .md4cFlagsLatexMath = props.md4cFlags.latexMath,
+      .md4cFlagsHardSoftBreaks = props.md4cFlags.hardSoftBreaks,
       .styleFingerprint = computeStyleFingerprint(props.markdownStyle),
       .fontScale = fontScale,
       .flavor = flavor,

--- a/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
@@ -67,6 +67,8 @@ static inline bool ENRMPropsNeedExactStreamingMeasurement(const PropsT &oldProps
          oldProps.md4cFlags.superscript != newProps.md4cFlags.superscript ||
          oldProps.md4cFlags.subscript != newProps.md4cFlags.subscript ||
          oldProps.md4cFlags.latexMath != newProps.md4cFlags.latexMath ||
+         oldProps.md4cFlags.highlight != newProps.md4cFlags.highlight ||
+         oldProps.md4cFlags.hardSoftBreaks != newProps.md4cFlags.hardSoftBreaks ||
          computeStyleFingerprint(oldProps.markdownStyle) != computeStyleFingerprint(newProps.markdownStyle);
 }
 

--- a/packages/react-native-enriched-markdown/ios/parser/ENRMMarkdownParser.h
+++ b/packages/react-native-enriched-markdown/ios/parser/ENRMMarkdownParser.h
@@ -8,6 +8,7 @@
 @property (nonatomic, assign) BOOL superscript;
 @property (nonatomic, assign) BOOL subscript;
 @property (nonatomic, assign) BOOL highlight;
+@property (nonatomic, assign) BOOL hardSoftBreaks;
 
 + (instancetype)defaultFlags;
 

--- a/packages/react-native-enriched-markdown/ios/parser/ENRMMarkdownParser.mm
+++ b/packages/react-native-enriched-markdown/ios/parser/ENRMMarkdownParser.mm
@@ -13,6 +13,7 @@ extern MarkdownASTNode *parseMarkdownWithCppParser(NSString *markdown, ENRMMd4cF
     _superscript = NO;
     _subscript = NO;
     _highlight = NO;
+    _hardSoftBreaks = NO;
   }
   return self;
 }
@@ -30,6 +31,7 @@ extern MarkdownASTNode *parseMarkdownWithCppParser(NSString *markdown, ENRMMd4cF
   copy.superscript = self.superscript;
   copy.subscript = self.subscript;
   copy.highlight = self.highlight;
+  copy.hardSoftBreaks = self.hardSoftBreaks;
   return copy;
 }
 

--- a/packages/react-native-enriched-markdown/ios/parser/MarkdownParserBridge.mm
+++ b/packages/react-native-enriched-markdown/ios/parser/MarkdownParserBridge.mm
@@ -155,6 +155,7 @@ MarkdownASTNode *parseMarkdownWithCppParser(NSString *markdown, ENRMMd4cFlags *f
   cppFlags.superscript = flags.superscript;
   cppFlags.subscript = flags.subscript;
   cppFlags.highlight = flags.highlight;
+  cppFlags.hardSoftBreaks = flags.hardSoftBreaks;
 
   Markdown::MD4CParser parser;
   auto cppAST = parser.parse(cppMarkdown, cppFlags);

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
@@ -321,6 +321,11 @@ export interface Md4cFlagsInternal {
    * @default false
    */
   highlight: boolean;
+  /**
+   * Treat soft breaks (single newlines) as hard breaks (visible line breaks).
+   * @default false
+   */
+  hardSoftBreaks: boolean;
 }
 
 interface StreamingConfigInternal {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
@@ -322,6 +322,11 @@ export interface Md4cFlagsInternal {
    * @default false
    */
   highlight: boolean;
+  /**
+   * Treat soft breaks (single newlines) as hard breaks (visible line breaks).
+   * @default false
+   */
+  hardSoftBreaks: boolean;
 }
 
 interface StreamingConfigInternal {

--- a/packages/react-native-enriched-markdown/src/native/EnrichedMarkdownText.tsx
+++ b/packages/react-native-enriched-markdown/src/native/EnrichedMarkdownText.tsx
@@ -101,6 +101,7 @@ const defaultMd4cFlags: Md4cFlags = {
   subscript: false,
   latexMath: true,
   highlight: false,
+  hardSoftBreaks: false,
 };
 
 export const EnrichedMarkdownText = ({
@@ -147,6 +148,7 @@ export const EnrichedMarkdownText = ({
       subscript: md4cFlags.subscript ?? false,
       latexMath: md4cFlags.latexMath ?? true,
       highlight: md4cFlags.highlight ?? false,
+      hardSoftBreaks: md4cFlags.hardSoftBreaks ?? false,
     }),
     [md4cFlags]
   );

--- a/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownStyle.ts
@@ -364,4 +364,11 @@ export interface Md4cFlags {
    * @default false
    */
   highlight?: boolean;
+  /**
+   * Treat soft breaks (single newlines) as hard breaks (visible line breaks).
+   * When enabled, a single newline in the source renders as a line break
+   * instead of being collapsed to a space (CommonMark default).
+   * @default false
+   */
+  hardSoftBreaks?: boolean;
 }

--- a/packages/react-native-enriched-markdown/src/web/EnrichedMarkdownText.tsx
+++ b/packages/react-native-enriched-markdown/src/web/EnrichedMarkdownText.tsx
@@ -43,6 +43,7 @@ export const EnrichedMarkdownText = ({
     superscript = false,
     subscript = false,
     highlight = false,
+    hardSoftBreaks = false,
   } = md4cFlags;
 
   useEffect(() => {
@@ -57,6 +58,7 @@ export const EnrichedMarkdownText = ({
         superscript,
         subscript,
         highlight,
+        hardSoftBreaks,
       }),
       katexPromise,
     ])
@@ -85,7 +87,15 @@ export const EnrichedMarkdownText = ({
     return () => {
       cancelled = true;
     };
-  }, [markdown, underline, latexMath, superscript, subscript, highlight]);
+  }, [
+    markdown,
+    underline,
+    latexMath,
+    superscript,
+    subscript,
+    highlight,
+    hardSoftBreaks,
+  ]);
 
   const callbacks = useMemo<RendererCallbacks>(
     () => ({ onLinkPress, onLinkLongPress, onTaskListItemPress }),

--- a/packages/react-native-enriched-markdown/src/web/parseMarkdown.ts
+++ b/packages/react-native-enriched-markdown/src/web/parseMarkdown.ts
@@ -7,7 +7,8 @@ type ParseFn = (
   latexMath: number,
   superscript: number,
   subscript: number,
-  highlight: number
+  highlight: number,
+  hardSoftBreaks: number
 ) => string;
 
 // Caching the Promise (not the resolved value) means concurrent callers share
@@ -23,6 +24,7 @@ function initializeParser(): Promise<ParseFn> {
       .then((wasmModule) =>
         wasmModule.cwrap('parseMarkdown', 'string', [
           'string',
+          'number',
           'number',
           'number',
           'number',
@@ -55,6 +57,7 @@ export async function parseMarkdown(
     superscript = false,
     subscript = false,
     highlight = false,
+    hardSoftBreaks = false,
   }: Md4cFlags = {}
 ): Promise<ASTNode> {
   const parse = await initializeParser();
@@ -66,7 +69,8 @@ export async function parseMarkdown(
       latexMath ? 1 : 0,
       superscript ? 1 : 0,
       subscript ? 1 : 0,
-      highlight ? 1 : 0
+      highlight ? 1 : 0,
+      hardSoftBreaks ? 1 : 0
     )
   );
 


### PR DESCRIPTION
### What/Why?
Wire up md4c's `MD_FLAG_HARD_SOFT_BREAKS` so consumers can opt into treating single newlines (soft breaks) as visible line breaks instead of collapsing them to spaces per CommonMark defaults.

This is useful when displaying content authored in `EnrichedMarkdownTextInput`, where pressing Enter produces a single newline that would otherwise disappear in `EnrichedMarkdownText`.

Wired across all platforms: C++ core, iOS (RN + standalone Swift package), Android (RN + standalone package), Web/WASM, JS/TS types and codegen specs. Includes cache invalidation, streaming re-measure checks, documentation, and Storybook updates.

Closes #618

### Testing
<!-- How to test changed code? What testing has been done? -->

#### Screenshots

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/8fcf6f64-48ac-4774-9e3d-29c005338ecc" width=300 /> | <video src="https://github.com/user-attachments/assets/7c33be19-6ce7-43d7-b902-ffffbb9f87c9" width=300 /> |

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

