### PR TITLE
feat: add onCopyPress event for code block copy

### DIFF
--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/CodeBlock.stories.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/block/CodeBlock.stories.tsx
@@ -103,3 +103,29 @@ export const Default: TextStory<CodeBlockStyleControls> = {
     );
   },
 };
+
+export const CopyEvent: TextStory<CodeBlockStyleControls> = {
+  args: {
+    markdown: MARKDOWN,
+    flavor: 'github',
+    ...codeBlockStyledDefaults,
+  },
+  argTypes: {
+    ...argTypes,
+    onCopyPress: { action: 'onCopyPress' },
+  },
+  render: (args) => {
+    const { controls, rest } = splitStyleControls(
+      args,
+      codeBlockStyledDefaults
+    );
+    return (
+      <EnrichedMarkdownTextStory
+        title="Code Block — onCopyPress"
+        description="Tap the header copy button (or long-press → Copy) to fire onCopyPress with the code and language (Actions panel). Requires flavor=github."
+        {...rest}
+        style={{ codeBlock: toCodeBlockStyle(controls) }}
+      />
+    );
+  },
+};

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -77,6 +77,28 @@ Callback when a task list checkbox is tapped. Receives `index` (0-based), `check
 | ----------------------------------------------- | ------------- | -------- |
 | `(event: TaskListItemPressEvent) => void`      | -             | Both     |
 
+### `onCopyPress`
+
+Callback when code is copied from a fenced code block, via the header copy button, the long-press context-menu **Copy** action, or the VoiceOver copy action. Receives `code` (the copied code) and `language` (the fence language, or `""` if none). Does not fire for **Copy as Markdown**.
+
+Only fires when `flavor="github"` — the copy button is part of the GitHub flavor's code block renderer.
+
+| Type                                  | Default Value | Platform         |
+| ------------------------------------- | ------------- | ---------------- |
+| `(event: CopyPressEvent) => void`     | -             | Both, macOS      |
+
+**Example:**
+
+```tsx
+<EnrichedMarkdownText
+  flavor="github"
+  markdown={"```ts\nconst x = 1;\n```"}
+  onCopyPress={({ code, language }) => {
+    console.log(`Copied ${language} code:`, code);
+  }}
+/>
+```
+
 ### `enableLinkPreview`
 
 Controls the native link preview on long press (iOS only). Automatically set to `false` when `onLinkLongPress` is provided.

--- a/docs/CODE_HIGHLIGHT.md
+++ b/docs/CODE_HIGHLIGHT.md
@@ -41,8 +41,9 @@ code color.
 
 ## Copy button
 
-Each code block's header shows a copy button (and a long-press context menu with **Copy** /
-**Copy as Markdown**). To observe when a user copies code, pass
+With `flavor="github"`, each code block's header shows a copy button (and a long-press context
+menu with **Copy** / **Copy as Markdown**). The CommonMark flavor renders code blocks inline with
+no header, so it has no copy button. To observe when a user copies code, pass
 [`onCopyPress`](./API_REFERENCE.md#oncopypress) — it fires with the copied `code` and its
 `language` for the header button, the context-menu **Copy** action, and the VoiceOver copy action.
 The copy label shown to assistive technologies is configurable via

--- a/docs/CODE_HIGHLIGHT.md
+++ b/docs/CODE_HIGHLIGHT.md
@@ -39,6 +39,15 @@ Token colors are set through `codeBlock.syntaxColors`. The 14 token types are: `
 `variable`, `property`, `tag`, `attribute`, `embedded`. Any type left unset is drawn in the normal
 code color.
 
