### PR TITLE
feat(ios): add selectable control and selection color

### DIFF
--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
@@ -6,6 +6,7 @@ struct PlaygroundScreen: View {
 
     @State private var markdown: String = ""
     @State private var underlineEnabled: Bool = true
+    @State private var selectableEnabled: Bool = true
     @State private var setMarkdownSheetVisible: Bool = false
     @State private var rawInput: String = ""
     @State private var blockImageURI: String?
@@ -24,6 +25,13 @@ struct PlaygroundScreen: View {
                         isActive: underlineEnabled
                     ) {
                         underlineEnabled.toggle()
+                    }
+                    PlaygroundButton(
+                        label: "Selectable",
+                        accessibilityId: "selectable-button",
+                        isActive: selectableEnabled
+                    ) {
+                        selectableEnabled.toggle()
                     }
                 }
 
@@ -45,6 +53,8 @@ struct PlaygroundScreen: View {
         .accessibilityIdentifier("playground-screen")
         .markdownTheme(PlaygroundMarkdownTheme)
         .markdownSelectionMenu(MarkdownSelectionMenuConfig())
+        .markdownSelectable(selectableEnabled)
+        .markdownSelectionColor(.orange)
         .onAppear(perform: loadBundledImages)
         .sheet(isPresented: $setMarkdownSheetVisible) {
             SetMarkdownSheet(

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -10,6 +10,8 @@ public struct EnrichedMarkdownText: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.markdownLinkPressHandler) private var onLinkPress
     @Environment(\.markdownSelectionMenu) private var selectionMenuConfig
+    @Environment(\.markdownSelectable) private var isSelectionEnabled
+    @Environment(\.markdownSelectionColor) private var selectionColor
     @StateObject private var renderStore = MarkdownRenderStore()
 
     public init(_ markdown: String, flags: Md4cFlags = .commonMark) {
@@ -31,7 +33,9 @@ public struct EnrichedMarkdownText: View {
             sourceMarkdown: renderStore.sourceMarkdown,
             styleConfig: styleConfig,
             onLinkPress: onLinkPress,
-            selectionMenuConfig: selectionMenuConfig
+            selectionMenuConfig: selectionMenuConfig,
+            isSelectionEnabled: isSelectionEnabled,
+            selectionColor: selectionColor
         )
         .fixedSize(horizontal: false, vertical: true)
         .onAppear {

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Environment+Selection.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Environment+Selection.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+private struct MarkdownSelectableKey: EnvironmentKey {
+    static let defaultValue: Bool = true
+}
+
+private struct MarkdownSelectionColorKey: EnvironmentKey {
+    static let defaultValue: Color? = nil
+}
+
+public extension EnvironmentValues {
+    var markdownSelectable: Bool {
+        get { self[MarkdownSelectableKey.self] }
+        set { self[MarkdownSelectableKey.self] = newValue }
+    }
+
+    var markdownSelectionColor: Color? {
+        get { self[MarkdownSelectionColorKey.self] }
+        set { self[MarkdownSelectionColorKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Controls whether the rendered markdown text can be selected.
+    /// Defaults to `true`. Links remain tappable when selection is disabled.
+    func markdownSelectable(_ isSelectable: Bool) -> some View {
+        environment(\.markdownSelectable, isSelectable)
+    }
+
+    /// Tint for the selection highlight, handles, and caret. UIKit derives
+    /// all three from a single tint, so this covers both Android's
+    /// `selectionColor` and `selectionHandleColor`. `nil` keeps the
+    /// system tint.
+    func markdownSelectionColor(_ color: Color?) -> some View {
+        environment(\.markdownSelectionColor, color)
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -7,6 +7,8 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
     let styleConfig: MarkdownStyleConfig
     let onLinkPress: ((URL) -> Void)?
     let selectionMenuConfig: MarkdownSelectionMenuConfig
+    let isSelectionEnabled: Bool
+    let selectionColor: Color?
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -24,6 +26,8 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
         context.coordinator.sourceMarkdown = sourceMarkdown
         context.coordinator.selectionMenuConfig = selectionMenuConfig
         textView.styleConfig = styleConfig
+        textView.isSelectionEnabled = isSelectionEnabled
+        textView.tintColor = selectionColor.map { UIColor($0) }
         textView.setMarkdownAttributedText(attributedText)
     }
 
@@ -162,6 +166,25 @@ final class MarkdownTextView: UITextView {
                 updateDecorationStyleConfig()
             }
         }
+    }
+
+    /// Gates the selection UI while keeping `isSelectable` on, so link taps
+    /// keep working when selection is disabled. Selection requires first
+    /// responder; link interaction does not.
+    var isSelectionEnabled: Bool = true {
+        didSet {
+            guard isSelectionEnabled != oldValue else { return }
+            if !isSelectionEnabled {
+                selectedTextRange = nil
+                if isFirstResponder {
+                    resignFirstResponder()
+                }
+            }
+        }
+    }
+
+    override var canBecomeFirstResponder: Bool {
+        isSelectionEnabled && super.canBecomeFirstResponder
     }
 
     override var intrinsicContentSize: CGSize {

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/MarkdownTextViewTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/MarkdownTextViewTests.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+final class MarkdownTextViewTests: XCTestCase {
+    func testDefaultConfiguration() {
+        let textView = MarkdownTextView()
+
+        XCTAssertTrue(textView.isSelectionEnabled)
+        XCTAssertTrue(textView.isSelectable)
+        XCTAssertFalse(textView.isEditable)
+        XCTAssertTrue(textView.canBecomeFirstResponder)
+    }
+
+    func testDisablingSelectionBlocksFirstResponder() {
+        let textView = MarkdownTextView()
+
+        textView.isSelectionEnabled = false
+
+        XCTAssertFalse(textView.canBecomeFirstResponder)
+    }
+
+    func testDisablingSelectionClearsExistingSelection() {
+        let textView = MarkdownTextView()
+        textView.setMarkdownAttributedText(NSAttributedString(string: "Hello world"))
+        textView.selectedRange = NSRange(location: 0, length: 5)
+        XCTAssertEqual(textView.selectedRange.length, 5)
+
+        textView.isSelectionEnabled = false
+
+        XCTAssertEqual(textView.selectedRange.length, 0)
+    }
+
+    func testReenablingSelectionRestoresFirstResponder() {
+        let textView = MarkdownTextView()
+
+        textView.isSelectionEnabled = false
+        textView.isSelectionEnabled = true
+
+        XCTAssertTrue(textView.canBecomeFirstResponder)
+    }
+
+    func testSelectionStaysSelectableWhenDisabled() {
+        // isSelectable must stay true while selection is gated: link taps
+        // route through UITextViewDelegate only for selectable text views.
+        let textView = MarkdownTextView()
+
+        textView.isSelectionEnabled = false
+
+        XCTAssertTrue(textView.isSelectable)
+    }
+
+    func testEnvironmentDefaults() {
+        let environment = EnvironmentValues()
+
+        XCTAssertTrue(environment.markdownSelectable)
+        XCTAssertNil(environment.markdownSelectionColor)
+    }
+}


### PR DESCRIPTION
Adds .markdownSelectable(_:) and .markdownSelectionColor(_:) environment modifiers, matching the Android package's setIsSelectable and setSelectionColor/setSelectionHandleColor (UIKit derives the highlight, handles, and caret from a single tint, so one color modifier covers both Android setters).

Selection is gated via first responder instead of isSelectable so link taps keep working while selection is disabled.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

