### PR TITLE
fix: list marker dropped when inserting character

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/BlockStore.kt
@@ -116,7 +116,14 @@ class BlockStore {
         it.type in BlockType.ANCHORED && it.start >= editLocation && it.end == deleteEnd
       }
 
-    RangeEditAdjustment.adjustForEdit(ranges, editLocation, deletedLength, insertedLength) { true }
+    RangeEditAdjustment.adjustForEdit(
+      ranges,
+      editLocation,
+      deletedLength,
+      insertedLength,
+      inheritsReplacementAtStart = { true },
+      growsAtStartOnInsert = { true },
+    )
 
     for (anchor in anchors) {
       when {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/FormattingStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/FormattingStore.kt
@@ -168,9 +168,13 @@ class FormattingStore {
     deletedLength: Int,
     insertedLength: Int,
   ) {
-    RangeEditAdjustment.adjustForEdit(ranges, editLocation, deletedLength, insertedLength) {
-      it.type != StyleType.LINK
-    }
+    RangeEditAdjustment.adjustForEdit(
+      ranges,
+      editLocation,
+      deletedLength,
+      insertedLength,
+      inheritsReplacementAtStart = { it.type != StyleType.LINK },
+    )
     coalesceAdjacentSameTypeRanges()
   }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/RangeEditAdjustment.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/RangeEditAdjustment.kt
@@ -25,14 +25,22 @@ internal object RangeEditAdjustment {
    * characters at [editLocation] with [insertedLength] characters. Ranges
    * deleted outright or clipped to zero length are removed.
    *
-   * Insert-only edits at exactly `range.start` or `range.end` do NOT grow the
-   * range — the typed characters stay outside it. Whether boundary text joins
-   * the range is decided elsewhere: pending styles for inline ranges, line
-   * re-normalization for block ranges.
+   * Insert-only edits at exactly `range.end` do NOT grow the range — the typed
+   * characters stay outside it. An insert at exactly `range.start` grows the
+   * range only when [growsAtStartOnInsert] returns true; otherwise the range
+   * shifts and the typed characters stay outside it. Whether boundary text
+   * otherwise joins the range is decided elsewhere: pending styles for inline
+   * ranges, line re-normalization for block ranges.
    *
    * [inheritsReplacementAtStart]: when it returns true for a range whose start
    * is the edit location, replacement text joins the range (UIKit attribute
    * inheritance); when false, the old clip/remove behavior applies.
+   *
+   * [growsAtStartOnInsert]: when it returns true, a pure insert at `range.start`
+   * grows the range to cover the inserted text instead of shifting the range
+   * past it. Block ranges own their whole line, so a character typed at the line
+   * start must keep the line's block; inline styles must NOT set this (a
+   * character typed before a bold run must not become bold).
    */
   fun <T : MutableRangeBounds> adjustForEdit(
     ranges: MutableList<T>,
@@ -40,6 +48,7 @@ internal object RangeEditAdjustment {
     deletedLength: Int,
     insertedLength: Int,
     inheritsReplacementAtStart: (T) -> Boolean = { false },
+    growsAtStartOnInsert: (T) -> Boolean = { false },
   ) {
     if (deletedLength == 0 && insertedLength == 0) return
 
@@ -93,6 +102,10 @@ internal object RangeEditAdjustment {
         }
       } else {
         when {
+          range.start == editLocation && growsAtStartOnInsert(range) -> {
+            range.end += insertedLength
+          }
+
           range.start >= editLocation -> {
             range.start += insertedLength
             range.end += insertedLength

--- a/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
@@ -158,7 +158,7 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
     }
 
     ENRMAdjustedRange adjusted =
-        ENRMAdjustRangeForEdit(blockRange.range, editLocation, deletedLength, insertedLength, YES);
+        ENRMAdjustRangeForEdit(blockRange.range, editLocation, deletedLength, insertedLength, YES, YES);
     if (adjusted.shouldRemove) {
       // A persisting block deleted exactly to its end collapses to a zero-length
       // anchor (the line's newline survived, so the line stays the block); a

--- a/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMBlockStore.mm
@@ -157,8 +157,9 @@ static NSRange paragraphBoundsForRange(NSRange range, NSString *text)
       continue;
     }
 
-    ENRMAdjustedRange adjusted =
-        ENRMAdjustRangeForEdit(blockRange.range, editLocation, deletedLength, insertedLength, YES, YES);
+    ENRMAdjustedRange adjusted = ENRMAdjustRangeForEdit(blockRange.range, editLocation, deletedLength, insertedLength,
+                                                        /* inheritsReplacementAtStart */ YES,
+                                                        /* growsAtStartOnInsert */ YES);
     if (adjusted.shouldRemove) {
       // A persisting block deleted exactly to its end collapses to a zero-length
       // anchor (the line's newline survived, so the line stays the block); a

--- a/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMFormattingStore.mm
@@ -253,8 +253,8 @@
   for (NSUInteger idx = 0; idx < _ranges.count; idx++) {
     ENRMFormattingRange *formattingRange = _ranges[idx];
     BOOL inheritsReplacement = formattingRange.type != ENRMInputStyleTypeLink;
-    ENRMAdjustedRange adjusted =
-        ENRMAdjustRangeForEdit(formattingRange.range, editLocation, deletedLength, insertedLength, inheritsReplacement);
+    ENRMAdjustedRange adjusted = ENRMAdjustRangeForEdit(formattingRange.range, editLocation, deletedLength,
+                                                        insertedLength, inheritsReplacement, NO);
     formattingRange.range = adjusted.range;
     if (adjusted.shouldRemove) {
       [indexesToRemove addIndex:idx];

--- a/packages/react-native-enriched-markdown/ios/input/ENRMRangeEditAdjustment.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMRangeEditAdjustment.h
@@ -15,15 +15,24 @@ typedef struct {
 /// overlap classification lives in exactly one place. `shouldRemove` is set
 /// when the range was deleted outright or clipped to zero length.
 ///
-/// Insert-only edits at exactly the range start or end do NOT grow the range —
-/// the typed characters stay outside it. Whether boundary text joins the range
-/// is decided elsewhere: pending styles for inline ranges, line
+/// Insert-only edits at exactly the range end do NOT grow the range — the typed
+/// characters stay outside it. An insert at exactly the range start grows the
+/// range only when `growsAtStartOnInsert` is YES; otherwise the range shifts and
+/// the typed characters stay outside it. Whether boundary text joins the range is
+/// otherwise decided elsewhere: pending styles for inline ranges, line
 /// re-normalization for block ranges.
 ///
 /// `inheritsReplacementAtStart`: when YES, a replacement whose deletion starts
 /// at the range start lets the inserted text join the range (UIKit attribute
 /// inheritance); when NO, the old clip/remove behavior applies.
+///
+/// `growsAtStartOnInsert`: when YES, a pure insert at the range start grows the
+/// range to cover the inserted text instead of shifting the range past it. Block
+/// ranges own their whole line, so a character typed at the line start must keep
+/// the line's block; inline styles must NOT set this (a character typed before a
+/// bold run must not become bold).
 ENRMAdjustedRange ENRMAdjustRangeForEdit(NSRange range, NSUInteger editLocation, NSUInteger deletedLength,
-                                         NSUInteger insertedLength, BOOL inheritsReplacementAtStart);
+                                         NSUInteger insertedLength, BOOL inheritsReplacementAtStart,
+                                         BOOL growsAtStartOnInsert);
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/input/ENRMRangeEditAdjustment.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMRangeEditAdjustment.mm
@@ -26,7 +26,8 @@ static EditOverlap classifyOverlap(NSUInteger rangeStart, NSUInteger rangeEnd, N
 }
 
 ENRMAdjustedRange ENRMAdjustRangeForEdit(NSRange range, NSUInteger editLocation, NSUInteger deletedLength,
-                                         NSUInteger insertedLength, BOOL inheritsReplacementAtStart)
+                                         NSUInteger insertedLength, BOOL inheritsReplacementAtStart,
+                                         BOOL growsAtStartOnInsert)
 {
   ENRMAdjustedRange result = {range, NO};
   NSUInteger rangeStart = range.location;
@@ -77,7 +78,9 @@ ENRMAdjustedRange ENRMAdjustRangeForEdit(NSRange range, NSUInteger editLocation,
       }
     }
   } else if (insertedLength > 0) {
-    if (rangeStart >= editLocation) {
+    if (rangeStart == editLocation && growsAtStartOnInsert) {
+      result.range = NSMakeRange(rangeStart, range.length + insertedLength);
+    } else if (rangeStart >= editLocation) {
       result.range = NSMakeRange(rangeStart + insertedLength, range.length);
     } else if (editLocation < rangeEnd) {
       result.range = NSMakeRange(rangeStart, range.length + insertedLength);


### PR DESCRIPTION
### What/Why?

Fixes #630. 

Inserting a character at the very first position of a list item's line dropped the whole list block - the marker stopped drawing and `getMarkdown()` lost the marker (`- aest` -> `aest`). 

A leading insert **shifted** the block off the line start (`[0,N) -> [1,N+1)`), so the orphan-prune pass (which runs before normalize) saw the anchor was no longer at a line start and removed the block. Fix: a leading insert now **grows** the block instead of shifting it, keeping it anchored. Uses a new block-only `growsAtStartOnInsert` flag rather than reusing `inheritsReplacementAtStart` (also set for inline styles - growing those would make a char typed before a bold run become bold). Patched on iOS (`ENRMRangeEditAdjustment`) and Android (`RangeEditAdjustment`).

### Testing

Go to playground, set markdown to `- est`, caret to position 0, type `a`, assert the editor still renders a bulleted `aest`. 

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/55a80c3a-b550-4e43-a746-3a7d3d6bdbbe" width=300 /> | <video src="https://github.com/user-attachments/assets/77c7b2e7-d821-413f-b647-2b811cafbb29" width=300 /> |

  ### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)