### PR TITLE
fix(ios): render soft line breaks as spaces

### DIFF
--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Parser/MarkdownASTNode.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Parser/MarkdownASTNode.swift
@@ -29,6 +29,7 @@ public enum NodeType: Int, CaseIterable, Sendable {
     case superscript
     case `subscript`
     case highlight
+    case softBreak
 }
 
 public struct MarkdownASTNode: Sendable, Equatable {

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
@@ -55,6 +55,8 @@ final class RendererFactory {
             return LinkRenderer(factory: self, config: config)
         case .lineBreak:
             return LineBreakRenderer()
+        case .softBreak:
+            return SoftBreakRenderer()
         case .code:
             return CodeRenderer(factory: self, config: config)
         case .image:

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/SoftBreakRenderer.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/SoftBreakRenderer.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+final class SoftBreakRenderer: NodeRenderer {
+    func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
+        let space = NSAttributedString(
+            string: " ",
+            attributes: context.getTextAttributes()
+        )
+        output.append(space)
+    }
+}

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/ParserTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/ParserTests.swift
@@ -105,7 +105,26 @@ final class ParserTests: XCTestCase {
     }
 
     func testNodeTypeEnumCountMatches() {
-        XCTAssertEqual(NodeType.allCases.count, 30)
+        XCTAssertEqual(NodeType.allCases.count, 31)
+    }
+
+    func testParsesSoftBreak() {
+        let ast = parser.parseMarkdown("line one\nline two")
+
+        let paragraph = ast.child(ofType: .paragraph)
+        XCTAssertNotNil(paragraph?.child(ofType: .softBreak))
+        XCTAssertNil(paragraph?.child(ofType: .lineBreak))
+    }
+
+    func testParsesSoftBreakAsLineBreakWithHardSoftBreaksFlag() {
+        let ast = parser.parseMarkdown(
+            "line one\nline two",
+            flags: Md4cFlags(hardSoftBreaks: true)
+        )
+
+        let paragraph = ast.child(ofType: .paragraph)
+        XCTAssertNotNil(paragraph?.child(ofType: .lineBreak))
+        XCTAssertNil(paragraph?.child(ofType: .softBreak))
     }
 
     func testParsesDeeplyNestedBlockquotes() {

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/RendererTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/RendererTests.swift
@@ -406,6 +406,19 @@ final class RendererTests: XCTestCase {
         XCTAssertNotNil(attributes[.font] as? UIFont)
     }
 
+    func testSoftLineBreakRendersAsSpace() {
+        let result = MarkdownRenderer.render("alpha\nbeta", config: config)
+        XCTAssertTrue(result.string.contains("alpha beta"))
+        XCTAssertFalse(result.string.contains("\u{2028}"))
+
+        let spaceRange = (result.string as NSString).range(of: " ")
+        XCTAssertNotEqual(spaceRange.location, NSNotFound)
+
+        var effectiveRange = NSRange()
+        let attributes = result.attributes(at: spaceRange.location, effectiveRange: &effectiveRange)
+        XCTAssertNotNil(attributes[.font] as? UIFont)
+    }
+
 
     func testInlineCodeUsesMonospacedFont() {
         let result = MarkdownRenderer.render("Use `code` here", config: config)

--- a/packages/ios-enriched-markdown/cpp/SwiftParserShim.cpp
+++ b/packages/ios-enriched-markdown/cpp/SwiftParserShim.cpp
@@ -6,7 +6,7 @@
 #include <new>
 #include <string>
 
-static_assert(static_cast<int>(Markdown::NodeType::Highlight) == 29,
+static_assert(static_cast<int>(Markdown::NodeType::SoftBreak) == 30,
               "NodeType enum must stay in sync with Swift NodeType");
 
 struct EMCParseResult {


### PR DESCRIPTION
The shared C++ parser emits SoftBreak nodes (raw value 30), but the Swift NodeType enum ended at highlight (29), so the bridge mapped soft breaks to .document and they rendered as nothing — words on adjacent lines of a paragraph ran together. Android renders them as a space.

Add the softBreak case, a SoftBreakRenderer appending a space with the current context attributes, and pin the enum tail with a SoftBreak static_assert in the Swift shim.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

