### PR TITLE
chore: block logs in maestro tests

### DIFF
--- a/.maestro/scripts/run-tests.sh
+++ b/.maestro/scripts/run-tests.sh
@@ -125,18 +125,27 @@ case "$PLATFORM" in
   *)        echo "Error: --platform is required. (--platform <ios|android>)" >&2; exit 1 ;;
 esac
 
+# Suppress the RN example's LogBox for this run so warning overlays never corrupt
+# the exact-match (100%) screenshot assertions. The flag file is a bundled source
+# input, so the build/Metro picks it up; it is restored on exit.
+E2E_FLAG_FILE="$REPO_ROOT/apps/react-native-example/e2e-config.json"
+printf '{\n  "disableLogBox": true\n}\n' > "$E2E_FLAG_FILE"
+
+cleanup() {
+  printf '{\n  "disableLogBox": false\n}\n' > "$E2E_FLAG_FILE"
+  if [ -n "${DEVICE_ID:-}" ]; then
+    if [ "$PLATFORM" = ios ]; then
+      xcrun simctl shutdown "$DEVICE_ID" 2>/dev/null || true
+    else
+      adb -s "$DEVICE_ID" emu kill 2>/dev/null || true
+    fi
+  fi
+}
+trap cleanup EXIT
+
 SETUP_OUTPUT=$("$SETUP" 2>&1)
 echo "$SETUP_OUTPUT"
 DEVICE_ID=$(echo "$SETUP_OUTPUT" | grep "^DEVICE_ID=" | cut -d= -f2)
-
-shutdown_device() {
-  if [ "$PLATFORM" = ios ]; then
-    xcrun simctl shutdown "$DEVICE_ID" 2>/dev/null || true
-  else
-    adb -s "$DEVICE_ID" emu kill 2>/dev/null || true
-  fi
-}
-trap shutdown_device EXIT
 
 app_installed() {
   if [ "$PLATFORM" = ios ]; then

--- a/.maestro/scripts/run-tests.sh
+++ b/.maestro/scripts/run-tests.sh
@@ -127,12 +127,20 @@ esac
 
 # Suppress the RN example's LogBox for this run so warning overlays never corrupt
 # the exact-match (100%) screenshot assertions. The flag file is a bundled source
-# input, so the build/Metro picks it up; it is restored on exit.
+# input, so the build/Metro picks it up. Only the RN app uses it, so leave the
+# native-example apps untouched; the original file bytes are restored on exit.
 E2E_FLAG_FILE="$REPO_ROOT/apps/react-native-example/e2e-config.json"
-printf '{\n  "disableLogBox": true\n}\n' > "$E2E_FLAG_FILE"
+E2E_FLAG_BACKUP=""
+if [ "$APP" = "rn" ]; then
+  E2E_FLAG_BACKUP="$(mktemp)"
+  cp "$E2E_FLAG_FILE" "$E2E_FLAG_BACKUP"
+  node -e 'const f=process.argv[1],fs=require("fs");const c=JSON.parse(fs.readFileSync(f,"utf8"));c.disableLogBox=true;fs.writeFileSync(f,JSON.stringify(c,null,2)+"\n");' "$E2E_FLAG_FILE"
+fi
 
 cleanup() {
-  printf '{\n  "disableLogBox": false\n}\n' > "$E2E_FLAG_FILE"
+  if [ -n "$E2E_FLAG_BACKUP" ] && [ -f "$E2E_FLAG_BACKUP" ]; then
+    mv "$E2E_FLAG_BACKUP" "$E2E_FLAG_FILE"
+  fi
   if [ -n "${DEVICE_ID:-}" ]; then
     if [ "$PLATFORM" = ios ]; then
       xcrun simctl shutdown "$DEVICE_ID" 2>/dev/null || true

--- a/apps/react-native-example/e2e-config.json
+++ b/apps/react-native-example/e2e-config.json
@@ -1,0 +1,3 @@
+{
+  "disableLogBox": false
+}

--- a/apps/react-native-example/index.js
+++ b/apps/react-native-example/index.js
@@ -1,7 +1,12 @@
-import { AppRegistry } from 'react-native';
+import { AppRegistry, LogBox } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import App from './src/App';
 import { name as appName } from './app.json';
+import e2eConfig from './e2e-config.json';
+
+if (e2eConfig.disableLogBox) {
+  LogBox.ignoreAllLogs();
+}
 
 const Root = () => (
   <SafeAreaProvider>


### PR DESCRIPTION
### What/Why?

Suppresses the RN example app's LogBox during Maestro E2E runs so dev warning overlays/toasts never corrupt the exact-match (100% threshold) screenshot assertions.

Driven entirely from `run-tests.sh` via a bundled flag file (`e2e-config.json`) — no native module, no `pod install`, no Metro config, and no per-flow YAML changes:

- `run-tests.sh` flips the flag to `true` before build/setup and restores it to `false` on exit (folded into the existing device-shutdown trap).
- `index.js` reads the flag and calls `LogBox.ignoreAllLogs()` when it's set.
- Because the flag is a bundled source input (not an env var), Metro reliably picks it up; the `- launchApp` at the start of each flow reloads the bundle.

Normal `yarn ios`/dev builds keep LogBox on (flag defaults to `false`).

### Testing

- Run `yarn test:e2e:smoke:ios` (or `:android`) and confirm screenshots no longer capture the LogBox warning overlay.
- Verify a plain `yarn react-native-example ios` still shows LogBox warnings.
- After a run, confirm `e2e-config.json` is restored to `false` (clean git tree).

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)