### PR TITLE
fix(ios): reset typing attributes before importing markdown

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -666,6 +666,10 @@ static const NSTimeInterval kENRMAtomicSnapPollInterval = 0.1;
   [_editSession enterPhase:ENRMEditPhaseImporting];
 
   [_editSession enterPhase:ENRMEditPhaseFormatting];
+  // UITextView stamps typingAttributes (including list headIndent from the
+  // previous cursor) onto all text set via .text. Reset before import so
+  // setValue does not indent non-list lines with the old list depth.
+  [self resetBaseTypingAttributes];
   ENRMSetPlainText(_textView, parsed.plainText);
   [_editSession enterPhase:ENRMEditPhaseImporting];
 


### PR DESCRIPTION
### What/Why?

When `setValue` reloads markdown via `importMarkdown`, iOS assigns plain text using `textView.text = ...`. UITextView stamps the current `typingAttributes` onto all of that text — including any list paragraph `headIndent` left over from where the cursor was before blur.

If the user blurs while focused in a nested list item, non-list paragraphs incorrectly pick up that list indent after `setValue`, even though the parsed markdown and block store are correct.

Reset base typing attributes before `ENRMSetPlainText` so import only applies block styling from the parsed markdown (via `applyFormatting`), not stale composer state from the previous cursor position.

### Testing

1. Open an editable `EnrichedMarkdownTextInput` with mixed content: a normal paragraph, a nested list, and another normal paragraph.
2. Place the cursor in a nested list item.
3. Blur the field while JS calls `setValue` with the current markdown (e.g. on blur to refresh link formatting).
4. **Before:** non-list paragraphs render with the nested list indent.
5. **After:** non-list paragraphs stay at normal indent; list items still render at the correct depth.

Tested on iOS

| Before | After |
| - | - |
| <img width="300" alt="Before" src="https://github.com/user-attachments/assets/b0768998-c253-46de-9d0d-1aa892304040" /> | <img width="300" alt="After" src="https://github.com/user-attachments/assets/0060f5c8-4357-499f-a3e5-012a1dea656c" /> |

### PR Checklist

- [X] Code compiles and runs on iOS
- [X] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [X] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)