+## Copy button
+
+Each code block's header shows a copy button (and a long-press context menu with **Copy** /
+**Copy as Markdown**). To observe when a user copies code, pass
+[`onCopyPress`](./API_REFERENCE.md#oncopypress) — it fires with the copied `code` and its
+`language` for the header button, the context-menu **Copy** action, and the VoiceOver copy action.
+The copy label shown to assistive technologies is configurable via
+[`selectionMenuConfig`](./COPY_OPTIONS.md).
+
 ## Supported languages
 
 Fence info strings map to a grammar (for example `js`, `jsx` -> JavaScript). The **curated default

--- a/docs/COPY_OPTIONS.md
+++ b/docs/COPY_OPTIONS.md
@@ -97,7 +97,8 @@ Notes:
   and code block copy menus. The code block header's copy button also reuses
   the copy label for assistive technologies: it is the button's
   contentDescription on Android, and on iOS it names the VoiceOver custom
-  action that triggers the copy.
+  action that triggers the copy. To be notified when code is copied from a code
+  block, use the [`onCopyPress`](./API_REFERENCE.md#oncopypress) callback.
 - OS-provided actions (Look Up, Translate…) and the system **Cut / Paste /
   Select All** items are localized by the platform and are not affected by this
   config.

--- a/docs/COPY_OPTIONS.md
+++ b/docs/COPY_OPTIONS.md
@@ -94,8 +94,9 @@ Notes:
   required; any category left `undefined` falls back to it. The `{count}` token
   is replaced by the number of selected images.
 - The labels apply to the main text selection menu as well as the table, math,
-  and code block copy menus. The code block header's copy button also reuses
-  the copy label for assistive technologies: it is the button's
+  and code block copy menus. With `flavor="github"`, the code block header's copy
+  button also reuses the copy label for assistive technologies (the CommonMark
+  flavor renders code inline with no header button): it is the button's
   contentDescription on Android, and on iOS it names the VoiceOver custom
   action that triggers the copy. To be notified when code is copied from a code
   block, use the [`onCopyPress`](./API_REFERENCE.md#oncopypress) callback.

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -99,6 +99,7 @@ class EnrichedMarkdown
     private var onLinkPressCallback: ((String) -> Unit)? = null
     private var onLinkLongPressCallback: ((String) -> Unit)? = null
     private var onTaskListItemPressCallback: ((Int, Boolean, String) -> Unit)? = null
+    private var onCopyPressCallback: ((String, String) -> Unit)? = null
     private var contextMenuItemTexts: List<String> = emptyList()
     var onContextMenuItemPressCallback: ((itemText: String, selectedText: String, selectionStart: Int, selectionEnd: Int) -> Unit)? = null
     var spoilerOverlay: SpoilerOverlay = SpoilerOverlay.PARTICLES
@@ -239,6 +240,10 @@ class EnrichedMarkdown
 
     fun setOnTaskListItemPressCallback(callback: ((taskIndex: Int, checked: Boolean, itemText: String) -> Unit)?) {
       onTaskListItemPressCallback = callback
+    }
+
+    fun setOnCopyPressCallback(callback: ((code: String, language: String) -> Unit)?) {
+      onCopyPressCallback = callback
     }
 
     fun setContextMenuItems(items: List<String>) {
@@ -557,6 +562,9 @@ class EnrichedMarkdown
     ) = CodeBlockContainerView(context, style).apply {
       copyLabel = this@EnrichedMarkdown.selectionMenuConfig.copyLabel
       copyAsMarkdownLabel = this@EnrichedMarkdown.selectionMenuConfig.copyAsMarkdownLabel
+      onCopyPress = { code, language ->
+        this@EnrichedMarkdown.onCopyPressCallback?.invoke(code, language)
+      }
       applyCodeBlockNode(segment.node)
     }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -16,6 +16,7 @@ import com.facebook.yoga.YogaMeasureMode
 import com.swmansion.enriched.markdown.spoiler.SpoilerOverlay
 import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
 import com.swmansion.enriched.markdown.utils.common.emitContextMenuItemPress
+import com.swmansion.enriched.markdown.utils.common.emitCopyPress
 import com.swmansion.enriched.markdown.utils.common.emitLinkLongPress
 import com.swmansion.enriched.markdown.utils.common.emitLinkPress
 import com.swmansion.enriched.markdown.utils.common.emitTaskListItemPress
@@ -57,6 +58,10 @@ class EnrichedMarkdownManager :
       view.setMarkdownContent(updatedMarkdown)
       view.commitProps()
       emitTaskListItemPress(view, taskIndex, newChecked, itemText)
+    }
+
+    view.setOnCopyPressCallback { code, language ->
+      emitCopyPress(view, code, language)
     }
 
     return view

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/events/CopyPressEvent.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/events/CopyPressEvent.kt
@@ -1,0 +1,24 @@
+package com.swmansion.enriched.markdown.events
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class CopyPressEvent(
+  surfaceId: Int,
+  viewId: Int,
+  private val code: String,
+  private val language: String,
+) : Event<CopyPressEvent>(surfaceId, viewId) {
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap =
+    Arguments.createMap().apply {
+      putString("code", code)
+      putString("language", language)
+    }
+
+  companion object {
+    const val EVENT_NAME: String = "onCopyPress"
+  }
+}

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MarkdownViewManagerUtils.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/MarkdownViewManagerUtils.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.UIManagerHelper
 import com.swmansion.enriched.markdown.accessibility.AccessibilityLabels
 import com.swmansion.enriched.markdown.events.ContextMenuItemPressEvent
+import com.swmansion.enriched.markdown.events.CopyPressEvent
 import com.swmansion.enriched.markdown.events.LinkLongPressEvent
 import com.swmansion.enriched.markdown.events.LinkPressEvent
 import com.swmansion.enriched.markdown.events.TaskListItemPressEvent
@@ -19,6 +20,8 @@ fun markdownEventTypeConstants(): MutableMap<String, Any> {
     mapOf("registrationName" to LinkLongPressEvent.EVENT_NAME)
   map[TaskListItemPressEvent.EVENT_NAME] =
     mapOf("registrationName" to TaskListItemPressEvent.EVENT_NAME)
+  map[CopyPressEvent.EVENT_NAME] =
+    mapOf("registrationName" to CopyPressEvent.EVENT_NAME)
   map[ContextMenuItemPressEvent.EVENT_NAME] =
     mapOf("registrationName" to ContextMenuItemPressEvent.EVENT_NAME)
   return map
@@ -55,6 +58,19 @@ fun emitTaskListItemPress(
   val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.id)
   eventDispatcher?.dispatchEvent(
     TaskListItemPressEvent(surfaceId, view.id, taskIndex, checked, itemText),
+  )
+}
+
+fun emitCopyPress(
+  view: View,
+  code: String,
+  language: String,
+) {
+  val context = view.context as com.facebook.react.bridge.ReactContext
+  val surfaceId = UIManagerHelper.getSurfaceId(context)
+  val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, view.id)
+  eventDispatcher?.dispatchEvent(
+    CopyPressEvent(surfaceId, view.id, code, language),
   )
 }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/CodeBlockContainerView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/CodeBlockContainerView.kt
@@ -66,6 +66,8 @@ class CodeBlockContainerView(
     }
   var copyAsMarkdownLabel: String = ""
 
+  var onCopyPress: ((code: String, language: String) -> Unit)? = null
+
   private var code: String = ""
   private var language: String? = null
   private var fenceChar: String = "`"
@@ -237,6 +239,7 @@ class CodeBlockContainerView(
   private fun copyCode() {
     if (code.isEmpty()) return
     copyToClipboard(code)
+    onCopyPress?.invoke(code, language ?: "")
   }
 
   private fun copyFencedMarkdown() {

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -74,6 +74,7 @@ static char kENRMSegmentFadeAnimatorKey;
 - (void)emitLinkPress:(NSString *)url;
 - (void)emitLinkLongPress:(NSString *)url;
 - (void)emitTaskListItemPress:(NSInteger)index checked:(BOOL)checked text:(NSString *)text;
+- (void)emitCopyPress:(NSString *)code language:(NSString *)language;
 - (void)emitContextMenuItemPress:(NSString *)itemText
                     selectedText:(NSString *)selectedText
                   selectionStart:(NSUInteger)selectionStart
@@ -802,6 +803,14 @@ static char kENRMSegmentFadeAnimatorKey;
   ENRMCodeBlockContainerView *codeBlockView = [[ENRMCodeBlockContainerView alloc] initWithConfig:_config];
   codeBlockView.copyLabel = _selectionMenuLabels.copyLabel;
   codeBlockView.copyAsMarkdownLabel = _selectionMenuLabels.copyAsMarkdownLabel;
+
+  __weak EnrichedMarkdown *weakSelf = self;
+  codeBlockView.onCopyPress = ^(NSString *code, NSString *language) {
+    EnrichedMarkdown *strongSelf = weakSelf;
+    if (strongSelf)
+      [strongSelf emitCopyPress:code language:language];
+  };
+
   [codeBlockView applyCodeBlockNode:codeBlockSegment.codeBlockNode];
   return codeBlockView;
 }
@@ -1181,6 +1190,14 @@ Class<RCTComponentViewProtocol> EnrichedMarkdownCls(void)
   auto emitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(_eventEmitter);
   if (emitter)
     emitter->onTaskListItemPress({.index = (int)index, .checked = checked, .text = std::string(text.UTF8String ?: "")});
+}
+
+- (void)emitCopyPress:(NSString *)code language:(NSString *)language
+{
+  auto emitter = std::static_pointer_cast<EnrichedMarkdownEventEmitter const>(_eventEmitter);
+  if (emitter)
+    emitter->onCopyPress(
+        {.code = std::string(code.UTF8String ?: ""), .language = std::string(language.UTF8String ?: "")});
 }
 
 - (void)emitContextMenuItemPress:(NSString *)itemText

--- a/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.h
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.h
@@ -6,6 +6,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void (^ENRMCodeBlockCopyBlock)(NSString *code, NSString *language);
+
 @interface ENRMCodeBlockContainerView : RCTUIView
 
 - (instancetype)initWithConfig:(StyleConfig *)config;
@@ -24,6 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 // retained returns). Property names are unchanged so call sites stay the same.
 @property (nonatomic, copy, nullable, getter=menuCopyLabel) NSString *copyLabel;
 @property (nonatomic, copy, nullable, getter=menuCopyAsMarkdownLabel) NSString *copyAsMarkdownLabel;
+
+// Fired when the code is copied (header button, context-menu Copy, or the
+// VoiceOver copy action); set by the host to bridge up to the JS onCopyPress
+// event. Not fired for "Copy as Markdown".
+@property (nonatomic, copy, nullable) ENRMCodeBlockCopyBlock onCopyPress;
 
 @end
 

--- a/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
@@ -444,6 +444,9 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
 - (void)copyCodeToPasteboard
 {
   copyStringToPasteboard(_cachedCode);
+  if (self.onCopyPress) {
+    self.onCopyPress(_cachedCode ?: @"", _cachedLanguage ?: @"");
+  }
 }
 
 - (void)copyMarkdownToPasteboard

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
@@ -248,6 +248,11 @@ export interface TaskListItemPressEvent {
   text: string;
 }
 
+export interface CopyPressEvent {
+  code: string;
+  language: string;
+}
+
 export interface ContextMenuItemConfig {
   text: string;
   icon?: string;
@@ -378,6 +383,12 @@ export interface NativeProps extends ViewProps {
    * Receives the 0-based task index, current checked state, and the item's plain text.
    */
   onTaskListItemPress?: CodegenTypes.BubblingEventHandler<TaskListItemPressEvent>;
+  /**
+   * Callback fired when code is copied from a fenced code block's header copy
+   * button, its long-press context-menu "Copy" action, or the VoiceOver copy
+   * action. Receives the copied code and its language.
+   */
+  onCopyPress?: CodegenTypes.BubblingEventHandler<CopyPressEvent>;
   /**
    * Controls whether the system link preview is shown on long press (iOS only).
    *

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
@@ -249,6 +249,11 @@ export interface TaskListItemPressEvent {
   text: string;
 }
 
+export interface CopyPressEvent {
+  code: string;
+  language: string;
+}
+
 export interface ContextMenuItemConfig {
   text: string;
   icon?: string;
@@ -379,6 +384,12 @@ export interface NativeProps extends ViewProps {
    * Receives the 0-based task index, current checked state, and the item's plain text.
    */
   onTaskListItemPress?: CodegenTypes.BubblingEventHandler<TaskListItemPressEvent>;
+  /**
+   * Callback fired when code is copied from a fenced code block's header copy
+   * button, its long-press context-menu "Copy" action, or the VoiceOver copy
+   * action. Receives the copied code and its language.
+   */
+  onCopyPress?: CodegenTypes.BubblingEventHandler<CopyPressEvent>;
   /**
    * Controls whether the system link preview is shown on long press (iOS only).
    *

--- a/packages/react-native-enriched-markdown/src/index.tsx
+++ b/packages/react-native-enriched-markdown/src/index.tsx
@@ -12,6 +12,7 @@ export type {
   LinkPressEvent,
   LinkLongPressEvent,
   TaskListItemPressEvent,
+  CopyPressEvent,
 } from './types/events';
 export type {
   AccessibilityLabels,

--- a/packages/react-native-enriched-markdown/src/index.web.tsx
+++ b/packages/react-native-enriched-markdown/src/index.web.tsx
@@ -5,4 +5,5 @@ export type {
   LinkPressEvent,
   LinkLongPressEvent,
   TaskListItemPressEvent,
+  CopyPressEvent,
 } from './types/events';

--- a/packages/react-native-enriched-markdown/src/native/EnrichedMarkdownText.tsx
+++ b/packages/react-native-enriched-markdown/src/native/EnrichedMarkdownText.tsx
@@ -21,6 +21,7 @@ import type {
   LinkPressEvent,
   LinkLongPressEvent,
   TaskListItemPressEvent,
+  CopyPressEvent,
   OnContextMenuItemPressEvent,
 } from '../types/events';
 
@@ -32,7 +33,12 @@ export type {
   SelectionMenuConfig,
   SelectionMenuPluralLabels,
 };
-export type { LinkPressEvent, LinkLongPressEvent, TaskListItemPressEvent };
+export type {
+  LinkPressEvent,
+  LinkLongPressEvent,
+  TaskListItemPressEvent,
+  CopyPressEvent,
+};
 
 // Default English labels for the built-in selection menu actions. Defaults are
 // resolved here (JS-side) so the native code always receives a concrete string.
@@ -111,6 +117,7 @@ export const EnrichedMarkdownText = ({
   onLinkPress,
   onLinkLongPress,
   onTaskListItemPress,
+  onCopyPress,
   enableLinkPreview,
   selectable = true,
   md4cFlags = defaultMd4cFlags,
@@ -222,6 +229,14 @@ export const EnrichedMarkdownText = ({
     [onTaskListItemPress]
   );
 
+  const handleCopyPress = useCallback(
+    (e: NativeSyntheticEvent<CopyPressEvent>) => {
+      const { code, language } = e.nativeEvent;
+      onCopyPress?.({ code, language });
+    },
+    [onCopyPress]
+  );
+
   const tableMode = streamingConfig?.tableMode ?? 'progressive';
   const normalizedStreamingConfig = useMemo(() => ({ tableMode }), [tableMode]);
   const normalizedSelectionMenuConfig = useMemo(() => {
@@ -282,6 +297,7 @@ export const EnrichedMarkdownText = ({
     onLinkPress: handleLinkPress,
     onLinkLongPress: handleLinkLongPress,
     onTaskListItemPress: handleTaskListItemPress,
+    onCopyPress: handleCopyPress,
     enableLinkPreview: onLinkLongPress == null && (enableLinkPreview ?? true),
     selectable,
     md4cFlags: normalizedMd4cFlags,

--- a/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
@@ -5,6 +5,7 @@ import type {
   LinkPressEvent,
   LinkLongPressEvent,
   TaskListItemPressEvent,
+  CopyPressEvent,
 } from './events';
 
 /**
@@ -149,6 +150,17 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    * @platform ios, android, web
    */
   onTaskListItemPress?: (event: TaskListItemPressEvent) => void;
+  /**
+   * Callback fired when code is copied from a fenced code block, via the header
+   * copy button, the long-press context-menu "Copy" action, or the VoiceOver
+   * copy action. Receives the copied code and its language. Does not fire for
+   * "Copy as Markdown".
+   *
+   * Only fires when `flavor="github"` (the copy button is part of the GitHub
+   * flavor's container-based code block renderer).
+   * @platform ios, android, macos
+   */
+  onCopyPress?: (event: CopyPressEvent) => void;
   /**
    * Controls whether the system link preview is shown on long press (iOS only).
    *

--- a/packages/react-native-enriched-markdown/src/types/events.ts
+++ b/packages/react-native-enriched-markdown/src/types/events.ts
@@ -12,6 +12,11 @@ export interface TaskListItemPressEvent {
   text: string;
 }
 
+export interface CopyPressEvent {
+  code: string;
+  language: string;
+}
+
 /**
  * Native-level context menu item config sent to the native component.
  * Does not include the `onPress` callback — callbacks are managed on the JS side.


### PR DESCRIPTION
### What/Why?
Adds an `onCopyPress({ code, language })` callback that fires when code is copied from a fenced code block (header button, context-menu Copy, or VoiceOver), so apps can react to copies. GitHub flavor only; does not fire for "Copy as Markdown".

### Testing
Add `onCopyPress={({ code, language }) => console.log(language, code.length)}` to a `flavor="github"` block and confirm it fires for the header button and context-menu Copy (but not Copy as Markdown) on iOS and Android.

| iOS | Android |
| - | - |
| <video src="https://github.com/user-attachments/assets/690de3b9-5ff0-4942-bfa5-f2c71ab4cbd4" width=300 /> | <video src="https://github.com/user-attachments/assets/b4d5846a-e76f-4dd0-ae81-dd73140c8f83" width=300 /> |


### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)
