### PR TITLE
feat(ios): show Select All in selection menu when the system omits it

### DIFF
--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -68,9 +68,24 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
                 attributedText: textView.attributedText ?? NSAttributedString(),
                 sourceMarkdown: sourceMarkdown
             )
-            guard !specs.isEmpty else { return UIMenu(children: suggestedActions) }
+            var actions = specs.map(Self.makeAction(for:))
 
-            let actions = specs.map(Self.makeAction(for:))
+            // Recent iOS versions stop suggesting Select All for non-editable text
+            // views, leaving no way to grow a long-press selection to the whole
+            // document; provide it ourselves when the system didn't (Android's
+            // selection menu always has it).
+            // The system shows its own item only when the command is suggested AND
+            // canPerformAction allows it; recent iOS returns false there for
+            // non-editable text views, hiding Select All even though the command
+            // is present in suggestedActions.
+            let textLength = textView.attributedText?.length ?? 0
+            let systemShowsSelectAll = Self.containsSelectAll(suggestedActions)
+                && textView.canPerformAction(#selector(UIResponder.selectAll(_:)), withSender: nil)
+            if range.length < textLength, !systemShowsSelectAll {
+                actions.append(Self.makeSelectAllAction(for: textView))
+            }
+
+            guard !actions.isEmpty else { return UIMenu(children: suggestedActions) }
             return UIMenu(children: Self.splice(actions, into: suggestedActions))
         }
 
@@ -82,6 +97,35 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
                 identifier: UIAction.Identifier(spec.identifier)
             ) { _ in
                 UIPasteboard.general.string = spec.pasteboardString
+            }
+        }
+
+        @available(iOS 16.0, *)
+        static func makeSelectAllAction(for textView: UITextView) -> UIAction {
+            UIAction(
+                title: "Select All",
+                image: UIImage(systemName: "text.badge.checkmark"),
+                identifier: UIAction.Identifier("com.swmansion.enriched.markdown.selectAll")
+            ) { [weak textView] _ in
+                guard let textView else { return }
+                Self.selectEntireDocument(in: textView)
+            }
+        }
+
+        static func selectEntireDocument(in textView: UITextView) {
+            textView.selectedRange = NSRange(location: 0, length: textView.attributedText?.length ?? 0)
+        }
+
+        @available(iOS 16.0, *)
+        static func containsSelectAll(_ elements: [UIMenuElement]) -> Bool {
+            elements.contains { element in
+                if let command = element as? UICommand, command.action == #selector(UIResponder.selectAll(_:)) {
+                    return true
+                }
+                if let menu = element as? UIMenu {
+                    return containsSelectAll(menu.children)
+                }
+                return false
             }
         }
 

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/SelectionMenuItemsTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/SelectionMenuItemsTests.swift
@@ -180,6 +180,40 @@ final class SelectionMenuItemsTests: XCTestCase {
         XCTAssertTrue((result[2] as? UIMenu)?.identifier == .lookup)
     }
 
+    // MARK: - Select All fallback
+
+    func testContainsSelectAllDetectsCommandNestedInStandardEditMenu() throws {
+        guard #available(iOS 16.0, *) else { throw XCTSkip("Requires iOS 16") }
+
+        let selectAll = UICommand(title: "Select All", action: #selector(UIResponder.selectAll(_:)))
+        let copy = UICommand(title: "Copy", action: #selector(UIResponder.copy(_:)))
+        let standardEdit = UIMenu(title: "", identifier: .standardEdit, children: [copy, selectAll])
+
+        XCTAssertTrue(MarkdownTextViewRepresentable.Coordinator.containsSelectAll([standardEdit]))
+        XCTAssertFalse(MarkdownTextViewRepresentable.Coordinator.containsSelectAll([
+            UIMenu(title: "", identifier: .standardEdit, children: [copy]),
+        ]))
+    }
+
+    func testMakeSelectAllActionAttributes() throws {
+        guard #available(iOS 16.0, *) else { throw XCTSkip("Requires iOS 16") }
+
+        let action = MarkdownTextViewRepresentable.Coordinator.makeSelectAllAction(for: UITextView())
+
+        XCTAssertEqual(action.title, "Select All")
+        XCTAssertEqual(action.identifier.rawValue, "com.swmansion.enriched.markdown.selectAll")
+    }
+
+    func testSelectEntireDocumentSelectsFullRange() {
+        let textView = UITextView()
+        textView.attributedText = render("Hello **world** out there")
+        textView.selectedRange = NSRange(location: 0, length: 5)
+
+        MarkdownTextViewRepresentable.Coordinator.selectEntireDocument(in: textView)
+
+        XCTAssertEqual(textView.selectedRange, NSRange(location: 0, length: textView.attributedText.length))
+    }
+
     func testSplicePrependsWhenStandardEditMenuAbsent() throws {
         guard #available(iOS 16.0, *) else { throw XCTSkip("Requires iOS 16") }
 


### PR DESCRIPTION
Recent iOS versions suppress the standard Select All edit-menu item for non-editable text views (the command is present in suggestedActions but canPerformAction(selectAll:) returns false), leaving no way to grow a long-press selection to the whole document. Append a fallback action that selects the full document whenever the selection is partial and the system item would not render, matching the Android selection menu.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

