### PR TITLE
fix(android): font scaling measurement and bullet rendering

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -166,6 +166,7 @@ class EnrichedMarkdown
     fun setAllowFontScaling(allow: Boolean) {
       if (allowFontScaling == allow) return
       allowFontScaling = allow
+      MeasurementStore.updateFontScalingSettings(id, allowFontScaling, maxFontSizeMultiplier)
       recreateStyleConfig()
       dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
       dirtyFlags += DirtyFlag.FORCE_HEIGHT
@@ -175,6 +176,7 @@ class EnrichedMarkdown
     fun setMaxFontSizeMultiplier(multiplier: Float) {
       if (maxFontSizeMultiplier == multiplier) return
       maxFontSizeMultiplier = multiplier
+      MeasurementStore.updateFontScalingSettings(id, allowFontScaling, maxFontSizeMultiplier)
       recreateStyleConfig()
       dirtyFlags += DirtyFlag.RECREATE_SEGMENTS
       dirtyFlags += DirtyFlag.FORCE_HEIGHT
@@ -516,6 +518,7 @@ class EnrichedMarkdown
         selectionMenuConfig = this@EnrichedMarkdown.selectionMenuConfig
         accessibilityLabels = this@EnrichedMarkdown.accessibilityLabels
         setIsSelectable(selectable)
+        markdownStyle?.paragraphStyle?.fontSize?.let { setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, it) }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
           breakStrategy = BreakStrategyUtils.resolveBreakStrategy(textBreakStrategy)
         }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -162,7 +162,11 @@ object MeasurementStore {
     allowFontScaling: Boolean,
     maxFontSizeMultiplier: Float,
   ) {
+    val previous = fontScalingSettings[viewId]
     fontScalingSettings[viewId] = FontScalingSettings(allowFontScaling, maxFontSizeMultiplier)
+    if (previous != null && (previous.allowFontScaling != allowFontScaling || previous.maxFontSizeMultiplier != maxFontSizeMultiplier)) {
+      data.remove(viewId)
+    }
   }
 
   fun clearFontScalingSettings(viewId: Int) {
@@ -312,6 +316,7 @@ object MeasurementStore {
     val propsHash = computePropsHash(props, allowFontScaling, fontScale, maxFontSizeMultiplier)
 
     // 2. Render & Measure
+    measurePaint.textSize = fontSize
     val imageRequestHeaders = parseImageRequestHeaders(props.getArrayOrNull("imageRequestHeaders"))
     val spannable =
       tryRenderMarkdown(markdown, styleMap, context, md4cFlags, allowFontScaling, maxFontSizeMultiplier, imageRequestHeaders)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BaseListSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/BaseListSpan.kt
@@ -28,6 +28,14 @@ abstract class BaseListSpan(
   private var cachedText: CharSequence? = null
   private var cachedHasDeeperSpanByPosition = mutableMapOf<Int, Boolean>()
 
+  val markerFontMetrics: Paint.FontMetrics by lazy {
+    TextPaint()
+      .apply {
+        applyBlockStyleFont(blockStyle, context)
+        textSize = blockStyle.fontSize
+      }.fontMetrics
+  }
+
   protected abstract fun getMarkerWidth(): Float
 
   override fun updateMeasureState(textPaint: TextPaint) = applyTextStyle(textPaint)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/TaskListSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/TaskListSpan.kt
@@ -71,8 +71,7 @@ class TaskListSpan(
     layout: Layout?,
     start: Int,
   ) {
-    val fontMetrics = paint.fontMetrics
-    val capHeight = -fontMetrics.ascent * CAP_HEIGHT_RATIO
+    val capHeight = -markerFontMetrics.ascent * CAP_HEIGHT_RATIO
     val centerY = baseline - capHeight / HALF_DIVISOR
     // Right-align the checkbox inside the reserved marker column so it hugs
     // the gap before the text. At the default (markerColumnWidth ==

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/UnorderedListSpan.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/spans/UnorderedListSpan.kt
@@ -66,8 +66,7 @@ class UnorderedListSpan(
     // visually flush-left when the column width equals the bullet radius
     // (the default).
     val bulletX = x + (depth * marginLeft + markerColumnWidth) * dir
-    val fontMetrics = paint.fontMetrics
-    val bulletY = baseline + (fontMetrics.ascent + fontMetrics.descent) / 2f
+    val bulletY = baseline + (markerFontMetrics.ascent + markerFontMetrics.descent) / 2f
 
     when (depth) {
       0 -> {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/ListStyle.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/styles/ListStyle.kt
@@ -35,7 +35,7 @@ data class ListStyle(
       val lineHeightRaw = map.getDouble("lineHeight").toFloat()
       val lineHeight = parser.toPixelFromSP(lineHeightRaw)
       val bulletColor = parser.parseColor(map, "bulletColor")
-      val bulletSize = parser.toPixelFromDIP(map.getDouble("bulletSize").toFloat())
+      val bulletSize = parser.toPixelFromSP(map.getDouble("bulletSize").toFloat())
       val markerMinWidth = parser.toPixelFromDIP(map.getDouble("markerMinWidth").toFloat().coerceAtLeast(0f))
       val markerColor = parser.parseColor(map, "markerColor")
       val markerFontWeight = parser.parseString(map, "markerFontWeight", "normal")


### PR DESCRIPTION
### What/Why?
Fixes Android font scaling measurement mismatches and bullet/checkbox rendering issues when `allowFontScaling` is active or toggled at runtime.
**Measurement fixes:**
- Set `measurePaint.textSize` in `measureAndCache()` to prevent stale singleton paint from corrupting CommonMark measurement heights
- Align rendering view base paint with `paragraphStyle.fontSize` so measurement and rendering produce consistent `StaticLayout` heights
- Invalidate measurement cache when font scaling settings change
- Eagerly propagate font scaling settings in prop setters for Fabric (where `measure()` runs before `commitProps()`)
**List marker fixes:**
- Use `toPixelFromSP` for `bulletSize` so bullets scale proportionally with text (resolves to identical values as `toPixelFromDIP` when `allowFontScaling=false`)
- Add lazy-cached `markerFontMetrics` to `BaseListSpan` for correct bullet/checkbox vertical alignment independent of Layout base paint


### Testing
<!-- How to test changed code? What testing has been done? -->


<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

