### PR TITLE
feat(ios): add Copy as Markdown and Copy Image URL selection menu items

### DIFF
--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
@@ -44,6 +44,7 @@ struct PlaygroundScreen: View {
         .background(Color.gray50)
         .accessibilityIdentifier("playground-screen")
         .markdownTheme(PlaygroundMarkdownTheme)
+        .markdownSelectionMenu(MarkdownSelectionMenuConfig())
         .onAppear(perform: loadBundledImages)
         .sheet(isPresented: $setMarkdownSheetVisible) {
             SetMarkdownSheet(

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Extraction/SelectionMenuItems.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Extraction/SelectionMenuItems.swift
@@ -1,0 +1,69 @@
+import UIKit
+
+struct MenuItemSpec: Equatable {
+    enum Kind {
+        case copyMarkdown
+        case copyImageURLs
+    }
+
+    let kind: Kind
+    let title: String
+    let systemImageName: String
+    let identifier: String
+    let pasteboardString: String
+}
+
+/// Pure builder for the custom selection-menu items; UIKit menu construction
+/// stays in the coordinator so this logic is unit-testable.
+enum SelectionMenuItems {
+    static let copyMarkdownIdentifier = "com.swmansion.enriched.markdown.copyMarkdown"
+    static let copyImageURLIdentifier = "com.swmansion.enriched.markdown.copyImageURL"
+
+    static func build(
+        config: MarkdownSelectionMenuConfig,
+        selectedRange: NSRange,
+        attributedText: NSAttributedString,
+        sourceMarkdown: String?
+    ) -> [MenuItemSpec] {
+        var specs: [MenuItemSpec] = []
+
+        if config.copyAsMarkdown,
+           let markdown = MarkdownExtractor.markdown(
+               for: selectedRange,
+               in: attributedText,
+               sourceMarkdown: sourceMarkdown
+           ),
+           !markdown.isEmpty {
+            specs.append(
+                MenuItemSpec(
+                    kind: .copyMarkdown,
+                    title: config.copyAsMarkdownLabel,
+                    systemImageName: "doc.text",
+                    identifier: copyMarkdownIdentifier,
+                    pasteboardString: markdown
+                )
+            )
+        }
+
+        if config.copyImageUrl {
+            let urls = MarkdownExtractor.imageURLs(in: attributedText, range: selectedRange)
+            if !urls.isEmpty {
+                specs.append(
+                    MenuItemSpec(
+                        kind: .copyImageURLs,
+                        title: imageURLsTitle(count: urls.count),
+                        systemImageName: "link",
+                        identifier: copyImageURLIdentifier,
+                        pasteboardString: urls.joined(separator: "\n")
+                    )
+                )
+            }
+        }
+
+        return specs
+    }
+
+    static func imageURLsTitle(count: Int) -> String {
+        count == 1 ? "Copy Image URL" : "Copy \(count) Image URLs"
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -9,6 +9,7 @@ public struct EnrichedMarkdownText: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.markdownLinkPressHandler) private var onLinkPress
+    @Environment(\.markdownSelectionMenu) private var selectionMenuConfig
     @StateObject private var renderStore = MarkdownRenderStore()
 
     public init(_ markdown: String, flags: Md4cFlags = .commonMark) {
@@ -29,7 +30,8 @@ public struct EnrichedMarkdownText: View {
             attributedText: renderStore.attributedText,
             sourceMarkdown: renderStore.sourceMarkdown,
             styleConfig: styleConfig,
-            onLinkPress: onLinkPress
+            onLinkPress: onLinkPress,
+            selectionMenuConfig: selectionMenuConfig
         )
         .fixedSize(horizontal: false, vertical: true)
         .onAppear {

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Environment+SelectionMenu.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Environment+SelectionMenu.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Configuration for the custom items added to the text-selection edit menu.
+public struct MarkdownSelectionMenuConfig: Equatable, Sendable {
+    public var copyAsMarkdown: Bool
+    public var copyImageUrl: Bool
+    public var copyAsMarkdownLabel: String
+
+    public init(
+        copyAsMarkdown: Bool = true,
+        copyImageUrl: Bool = true,
+        copyAsMarkdownLabel: String = "Copy as Markdown"
+    ) {
+        self.copyAsMarkdown = copyAsMarkdown
+        self.copyImageUrl = copyImageUrl
+        self.copyAsMarkdownLabel = copyAsMarkdownLabel
+    }
+}
+
+private struct MarkdownSelectionMenuKey: EnvironmentKey {
+    static let defaultValue = MarkdownSelectionMenuConfig()
+}
+
+public extension EnvironmentValues {
+    var markdownSelectionMenu: MarkdownSelectionMenuConfig {
+        get { self[MarkdownSelectionMenuKey.self] }
+        set { self[MarkdownSelectionMenuKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Configures the custom edit-menu items ("Copy as Markdown",
+    /// "Copy Image URL") shown when text is selected. Requires iOS 16;
+    /// earlier versions keep the stock menu.
+    func markdownSelectionMenu(_ config: MarkdownSelectionMenuConfig) -> some View {
+        environment(\.markdownSelectionMenu, config)
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -6,6 +6,7 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
     let sourceMarkdown: String?
     let styleConfig: MarkdownStyleConfig
     let onLinkPress: ((URL) -> Void)?
+    let selectionMenuConfig: MarkdownSelectionMenuConfig
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -21,6 +22,7 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
     func updateUIView(_ textView: MarkdownTextView, context: Context) {
         context.coordinator.onLinkPress = onLinkPress
         context.coordinator.sourceMarkdown = sourceMarkdown
+        context.coordinator.selectionMenuConfig = selectionMenuConfig
         textView.styleConfig = styleConfig
         textView.setMarkdownAttributedText(attributedText)
     }
@@ -39,6 +41,7 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
     final class Coordinator: NSObject, UITextViewDelegate {
         var onLinkPress: ((URL) -> Void)?
         var sourceMarkdown: String?
+        var selectionMenuConfig = MarkdownSelectionMenuConfig()
 
         func textView(
             _ textView: UITextView,
@@ -51,6 +54,59 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
                 return false
             }
             return true
+        }
+
+        @available(iOS 16.0, *)
+        func textView(
+            _ textView: UITextView,
+            editMenuForTextIn range: NSRange,
+            suggestedActions: [UIMenuElement]
+        ) -> UIMenu? {
+            let specs = SelectionMenuItems.build(
+                config: selectionMenuConfig,
+                selectedRange: range,
+                attributedText: textView.attributedText ?? NSAttributedString(),
+                sourceMarkdown: sourceMarkdown
+            )
+            guard !specs.isEmpty else { return UIMenu(children: suggestedActions) }
+
+            let actions = specs.map(Self.makeAction(for:))
+            return UIMenu(children: Self.splice(actions, into: suggestedActions))
+        }
+
+        @available(iOS 16.0, *)
+        static func makeAction(for spec: MenuItemSpec) -> UIAction {
+            UIAction(
+                title: spec.title,
+                image: UIImage(systemName: spec.systemImageName),
+                identifier: UIAction.Identifier(spec.identifier)
+            ) { _ in
+                UIPasteboard.general.string = spec.pasteboardString
+            }
+        }
+
+        /// Inserts `actions` right after the system standard-edit submenu,
+        /// keeping every system item (dropping them would remove Select All,
+        /// which is the only way to grow a selection from the long-press menu
+        /// of a non-editable text view). Falls back to prepending when the
+        /// submenu is absent.
+        @available(iOS 16.0, *)
+        static func splice(_ actions: [UIMenuElement], into suggestedActions: [UIMenuElement]) -> [UIMenuElement] {
+            var result: [UIMenuElement] = []
+            var foundStandardEdit = false
+
+            for element in suggestedActions {
+                result.append(element)
+                if !foundStandardEdit, let menu = element as? UIMenu, menu.identifier == .standardEdit {
+                    result.append(contentsOf: actions)
+                    foundStandardEdit = true
+                }
+            }
+
+            if !foundStandardEdit {
+                result.insert(contentsOf: actions, at: 0)
+            }
+            return result
         }
     }
 }

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/SelectionMenuItemsTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/SelectionMenuItemsTests.swift
@@ -1,0 +1,198 @@
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+final class SelectionMenuItemsTests: XCTestCase {
+    private var config: MarkdownStyleConfig!
+
+    override func setUp() {
+        super.setUp()
+        config = MarkdownStyleConfig.baseline()
+    }
+
+    private func render(_ markdown: String) -> NSAttributedString {
+        MarkdownRenderer.render(markdown, config: config)
+    }
+
+    private func fullRange(of attributedText: NSAttributedString) -> NSRange {
+        NSRange(location: 0, length: attributedText.length)
+    }
+
+    // MARK: - Copy as Markdown
+
+    func testBuildIncludesCopyMarkdownForPartialSelection() {
+        let rendered = render("Forests cover **31%** of land.")
+        let range = (rendered.string as NSString).range(of: "31%")
+
+        let specs = SelectionMenuItems.build(
+            config: MarkdownSelectionMenuConfig(),
+            selectedRange: range,
+            attributedText: rendered,
+            sourceMarkdown: "Forests cover **31%** of land."
+        )
+
+        XCTAssertEqual(specs.count, 1)
+        XCTAssertEqual(specs.first?.kind, .copyMarkdown)
+        XCTAssertEqual(specs.first?.title, "Copy as Markdown")
+        XCTAssertEqual(specs.first?.systemImageName, "doc.text")
+        XCTAssertEqual(specs.first?.identifier, SelectionMenuItems.copyMarkdownIdentifier)
+        XCTAssertEqual(specs.first?.pasteboardString, "**31%**")
+    }
+
+    func testBuildReturnsSourceMarkdownVerbatimForFullSelection() {
+        let source = "# Title\n\nParagraph with **bold**."
+        let rendered = render(source)
+
+        let specs = SelectionMenuItems.build(
+            config: MarkdownSelectionMenuConfig(),
+            selectedRange: fullRange(of: rendered),
+            attributedText: rendered,
+            sourceMarkdown: source
+        )
+
+        XCTAssertEqual(specs.first?.pasteboardString, source)
+    }
+
+    func testBuildOmitsCopyMarkdownWhenDisabled() {
+        let rendered = render("Hello world")
+
+        let specs = SelectionMenuItems.build(
+            config: MarkdownSelectionMenuConfig(copyAsMarkdown: false),
+            selectedRange: fullRange(of: rendered),
+            attributedText: rendered,
+            sourceMarkdown: "Hello world"
+        )
+
+        XCTAssertTrue(specs.isEmpty)
+    }
+
+    func testBuildUsesCustomLabel() {
+        let rendered = render("Hello world")
+
+        let specs = SelectionMenuItems.build(
+            config: MarkdownSelectionMenuConfig(copyAsMarkdownLabel: "Kopiuj jako Markdown"),
+            selectedRange: fullRange(of: rendered),
+            attributedText: rendered,
+            sourceMarkdown: "Hello world"
+        )
+
+        XCTAssertEqual(specs.first?.title, "Kopiuj jako Markdown")
+    }
+
+    func testBuildReturnsEmptyForZeroLengthSelection() {
+        let rendered = render("Hello world")
+
+        let specs = SelectionMenuItems.build(
+            config: MarkdownSelectionMenuConfig(),
+            selectedRange: NSRange(location: 0, length: 0),
+            attributedText: rendered,
+            sourceMarkdown: "Hello world"
+        )
+
+        XCTAssertTrue(specs.isEmpty)
+    }
+
+    // MARK: - Copy Image URL
+
+    func testBuildOmitsImageActionWhenNoImages() {
+        let rendered = render("No images here.")
+
+        let specs = SelectionMenuItems.build(
+            config: MarkdownSelectionMenuConfig(),
+            selectedRange: fullRange(of: rendered),
+            attributedText: rendered,
+            sourceMarkdown: "No images here."
+        )
+
+        XCTAssertEqual(specs.map(\.kind), [.copyMarkdown])
+    }
+
+    func testBuildIncludesImageActionWithHttpUrls() {
+        let source = "![image](https://example.com/forest.jpg)"
+        let rendered = render(source)
+
+        let specs = SelectionMenuItems.build(
+            config: MarkdownSelectionMenuConfig(),
+            selectedRange: fullRange(of: rendered),
+            attributedText: rendered,
+            sourceMarkdown: source
+        )
+
+        let imageSpec = specs.first { $0.kind == .copyImageURLs }
+        XCTAssertEqual(imageSpec?.title, "Copy Image URL")
+        XCTAssertEqual(imageSpec?.systemImageName, "link")
+        XCTAssertEqual(imageSpec?.identifier, SelectionMenuItems.copyImageURLIdentifier)
+        XCTAssertEqual(imageSpec?.pasteboardString, "https://example.com/forest.jpg")
+    }
+
+    func testBuildJoinsMultipleImageURLsWithNewline() {
+        let source = "![image](https://example.com/a.jpg)\n\n![image](https://example.com/b.jpg)"
+        let rendered = render(source)
+
+        let specs = SelectionMenuItems.build(
+            config: MarkdownSelectionMenuConfig(),
+            selectedRange: fullRange(of: rendered),
+            attributedText: rendered,
+            sourceMarkdown: source
+        )
+
+        let imageSpec = specs.first { $0.kind == .copyImageURLs }
+        XCTAssertEqual(imageSpec?.title, "Copy 2 Image URLs")
+        XCTAssertEqual(imageSpec?.pasteboardString, "https://example.com/a.jpg\nhttps://example.com/b.jpg")
+    }
+
+    func testBuildOmitsImageActionWhenDisabled() {
+        let source = "![image](https://example.com/forest.jpg)"
+        let rendered = render(source)
+
+        let specs = SelectionMenuItems.build(
+            config: MarkdownSelectionMenuConfig(copyImageUrl: false),
+            selectedRange: fullRange(of: rendered),
+            attributedText: rendered,
+            sourceMarkdown: source
+        )
+
+        XCTAssertFalse(specs.contains { $0.kind == .copyImageURLs })
+    }
+
+    func testImageURLsTitlePluralization() {
+        XCTAssertEqual(SelectionMenuItems.imageURLsTitle(count: 1), "Copy Image URL")
+        XCTAssertEqual(SelectionMenuItems.imageURLsTitle(count: 3), "Copy 3 Image URLs")
+    }
+
+    // MARK: - Menu splicing
+
+    func testSpliceInsertsAfterStandardEditMenu() throws {
+        guard #available(iOS 16.0, *) else { throw XCTSkip("Requires iOS 16") }
+
+        let standardEdit = UIMenu(title: "", identifier: .standardEdit, children: [])
+        let lookUp = UIMenu(title: "", identifier: .lookup, children: [])
+        let custom = UIAction(title: "Copy as Markdown") { _ in }
+
+        let result = MarkdownTextViewRepresentable.Coordinator.splice(
+            [custom],
+            into: [standardEdit, lookUp]
+        )
+
+        XCTAssertEqual(result.count, 3)
+        XCTAssertTrue((result[0] as? UIMenu)?.identifier == .standardEdit)
+        XCTAssertTrue(result[1] === custom)
+        XCTAssertTrue((result[2] as? UIMenu)?.identifier == .lookup)
+    }
+
+    func testSplicePrependsWhenStandardEditMenuAbsent() throws {
+        guard #available(iOS 16.0, *) else { throw XCTSkip("Requires iOS 16") }
+
+        let lookUp = UIMenu(title: "", identifier: .lookup, children: [])
+        let custom = UIAction(title: "Copy as Markdown") { _ in }
+
+        let result = MarkdownTextViewRepresentable.Coordinator.splice(
+            [custom],
+            into: [lookUp]
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result[0] === custom)
+        XCTAssertTrue((result[1] as? UIMenu)?.identifier == .lookup)
+    }
+}


### PR DESCRIPTION
Adds a markdownSelectionMenu view modifier and custom edit-menu items on iOS 16+, spliced after the system standard-edit actions so Select All survives. Copy as Markdown uses the extractor (full selections paste the original source verbatim); Copy Image URL collects http(s) image attachment URLs in the selection. iOS 15 keeps the stock menu. Enables the default config in the example playground.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

