### PR TITLE
feat: codeblock streaming

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -284,11 +284,11 @@ When `true`, newly appended content fades in during streaming updates. Only the 
 
 ### `streamingConfig`
 
-Configuration for streaming behavior. Currently controls how incomplete tables are handled during streaming with `flavor="github"`.
+Configuration for streaming behavior. Controls how incomplete tables and fenced code blocks are handled during streaming with `flavor="github"`.
 
-| Type                    | Default Value            | Platform |
-| ----------------------- | ------------------------ | -------- |
-| `{ tableMode: string }` | `{ tableMode: 'progressive' }` | Both     |
+| Type                                        | Default Value                                          | Platform |
+| ------------------------------------------- | ------------------------------------------------------ | -------- |
+| `{ tableMode: string, codeBlockMode: string }` | `{ tableMode: 'progressive', codeBlockMode: 'progressive' }` | Both     |
 
 #### `tableMode`
 
@@ -305,6 +305,15 @@ Controls how incomplete (still-streaming) tables are rendered:
   streamingConfig={{ tableMode: 'hidden' }}
 />
 ```
+
+#### `codeBlockMode`
+
+Controls how a fenced code block whose closing fence has not arrived yet is rendered:
+
+- **`'progressive'`** (default): The code streams in line-by-line with its header (language label + copy button) visible but non-interactive — copying is disabled until the block completes. Syntax highlighting is deferred until the closing fence arrives, so it applies once instead of flickering on every token.
+- **`'hidden'`**: The entire code block is hidden until its closing fence arrives, then it appears complete (the same all-or-nothing behavior block math uses).
+
+Both modes only take effect when `streamingAnimation` is `true`.
 
 ### `spoilerOverlay`
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -288,7 +288,7 @@ Configuration for streaming behavior. Controls how incomplete tables and fenced 
 
 | Type                                        | Default Value                                          | Platform |
 | ------------------------------------------- | ------------------------------------------------------ | -------- |
-| `{ tableMode: string, codeBlockMode: string }` | `{ tableMode: 'progressive', codeBlockMode: 'progressive' }` | Both     |
+| `{ tableMode?: string, codeBlockMode?: string }` | `{ tableMode: 'progressive', codeBlockMode: 'progressive' }` | Both     |
 
 #### `tableMode`
 

--- a/docs/MARKDOWN_STREAMING.md
+++ b/docs/MARKDOWN_STREAMING.md
@@ -34,3 +34,29 @@ The `streamingConfig` prop controls this behavior:
 | `'progressive'` (default) | Renders the table row-by-row as content arrives. New rows fade in when `streamingAnimation` is enabled. Incomplete trailing rows are automatically trimmed. |
 | `'hidden'` | The table is completely hidden until it is followed by a blank line, indicating the table is complete. Prevents visual jank from partially formed tables. |
 
+## Code Block Streaming (GFM)
+
+Fenced code blocks are also block-level elements. While a block's closing fence
+(```` ``` ````) has not arrived, its content is still changing, which would
+otherwise make syntax highlighting flicker on every token.
+
+The `codeBlockMode` field of `streamingConfig` controls this:
+
+```tsx
+<EnrichedMarkdownText
+  markdown={streamingMarkdown}
+  flavor="github"
+  streamingAnimation
+  streamingConfig={{ codeBlockMode: 'progressive' }}
+/>
+```
+
+### Code Block Modes
+
+| Mode | Behavior |
+|---|---|
+| `'progressive'` (default) | The code streams in line-by-line with its header (language label + copy button) visible but non-interactive — copying is disabled until the block completes. Syntax highlighting is deferred so it applies once when the closing fence arrives instead of flickering per token. |
+| `'hidden'` | The entire code block is hidden until its closing fence arrives, then it appears complete (the same all-or-nothing behavior block math uses). |
+
+Both modes only take effect when `streamingAnimation` is `true`.
+

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -18,6 +18,7 @@ import com.swmansion.enriched.markdown.parser.Parser
 import com.swmansion.enriched.markdown.spoiler.SpoilerOverlay
 import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.BreakStrategyUtils
+import com.swmansion.enriched.markdown.utils.common.CodeBlockStreamingMode
 import com.swmansion.enriched.markdown.utils.common.FeatureFlags
 import com.swmansion.enriched.markdown.utils.common.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.utils.common.RenderedSegment
@@ -72,6 +73,7 @@ class EnrichedMarkdown
     private var forceHeightRecalculationCounter = 0
 
     var tableStreamingMode: TableStreamingMode = TableStreamingMode.PROGRESSIVE
+    var codeBlockStreamingMode: CodeBlockStreamingMode = CodeBlockStreamingMode.PROGRESSIVE
     private var renderPending: Boolean = false
 
     var currentMarkdown: String = ""
@@ -138,6 +140,7 @@ class EnrichedMarkdown
 
     fun commitProps() {
       MeasurementStore.updateStreamingTableMode(id, tableStreamingMode)
+      MeasurementStore.updateStreamingCodeBlockMode(id, codeBlockStreamingMode)
       MeasurementStore.updateFontScalingSettings(id, allowFontScaling, maxFontSizeMultiplier)
       if (renderPending) {
         renderPending = false
@@ -338,6 +341,7 @@ class EnrichedMarkdown
       val markdown = currentMarkdown.takeIf { it.isNotEmpty() } ?: return
       val isStreaming = streamingAnimation
       val tableMode = tableStreamingMode
+      val codeBlockMode = codeBlockStreamingMode
 
       val renderId = ++currentRenderId
 
@@ -345,19 +349,21 @@ class EnrichedMarkdown
         try {
           val renderableMarkdown =
             if (isStreaming) {
-              StreamingMarkdownFilter.renderableMarkdownForStreaming(markdown, tableMode)
+              StreamingMarkdownFilter.renderableMarkdownForStreaming(markdown, tableMode, codeBlockMode)
             } else {
               markdown
             }
 
+          val hasPendingCodeBlock = isStreaming && StreamingMarkdownFilter.endsInsideOpenCodeFence(renderableMarkdown)
+
           if (renderableMarkdown.isEmpty()) {
-            postToMain(renderId) { applyRenderedSegments(emptyList(), style) }
+            postToMain(renderId) { applyRenderedSegments(emptyList(), style, false) }
             return@execute
           }
 
           val ast =
             parser.parseMarkdown(renderableMarkdown, md4cFlags) ?: run {
-              postToMain(renderId) { applyRenderedSegments(emptyList(), style) }
+              postToMain(renderId) { applyRenderedSegments(emptyList(), style, false) }
               return@execute
             }
 
@@ -371,18 +377,26 @@ class EnrichedMarkdown
               onLinkLongPressCallback,
             )
 
-          postToMain(renderId) { applyRenderedSegments(renderedSegments, style) }
+          postToMain(renderId) { applyRenderedSegments(renderedSegments, style, hasPendingCodeBlock) }
         } catch (e: Exception) {
           Log.e(TAG, "Render failed", e)
-          postToMain(renderId) { applyRenderedSegments(emptyList(), style) }
+          postToMain(renderId) { applyRenderedSegments(emptyList(), style, false) }
         }
       }
     }
 
+    // The trailing code block whose closing fence has not streamed in yet, if
+    // any; its view defers syntax highlighting and header chrome until close.
+    private var pendingCodeBlockSegment: RenderedSegment.CodeBlock? = null
+
     private fun applyRenderedSegments(
       renderedSegments: List<RenderedSegment>,
       style: StyleConfig,
+      hasPendingCodeBlock: Boolean,
     ) {
+      pendingCodeBlockSegment =
+        if (hasPendingCodeBlock) renderedSegments.lastOrNull() as? RenderedSegment.CodeBlock else null
+
       val reset = DirtyFlag.RECREATE_SEGMENTS in dirtyFlags
       val forceHeight = DirtyFlag.FORCE_HEIGHT in dirtyFlags
       dirtyFlags.clear()
@@ -478,7 +492,10 @@ class EnrichedMarkdown
         }
 
         is RenderedSegment.CodeBlock -> {
-          (view as CodeBlockContainerView).applyCodeBlockNode(segment.node)
+          (view as CodeBlockContainerView).apply {
+            pending = segment === pendingCodeBlockSegment
+            applyCodeBlockNode(segment.node)
+          }
         }
       }
     }
@@ -565,6 +582,7 @@ class EnrichedMarkdown
       onCopyPress = { code, language ->
         this@EnrichedMarkdown.onCopyPressCallback?.invoke(code, language)
       }
+      pending = segment === pendingCodeBlockSegment
       applyCodeBlockNode(segment.node)
     }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -347,14 +347,14 @@ class EnrichedMarkdown
 
       executor.execute {
         try {
-          val renderableMarkdown =
+          val filtered =
             if (isStreaming) {
               StreamingMarkdownFilter.renderableMarkdownForStreaming(markdown, tableMode, codeBlockMode)
             } else {
-              markdown
+              null
             }
-
-          val hasPendingCodeBlock = isStreaming && StreamingMarkdownFilter.endsInsideOpenCodeFence(renderableMarkdown)
+          val renderableMarkdown = filtered?.markdown ?: markdown
+          val hasPendingCodeBlock = filtered?.endsInsideOpenCodeFence ?: false
 
           if (renderableMarkdown.isEmpty()) {
             postToMain(renderId) { applyRenderedSegments(emptyList(), style, false) }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -423,6 +423,14 @@ class EnrichedMarkdown
       segmentSignatures.clear()
       segmentSignatures.addAll(result.signatures)
 
+      // A just-closed block has unchanged content, so the reconciler reuses it
+      // without an update; sync pending here to trigger its deferred highlight.
+      segmentViews.forEachIndexed { index, view ->
+        if (view is CodeBlockContainerView) {
+          view.pending = pendingCodeBlockSegment != null && index == segmentViews.size - 1
+        }
+      }
+
       val topologyChanged = result.viewsToAttach.isNotEmpty() || result.viewsToRemove.isNotEmpty()
 
       if (width > 0) {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdown.kt
@@ -385,8 +385,7 @@ class EnrichedMarkdown
       }
     }
 
-    // The trailing code block whose closing fence has not streamed in yet, if
-    // any; its view defers syntax highlighting and header chrome until close.
+    // Trailing code block whose closing fence hasn't streamed in yet, if any.
     private var pendingCodeBlockSegment: RenderedSegment.CodeBlock? = null
 
     private fun applyRenderedSegments(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -14,6 +14,7 @@ import com.facebook.react.viewmanagers.EnrichedMarkdownManagerDelegate
 import com.facebook.react.viewmanagers.EnrichedMarkdownManagerInterface
 import com.facebook.yoga.YogaMeasureMode
 import com.swmansion.enriched.markdown.spoiler.SpoilerOverlay
+import com.swmansion.enriched.markdown.utils.common.CodeBlockStreamingMode
 import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
 import com.swmansion.enriched.markdown.utils.common.emitContextMenuItemPress
 import com.swmansion.enriched.markdown.utils.common.emitCopyPress
@@ -86,6 +87,7 @@ class EnrichedMarkdownManager :
     view.cleanup()
     MeasurementStore.release(view.id)
     MeasurementStore.clearStreamingTableMode(view.id)
+    MeasurementStore.clearStreamingCodeBlockMode(view.id)
     MeasurementStore.clearBreakStrategy(view.id)
     MeasurementStore.clearFontScalingSettings(view.id)
   }
@@ -206,6 +208,11 @@ class EnrichedMarkdownManager :
         else -> TableStreamingMode.PROGRESSIVE
       }
     view.tableStreamingMode = tableMode
+    view.codeBlockStreamingMode =
+      when (config?.getString("codeBlockMode")) {
+        "hidden" -> CodeBlockStreamingMode.HIDDEN
+        else -> CodeBlockStreamingMode.PROGRESSIVE
+      }
   }
 
   @ReactProp(name = "spoilerOverlay")

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -19,6 +19,7 @@ import com.swmansion.enriched.markdown.spans.MathMetrics
 import com.swmansion.enriched.markdown.spans.MathRenderMode
 import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.BreakStrategyUtils
+import com.swmansion.enriched.markdown.utils.common.CodeBlockStreamingMode
 import com.swmansion.enriched.markdown.utils.common.FeatureFlags
 import com.swmansion.enriched.markdown.utils.common.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.utils.common.RenderedSegment
@@ -69,6 +70,8 @@ object MeasurementStore {
   private val breakStrategies = ConcurrentHashMap<Int, String>()
 
   private val streamingTableModes = ConcurrentHashMap<Int, TableStreamingMode>()
+
+  private val streamingCodeBlockModes = ConcurrentHashMap<Int, CodeBlockStreamingMode>()
 
   private fun resolveFontScalingSettings(
     viewId: Int?,
@@ -191,6 +194,17 @@ object MeasurementStore {
 
   fun clearStreamingTableMode(viewId: Int) {
     streamingTableModes.remove(viewId)
+  }
+
+  fun updateStreamingCodeBlockMode(
+    viewId: Int,
+    mode: CodeBlockStreamingMode,
+  ) {
+    streamingCodeBlockModes[viewId] = mode
+  }
+
+  fun clearStreamingCodeBlockMode(viewId: Int) {
+    streamingCodeBlockModes.remove(viewId)
   }
 
   private fun getMeasureByIdInternal(
@@ -360,9 +374,17 @@ object MeasurementStore {
       } else {
         TableStreamingMode.PROGRESSIVE
       }
+    val codeBlockMode =
+      if (isStreaming) {
+        id?.let {
+          streamingCodeBlockModes[it]
+        } ?: CodeBlockStreamingMode.PROGRESSIVE
+      } else {
+        CodeBlockStreamingMode.PROGRESSIVE
+      }
     val markdown =
       if (isStreaming) {
-        StreamingMarkdownFilter.renderableMarkdownForStreaming(rawMarkdown, tableMode)
+        StreamingMarkdownFilter.renderableMarkdownForStreaming(rawMarkdown, tableMode, codeBlockMode)
       } else {
         rawMarkdown
       }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -384,7 +384,7 @@ object MeasurementStore {
       }
     val markdown =
       if (isStreaming) {
-        StreamingMarkdownFilter.renderableMarkdownForStreaming(rawMarkdown, tableMode, codeBlockMode)
+        StreamingMarkdownFilter.renderableMarkdownForStreaming(rawMarkdown, tableMode, codeBlockMode).markdown
       } else {
         rawMarkdown
       }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
@@ -11,20 +11,11 @@ enum class CodeBlockStreamingMode {
 }
 
 /**
- * Pre-parse filter that hides incomplete trailing tables, block math and
- * fenced code blocks during streaming. A table is considered complete only
- * after a blank separator line follows it; a block math (`$$`) is complete
- * only when a closing `$$` exists; a fenced code block is complete only when
- * a matching closing fence exists.
- *
- * A still-open fenced code block is handled first because its content may
- * contain lines that look like `$$` delimiters or `|` table rows; those must
- * not be treated as pending math/table blocks. In HIDDEN mode the open block
- * is truncated (like math); in PROGRESSIVE mode it is kept verbatim and only
- * the region before it is passed through the math/table filters.
- * endsInsideOpenCodeFence reports whether the (already filtered) markdown ends
- * inside such a block, so the renderer can defer highlighting and header
- * chrome on that trailing block until its closing fence arrives.
+ * Pre-parse filter that hides incomplete trailing tables, block math and code
+ * blocks while streaming. An open fenced code block is handled first so its
+ * body (which may hold `$$` or `|` lines) is not mistaken for a pending
+ * math/table block: HIDDEN truncates it, PROGRESSIVE keeps it and only filters
+ * the region before it. endsInsideOpenCodeFence flags that trailing open block.
  */
 object StreamingMarkdownFilter {
   fun renderableMarkdownForStreaming(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
@@ -11,6 +11,15 @@ enum class CodeBlockStreamingMode {
 }
 
 /**
+ * Filtered markdown plus whether it ends inside a still-open fenced code block
+ * (the trailing block whose highlighting/copy chrome the renderer defers).
+ */
+data class StreamingFilterResult(
+  val markdown: String,
+  val endsInsideOpenCodeFence: Boolean,
+)
+
+/**
  * Pre-parse filter that hides incomplete trailing tables, block math and code
  * blocks while streaming. An open fenced code block is handled first so its
  * body (which may hold `$$` or `|` lines) is not mistaken for a pending
@@ -22,30 +31,28 @@ object StreamingMarkdownFilter {
     markdown: String,
     tableMode: TableStreamingMode = TableStreamingMode.PROGRESSIVE,
     codeBlockMode: CodeBlockStreamingMode = CodeBlockStreamingMode.PROGRESSIVE,
-  ): String {
+  ): StreamingFilterResult {
     val lines = markdown.split("\n")
     val openFenceIndex = findOpenCodeFenceLineIndex(lines)
 
     if (openFenceIndex == -1) {
-      return removePendingTablesAndMath(markdown, tableMode)
+      return StreamingFilterResult(removePendingTablesAndMath(markdown, tableMode, lines), false)
     }
 
     val fenceOffset = buildLineOffsets(lines)[openFenceIndex]
     val head = markdown.substring(0, fenceOffset)
     if (codeBlockMode == CodeBlockStreamingMode.HIDDEN) {
-      return removePendingTablesAndMath(head, tableMode)
+      return StreamingFilterResult(removePendingTablesAndMath(head, tableMode), false)
     }
     val tail = markdown.substring(fenceOffset)
-    return removePendingTablesAndMath(head, tableMode) + tail
+    return StreamingFilterResult(removePendingTablesAndMath(head, tableMode) + tail, true)
   }
-
-  fun endsInsideOpenCodeFence(markdown: String): Boolean = findOpenCodeFenceLineIndex(markdown.split("\n")) != -1
 
   private fun removePendingTablesAndMath(
     markdown: String,
     tableMode: TableStreamingMode,
+    lines: List<String> = markdown.split("\n"),
   ): String {
-    val lines = markdown.split("\n")
     val afterMath = removePendingStreamingMathBlock(markdown, lines)
     val linesForTable = if (afterMath.length == markdown.length) lines else afterMath.split("\n")
     return removePendingStreamingTableBlock(afterMath, linesForTable, tableMode)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/StreamingMarkdownFilter.kt
@@ -5,21 +5,101 @@ enum class TableStreamingMode {
   PROGRESSIVE,
 }
 
+enum class CodeBlockStreamingMode {
+  HIDDEN,
+  PROGRESSIVE,
+}
+
 /**
- * Pre-parse filter that hides incomplete trailing tables and block math
- * during streaming. A table is considered complete only after a blank
- * separator line follows it; a block math (`$$`) is complete only when
- * a closing `$$` exists.
+ * Pre-parse filter that hides incomplete trailing tables, block math and
+ * fenced code blocks during streaming. A table is considered complete only
+ * after a blank separator line follows it; a block math (`$$`) is complete
+ * only when a closing `$$` exists; a fenced code block is complete only when
+ * a matching closing fence exists.
+ *
+ * A still-open fenced code block is handled first because its content may
+ * contain lines that look like `$$` delimiters or `|` table rows; those must
+ * not be treated as pending math/table blocks. In HIDDEN mode the open block
+ * is truncated (like math); in PROGRESSIVE mode it is kept verbatim and only
+ * the region before it is passed through the math/table filters.
+ * endsInsideOpenCodeFence reports whether the (already filtered) markdown ends
+ * inside such a block, so the renderer can defer highlighting and header
+ * chrome on that trailing block until its closing fence arrives.
  */
 object StreamingMarkdownFilter {
   fun renderableMarkdownForStreaming(
     markdown: String,
     tableMode: TableStreamingMode = TableStreamingMode.PROGRESSIVE,
+    codeBlockMode: CodeBlockStreamingMode = CodeBlockStreamingMode.PROGRESSIVE,
+  ): String {
+    val lines = markdown.split("\n")
+    val openFenceIndex = findOpenCodeFenceLineIndex(lines)
+
+    if (openFenceIndex == -1) {
+      return removePendingTablesAndMath(markdown, tableMode)
+    }
+
+    val fenceOffset = buildLineOffsets(lines)[openFenceIndex]
+    val head = markdown.substring(0, fenceOffset)
+    if (codeBlockMode == CodeBlockStreamingMode.HIDDEN) {
+      return removePendingTablesAndMath(head, tableMode)
+    }
+    val tail = markdown.substring(fenceOffset)
+    return removePendingTablesAndMath(head, tableMode) + tail
+  }
+
+  fun endsInsideOpenCodeFence(markdown: String): Boolean = findOpenCodeFenceLineIndex(markdown.split("\n")) != -1
+
+  private fun removePendingTablesAndMath(
+    markdown: String,
+    tableMode: TableStreamingMode,
   ): String {
     val lines = markdown.split("\n")
     val afterMath = removePendingStreamingMathBlock(markdown, lines)
     val linesForTable = if (afterMath.length == markdown.length) lines else afterMath.split("\n")
     return removePendingStreamingTableBlock(afterMath, linesForTable, tableMode)
+  }
+
+  private class FenceMarker(
+    val char: Char,
+    val length: Int,
+    val info: String,
+  )
+
+  private fun parseFenceMarker(line: String): FenceMarker? {
+    var i = 0
+    while (i < line.length && line[i] == ' ' && i < 3) i++
+    if (i >= line.length) return null
+    val ch = line[i]
+    if (ch != '`' && ch != '~') return null
+    var runLength = 0
+    while (i < line.length && line[i] == ch) {
+      i++
+      runLength++
+    }
+    if (runLength < 3) return null
+    val info = line.substring(i)
+    if (ch == '`' && info.contains('`')) return null
+    return FenceMarker(ch, runLength, info)
+  }
+
+  private fun findOpenCodeFenceLineIndex(lines: List<String>): Int {
+    var openIndex = -1
+    var openChar = ' '
+    var openLength = 0
+    for (i in lines.indices) {
+      val marker = parseFenceMarker(lines[i])
+      if (openIndex == -1) {
+        if (marker != null) {
+          openIndex = i
+          openChar = marker.char
+          openLength = marker.length
+        }
+      } else if (marker != null && marker.char == openChar && marker.length >= openLength && marker.info.isBlank()) {
+        openIndex = -1
+      }
+    }
+    return openIndex
   }
 
   private fun removePendingStreamingMathBlock(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/CodeBlockContainerView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/CodeBlockContainerView.kt
@@ -79,6 +79,9 @@ class CodeBlockContainerView(
       if (field == value) return
       field = value
       copyButton.isEnabled = !value
+      // The reconciler can reuse an unchanged block without re-applying the
+      // node, so re-derive here to pick up highlighting once the block closes.
+      rebuildCodeText()
     }
 
   private val textView =
@@ -173,6 +176,11 @@ class CodeBlockContainerView(
       languageView.text = CodeBlockNode.displayLanguageName(newLanguage)
     }
 
+    rebuildCodeText()
+  }
+
+  // Highlighting is deferred while pending, applied once the block closes.
+  private fun rebuildCodeText() {
     val plainCode = buildCodeText(code, codeBlockStyle)
     if (!pending) {
       CodeBlockHighlighter.highlight(plainCode, code, language, codeBlockStyle)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/CodeBlockContainerView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/CodeBlockContainerView.kt
@@ -72,9 +72,8 @@ class CodeBlockContainerView(
   private var language: String? = null
   private var fenceChar: String = "`"
 
-  // True while this block's closing fence has not streamed in yet: syntax
-  // highlighting is deferred and the header stays visible but non-interactive
-  // (copy disabled) until the block completes.
+  // True until the closing fence arrives: highlighting is deferred and copying
+  // is disabled, while the header stays visible.
   var pending: Boolean = false
     set(value) {
       if (field == value) return

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/CodeBlockContainerView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/CodeBlockContainerView.kt
@@ -97,10 +97,7 @@ class CodeBlockContainerView(
       setTextColor(codeBlockStyle.color)
       val horizontalPad = (inset - borderW).coerceAtLeast(0)
       setPadding(horizontalPad, inset, horizontalPad, inset)
-      setOnLongClickListener { view ->
-        showContextMenu(view)
-        true
-      }
+      setOnLongClickListener { view -> showContextMenu(view) }
     }
 
   private val scrollView =
@@ -157,10 +154,7 @@ class CodeBlockContainerView(
         }
       }
     isLongClickable = true
-    setOnLongClickListener { view ->
-      showContextMenu(view)
-      true
-    }
+    setOnLongClickListener { view -> showContextMenu(view) }
     addView(scrollView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))
     addView(languageView, LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT))
     addView(copyButton, LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT))
@@ -248,12 +242,15 @@ class CodeBlockContainerView(
     canvas.drawLine(borderWidth, y, width - borderWidth, y, dividerPaint)
   }
 
-  private fun showContextMenu(anchor: View) {
-    if (pending) return
+  // Returns whether a menu was shown, so the long-press listener only consumes
+  // the event when there is one (a pending block has no menu yet).
+  private fun showContextMenu(anchor: View): Boolean {
+    if (pending) return false
     ContextMenuPopup.show(anchor, this) {
       item(ContextMenuPopup.Icon.COPY, copyLabel) { copyCode() }
       item(ContextMenuPopup.Icon.DOCUMENT, copyAsMarkdownLabel) { copyFencedMarkdown() }
     }
+    return true
   }
 
   private fun copyCode() {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/CodeBlockContainerView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/views/CodeBlockContainerView.kt
@@ -72,6 +72,16 @@ class CodeBlockContainerView(
   private var language: String? = null
   private var fenceChar: String = "`"
 
+  // True while this block's closing fence has not streamed in yet: syntax
+  // highlighting is deferred and the header stays visible but non-interactive
+  // (copy disabled) until the block completes.
+  var pending: Boolean = false
+    set(value) {
+      if (field == value) return
+      field = value
+      copyButton.isEnabled = !value
+    }
+
   private val textView =
     AppCompatTextView(context).apply {
       includeFontPadding = false
@@ -165,7 +175,9 @@ class CodeBlockContainerView(
     }
 
     val plainCode = buildCodeText(code, codeBlockStyle)
-    CodeBlockHighlighter.highlight(plainCode, code, language, codeBlockStyle)
+    if (!pending) {
+      CodeBlockHighlighter.highlight(plainCode, code, language, codeBlockStyle)
+    }
     textView.text = plainCode
   }
 
@@ -230,6 +242,7 @@ class CodeBlockContainerView(
   }
 
   private fun showContextMenu(anchor: View) {
+    if (pending) return
     ContextMenuPopup.show(anchor, this) {
       item(ContextMenuPopup.Icon.COPY, copyLabel) { copyCode() }
       item(ContextMenuPopup.Icon.DOCUMENT, copyAsMarkdownLabel) { copyFencedMarkdown() }
@@ -237,7 +250,7 @@ class CodeBlockContainerView(
   }
 
   private fun copyCode() {
-    if (code.isEmpty()) return
+    if (pending || code.isEmpty()) return
     copyToClipboard(code)
     onCopyPress?.invoke(code, language ?: "")
   }

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -705,6 +705,15 @@ static char kENRMSegmentFadeAnimatorKey;
   _segmentViews = result.views;
   _segmentSignatures = result.signatures;
 
+  // A just-closed block has unchanged content, so the reconciler reuses it
+  // without an update; sync pending here to trigger its deferred highlight.
+  [_segmentViews enumerateObjectsUsingBlock:^(RCTUIView *segment, NSUInteger i, BOOL *stop) {
+    if ([segment isKindOfClass:[ENRMCodeBlockContainerView class]]) {
+      ((ENRMCodeBlockContainerView *)segment).pending =
+          self->_pendingCodeBlockSegment != nil && i == self->_segmentViews.count - 1;
+    }
+  }];
+
   if (self.bounds.size.width > 0) {
     [self setNeedsLayout];
 

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -106,8 +106,7 @@ static char kENRMSegmentFadeAnimatorKey;
   BOOL _streamingAnimation;
   ENRMTableStreamingMode _tableStreamingMode;
   ENRMCodeBlockStreamingMode _codeBlockStreamingMode;
-  // The trailing code block whose closing fence has not streamed in yet, if
-  // any; its view defers highlighting and header chrome until the block closes.
+  // Trailing code block whose closing fence hasn't streamed in yet, if any.
   ENRMCodeBlockSegment *_pendingCodeBlockSegment;
 
   size_t _renderedStyleFingerprint;

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -574,12 +574,14 @@ static char kENRMSegmentFadeAnimatorKey;
 
   __block NSArray<ENRMRenderedSegment *> *renderedSegments = nil;
   __block NSString *renderableMarkdown = nil;
+  __block BOOL endsInsideOpenCodeFence = NO;
 
   [_renderCoordinator
       scheduleRender:^BOOL {
-        renderableMarkdown = streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString, tableStreamingMode,
-                                                                                     codeBlockStreamingMode)
-                                                : markdownString;
+        renderableMarkdown = streamingAnimation
+                                 ? ENRMRenderableMarkdownForStreaming(markdownString, tableStreamingMode,
+                                                                      codeBlockStreamingMode, &endsInsideOpenCodeFence)
+                                 : markdownString;
 
         if (renderableMarkdown.length == 0) {
           renderedSegments = @[];
@@ -602,7 +604,9 @@ static char kENRMSegmentFadeAnimatorKey;
       }
       apply:^{
         self->_renderedStyleFingerprint = self->_pendingStyleFingerprint;
-        [self applyRenderedSegments:renderedSegments renderedMarkdown:renderableMarkdown];
+        [self applyRenderedSegments:renderedSegments
+                   renderedMarkdown:renderableMarkdown
+            endsInsideOpenCodeFence:endsInsideOpenCodeFence];
       }];
 }
 
@@ -639,10 +643,11 @@ static char kENRMSegmentFadeAnimatorKey;
 
   _renderCoordinator.blockAsyncRender = YES;
   _cachedMarkdown = [markdownString copy];
+  BOOL endsInsideOpenCodeFence = NO;
   NSString *renderableMarkdown =
-      _streamingAnimation
-          ? ENRMRenderableMarkdownForStreaming(markdownString, _tableStreamingMode, _codeBlockStreamingMode)
-          : markdownString;
+      _streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString, _tableStreamingMode,
+                                                               _codeBlockStreamingMode, &endsInsideOpenCodeFence)
+                          : markdownString;
   _renderedMarkdown = [renderableMarkdown copy];
   _renderedStyleFingerprint = _pendingStyleFingerprint;
 
@@ -655,7 +660,7 @@ static char kENRMSegmentFadeAnimatorKey;
     return;
   }
 
-  [self updatePendingCodeBlockSegmentForMarkdown:renderableMarkdown segments:renderedSegments];
+  [self updatePendingCodeBlockSegment:endsInsideOpenCodeFence segments:renderedSegments];
 
   for (ENRMRenderedSegment *segment in renderedSegments) {
     RCTUIView *view = [_segmentViewRegistry createViewForSegment:segment];
@@ -665,11 +670,10 @@ static char kENRMSegmentFadeAnimatorKey;
   }
 }
 
-- (void)updatePendingCodeBlockSegmentForMarkdown:(NSString *)renderedMarkdown
-                                        segments:(NSArray<ENRMRenderedSegment *> *)segments
+- (void)updatePendingCodeBlockSegment:(BOOL)endsInsideOpenCodeFence segments:(NSArray<ENRMRenderedSegment *> *)segments
 {
   _pendingCodeBlockSegment = nil;
-  if (!_streamingAnimation || !ENRMMarkdownEndsInsideOpenCodeFence(renderedMarkdown)) {
+  if (!_streamingAnimation || !endsInsideOpenCodeFence) {
     return;
   }
   ENRMRenderedSegment *last = segments.lastObject;
@@ -678,10 +682,12 @@ static char kENRMSegmentFadeAnimatorKey;
   }
 }
 
-- (void)applyRenderedSegments:(NSArray *)renderedSegments renderedMarkdown:(NSString *)renderedMarkdown
+- (void)applyRenderedSegments:(NSArray *)renderedSegments
+             renderedMarkdown:(NSString *)renderedMarkdown
+      endsInsideOpenCodeFence:(BOOL)endsInsideOpenCodeFence
 {
   _renderedMarkdown = [renderedMarkdown copy];
-  [self updatePendingCodeBlockSegmentForMarkdown:renderedMarkdown segments:renderedSegments];
+  [self updatePendingCodeBlockSegment:endsInsideOpenCodeFence segments:renderedSegments];
   BOOL segmentTopologyChanged = _streamingAnimation && [self renderedSegmentsChangeTopology:renderedSegments];
 
   ENRMSegmentReconciliationResult *result = [ENRMSegmentReconciler reconcileCurrentViews:_segmentViews

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdown.mm
@@ -105,6 +105,10 @@ static char kENRMSegmentFadeAnimatorKey;
   BOOL _enableLinkPreview;
   BOOL _streamingAnimation;
   ENRMTableStreamingMode _tableStreamingMode;
+  ENRMCodeBlockStreamingMode _codeBlockStreamingMode;
+  // The trailing code block whose closing fence has not streamed in yet, if
+  // any; its view defers highlighting and header chrome until the block closes.
+  ENRMCodeBlockSegment *_pendingCodeBlockSegment;
 
   size_t _renderedStyleFingerprint;
   size_t _pendingStyleFingerprint;
@@ -165,6 +169,7 @@ static char kENRMSegmentFadeAnimatorKey;
     _enableLinkPreview = YES;
     _streamingAnimation = NO;
     _tableStreamingMode = ENRMTableStreamingModeProgressive;
+    _codeBlockStreamingMode = ENRMCodeBlockStreamingModeProgressive;
     _selectionMenuConfig = (ENRMSelectionMenuConfig){.copyAsMarkdown = YES, .copyImageURL = YES};
     _lineBreakStrategy = NSLineBreakStrategyNone;
     _writingDirectionMode = ENRMWritingDirectionModeFirstStrong;
@@ -275,8 +280,11 @@ static char kENRMSegmentFadeAnimatorKey;
                             return view;
                           }
                           updateView:^(RCTUIView *view, ENRMRenderedSegment *segment) {
-                            [(ENRMCodeBlockContainerView *)view
-                                applyCodeBlockNode:segment.codeBlockSegment.codeBlockNode];
+                            EnrichedMarkdown *strongSelf = weakSelf;
+                            ENRMCodeBlockContainerView *codeBlockView = (ENRMCodeBlockContainerView *)view;
+                            codeBlockView.pending =
+                                strongSelf && segment.codeBlockSegment == strongSelf->_pendingCodeBlockSegment;
+                            [codeBlockView applyCodeBlockNode:segment.codeBlockSegment.codeBlockNode];
                           }]];
 
   _segmentViewRegistry = [[ENRMSegmentViewRegistry alloc] initWithHandlers:handlers];
@@ -560,6 +568,7 @@ static char kENRMSegmentFadeAnimatorKey;
   BOOL allowTrailingMargin = _allowTrailingMargin;
   BOOL streamingAnimation = _streamingAnimation;
   ENRMTableStreamingMode tableStreamingMode = _tableStreamingMode;
+  ENRMCodeBlockStreamingMode codeBlockStreamingMode = _codeBlockStreamingMode;
   NSLineBreakStrategy lineBreakStrategy = _lineBreakStrategy;
   ENRMWritingDirectionMode writingDirectionMode = _writingDirectionMode;
   NSWritingDirection resolvedLayoutDirection = _resolvedLayoutDirection;
@@ -569,7 +578,8 @@ static char kENRMSegmentFadeAnimatorKey;
 
   [_renderCoordinator
       scheduleRender:^BOOL {
-        renderableMarkdown = streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString, tableStreamingMode)
+        renderableMarkdown = streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString, tableStreamingMode,
+                                                                                     codeBlockStreamingMode)
                                                 : markdownString;
 
         if (renderableMarkdown.length == 0) {
@@ -631,7 +641,9 @@ static char kENRMSegmentFadeAnimatorKey;
   _renderCoordinator.blockAsyncRender = YES;
   _cachedMarkdown = [markdownString copy];
   NSString *renderableMarkdown =
-      _streamingAnimation ? ENRMRenderableMarkdownForStreaming(markdownString, _tableStreamingMode) : markdownString;
+      _streamingAnimation
+          ? ENRMRenderableMarkdownForStreaming(markdownString, _tableStreamingMode, _codeBlockStreamingMode)
+          : markdownString;
   _renderedMarkdown = [renderableMarkdown copy];
   _renderedStyleFingerprint = _pendingStyleFingerprint;
 
@@ -644,6 +656,8 @@ static char kENRMSegmentFadeAnimatorKey;
     return;
   }
 
+  [self updatePendingCodeBlockSegmentForMarkdown:renderableMarkdown segments:renderedSegments];
+
   for (ENRMRenderedSegment *segment in renderedSegments) {
     RCTUIView *view = [_segmentViewRegistry createViewForSegment:segment];
     [_segmentViews addObject:view];
@@ -652,9 +666,23 @@ static char kENRMSegmentFadeAnimatorKey;
   }
 }
 
+- (void)updatePendingCodeBlockSegmentForMarkdown:(NSString *)renderedMarkdown
+                                        segments:(NSArray<ENRMRenderedSegment *> *)segments
+{
+  _pendingCodeBlockSegment = nil;
+  if (!_streamingAnimation || !ENRMMarkdownEndsInsideOpenCodeFence(renderedMarkdown)) {
+    return;
+  }
+  ENRMRenderedSegment *last = segments.lastObject;
+  if (last.kind == ENRMSegmentKindCodeBlock) {
+    _pendingCodeBlockSegment = last.codeBlockSegment;
+  }
+}
+
 - (void)applyRenderedSegments:(NSArray *)renderedSegments renderedMarkdown:(NSString *)renderedMarkdown
 {
   _renderedMarkdown = [renderedMarkdown copy];
+  [self updatePendingCodeBlockSegmentForMarkdown:renderedMarkdown segments:renderedSegments];
   BOOL segmentTopologyChanged = _streamingAnimation && [self renderedSegmentsChangeTopology:renderedSegments];
 
   ENRMSegmentReconciliationResult *result = [ENRMSegmentReconciler reconcileCurrentViews:_segmentViews
@@ -811,6 +839,7 @@ static char kENRMSegmentFadeAnimatorKey;
       [strongSelf emitCopyPress:code language:language];
   };
 
+  codeBlockView.pending = codeBlockSegment == _pendingCodeBlockSegment;
   [codeBlockView applyCodeBlockNode:codeBlockSegment.codeBlockNode];
   return codeBlockView;
 }
@@ -954,6 +983,14 @@ static char kENRMSegmentFadeAnimatorKey;
     _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
   }
 
+  if (newViewProps.streamingConfig.codeBlockMode != oldViewProps.streamingConfig.codeBlockMode) {
+    NSString *codeBlockModeStr =
+        [[NSString alloc] initWithUTF8String:newViewProps.streamingConfig.codeBlockMode.c_str()];
+    _codeBlockStreamingMode = [codeBlockModeStr isEqualToString:@"hidden"] ? ENRMCodeBlockStreamingModeHidden
+                                                                           : ENRMCodeBlockStreamingModeProgressive;
+    _dirtyFlags |= ENRMDirtyForceHeight | ENRMDirtyRender;
+  }
+
   if (ENRMContextMenuItemsChanged(oldViewProps.contextMenuItems, newViewProps.contextMenuItems)) {
     _contextMenuItemTexts = ENRMContextMenuTextsFromItems(newViewProps.contextMenuItems);
     _contextMenuItemIcons = ENRMContextMenuIconsFromItems(newViewProps.contextMenuItems);
@@ -1081,6 +1118,8 @@ static char kENRMSegmentFadeAnimatorKey;
   _allowTrailingMargin = NO;
   _streamingAnimation = NO;
   _tableStreamingMode = ENRMTableStreamingModeProgressive;
+  _codeBlockStreamingMode = ENRMCodeBlockStreamingModeProgressive;
+  _pendingCodeBlockSegment = nil;
   _lineBreakStrategy = NSLineBreakStrategyNone;
   _writingDirectionMode = ENRMWritingDirectionModeFirstStrong;
   _renderedStyleFingerprint = 0;

--- a/packages/react-native-enriched-markdown/ios/internals/ENRMViewFreeMeasurement.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ENRMViewFreeMeasurement.h
@@ -232,7 +232,12 @@ static inline CGSize ENRMMeasureSegmentedMarkdownViewFree(const PropsT &typedPro
       NSString *tableModeStr = [[NSString alloc] initWithUTF8String:typedProps.streamingConfig.tableMode.c_str()];
       ENRMTableStreamingMode tableStreamingMode =
           [tableModeStr isEqualToString:@"hidden"] ? ENRMTableStreamingModeHidden : ENRMTableStreamingModeProgressive;
-      markdown = ENRMRenderableMarkdownForStreaming(markdown, tableStreamingMode);
+      NSString *codeBlockModeStr =
+          [[NSString alloc] initWithUTF8String:typedProps.streamingConfig.codeBlockMode.c_str()];
+      ENRMCodeBlockStreamingMode codeBlockStreamingMode = [codeBlockModeStr isEqualToString:@"hidden"]
+                                                              ? ENRMCodeBlockStreamingModeHidden
+                                                              : ENRMCodeBlockStreamingModeProgressive;
+      markdown = ENRMRenderableMarkdownForStreaming(markdown, tableStreamingMode, codeBlockStreamingMode);
       if (markdown.length == 0) {
         return fallback;
       }

--- a/packages/react-native-enriched-markdown/ios/internals/ENRMViewFreeMeasurement.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ENRMViewFreeMeasurement.h
@@ -237,7 +237,7 @@ static inline CGSize ENRMMeasureSegmentedMarkdownViewFree(const PropsT &typedPro
       ENRMCodeBlockStreamingMode codeBlockStreamingMode = [codeBlockModeStr isEqualToString:@"hidden"]
                                                               ? ENRMCodeBlockStreamingModeHidden
                                                               : ENRMCodeBlockStreamingModeProgressive;
-      markdown = ENRMRenderableMarkdownForStreaming(markdown, tableStreamingMode, codeBlockStreamingMode);
+      markdown = ENRMRenderableMarkdownForStreaming(markdown, tableStreamingMode, codeBlockStreamingMode, NULL);
       if (markdown.length == 0) {
         return fallback;
       }

--- a/packages/react-native-enriched-markdown/ios/internals/EnrichedMarkdownShadowNode.h
+++ b/packages/react-native-enriched-markdown/ios/internals/EnrichedMarkdownShadowNode.h
@@ -24,7 +24,8 @@ public:
 
   Size measureContent(const LayoutContext &layoutContext, const LayoutConstraints &layoutConstraints) const override;
 
-  static ShadowNodeTraits BaseTraits() {
+  static ShadowNodeTraits BaseTraits()
+  {
     auto traits = ConcreteViewShadowNode::BaseTraits();
     traits.set(ShadowNodeTraits::Trait::LeafYogaNode);
     traits.set(ShadowNodeTraits::Trait::MeasurableYogaNode);
@@ -34,6 +35,7 @@ public:
 private:
   int localHeightRecalculationCounter_{0};
   mutable int lastExactMeasurementCounter_{0};
+  mutable CGSize lastExactMeasurementSize_{0, 0};
 };
 
 } // namespace facebook::react

--- a/packages/react-native-enriched-markdown/ios/internals/EnrichedMarkdownShadowNode.mm
+++ b/packages/react-native-enriched-markdown/ios/internals/EnrichedMarkdownShadowNode.mm
@@ -20,7 +20,9 @@ EnrichedMarkdownShadowNode::EnrichedMarkdownShadowNode(const ShadowNode &sourceS
       localHeightRecalculationCounter_(
           static_cast<const EnrichedMarkdownShadowNode &>(sourceShadowNode).localHeightRecalculationCounter_),
       lastExactMeasurementCounter_(
-          static_cast<const EnrichedMarkdownShadowNode &>(sourceShadowNode).lastExactMeasurementCounter_)
+          static_cast<const EnrichedMarkdownShadowNode &>(sourceShadowNode).lastExactMeasurementCounter_),
+      lastExactMeasurementSize_(
+          static_cast<const EnrichedMarkdownShadowNode &>(sourceShadowNode).lastExactMeasurementSize_)
 {
   const auto &oldProps = *std::static_pointer_cast<const EnrichedMarkdownProps>(sourceShadowNode.getProps());
   const auto &newProps = *std::static_pointer_cast<const EnrichedMarkdownProps>(this->getProps());
@@ -57,7 +59,7 @@ Size EnrichedMarkdownShadowNode::measureContent(const LayoutContext &layoutConte
 
   return ENRMMeasureMarkdownContent<EnrichedMarkdownProps, EnrichedMarkdown>(
       typedProps, getStateData().getComponentViewRef(), receivedCounter, lastExactMeasurementCounter_,
-      MarkdownFlavor::GitHub, layoutContext, layoutConstraints,
+      lastExactMeasurementSize_, MarkdownFlavor::GitHub, layoutContext, layoutConstraints,
       ^(EnrichedMarkdown *view, CGFloat maxWidth, CGFloat fontScale) {
         return ENRMMeasureSegmentedMarkdownViewFree(*props, maxWidth, fontScale, pointScaleFactor,
                                                     resolvedLayoutDirection);

--- a/packages/react-native-enriched-markdown/ios/internals/EnrichedMarkdownTextShadowNode.h
+++ b/packages/react-native-enriched-markdown/ios/internals/EnrichedMarkdownTextShadowNode.h
@@ -26,7 +26,8 @@ public:
 
   Size measureContent(const LayoutContext &layoutContext, const LayoutConstraints &layoutConstraints) const override;
 
-  static ShadowNodeTraits BaseTraits() {
+  static ShadowNodeTraits BaseTraits()
+  {
     auto traits = ConcreteViewShadowNode::BaseTraits();
     traits.set(ShadowNodeTraits::Trait::LeafYogaNode);
     traits.set(ShadowNodeTraits::Trait::MeasurableYogaNode);
@@ -36,6 +37,7 @@ public:
 private:
   int localHeightRecalculationCounter_{0};
   mutable int lastExactMeasurementCounter_{0};
+  mutable CGSize lastExactMeasurementSize_{0, 0};
 };
 
 } // namespace facebook::react

--- a/packages/react-native-enriched-markdown/ios/internals/EnrichedMarkdownTextShadowNode.mm
+++ b/packages/react-native-enriched-markdown/ios/internals/EnrichedMarkdownTextShadowNode.mm
@@ -21,7 +21,9 @@ EnrichedMarkdownTextShadowNode::EnrichedMarkdownTextShadowNode(const ShadowNode 
       localHeightRecalculationCounter_(
           static_cast<const EnrichedMarkdownTextShadowNode &>(sourceShadowNode).localHeightRecalculationCounter_),
       lastExactMeasurementCounter_(
-          static_cast<const EnrichedMarkdownTextShadowNode &>(sourceShadowNode).lastExactMeasurementCounter_)
+          static_cast<const EnrichedMarkdownTextShadowNode &>(sourceShadowNode).lastExactMeasurementCounter_),
+      lastExactMeasurementSize_(
+          static_cast<const EnrichedMarkdownTextShadowNode &>(sourceShadowNode).lastExactMeasurementSize_)
 {
   const auto &oldProps = *std::static_pointer_cast<const EnrichedMarkdownTextProps>(sourceShadowNode.getProps());
   const auto &newProps = *std::static_pointer_cast<const EnrichedMarkdownTextProps>(this->getProps());
@@ -58,7 +60,7 @@ Size EnrichedMarkdownTextShadowNode::measureContent(const LayoutContext &layoutC
 
   return ENRMMeasureMarkdownContent<EnrichedMarkdownTextProps, EnrichedMarkdownText>(
       typedProps, getStateData().getComponentViewRef(), receivedCounter, lastExactMeasurementCounter_,
-      MarkdownFlavor::CommonMark, layoutContext, layoutConstraints,
+      lastExactMeasurementSize_, MarkdownFlavor::CommonMark, layoutContext, layoutConstraints,
       ^(EnrichedMarkdownText *view, CGFloat maxWidth, CGFloat fontScale) {
         return ENRMMeasureMarkdownViewFree(*props, maxWidth, fontScale, pointScaleFactor, resolvedLayoutDirection);
       });

--- a/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
@@ -88,8 +88,8 @@ static inline bool ENRMPropsNeedExactStreamingMeasurement(const PropsT &oldProps
 template <typename PropsT, typename ViewT>
 static inline Size
 ENRMMeasureMarkdownContent(const PropsT &typedProps, const std::shared_ptr<void> &componentViewRef, int receivedCounter,
-                           int &lastExactMeasurementCounter, MarkdownFlavor flavor, const LayoutContext &layoutContext,
-                           const LayoutConstraints &layoutConstraints,
+                           int &lastExactMeasurementCounter, CGSize &lastExactMeasurementSize, MarkdownFlavor flavor,
+                           const LayoutContext &layoutContext, const LayoutConstraints &layoutConstraints,
                            CGSize (^measureUncached)(ViewT *view, CGFloat maxWidth, CGFloat fontScale))
 {
   CGFloat maxWidth = layoutConstraints.maximumSize.width;
@@ -97,7 +97,18 @@ ENRMMeasureMarkdownContent(const PropsT &typedProps, const std::shared_ptr<void>
   RCTInternalGenericWeakWrapper *weakWrapper = (RCTInternalGenericWeakWrapper *)unwrapManagedObject(componentViewRef);
   ViewT *view = weakWrapper ? (ViewT *)weakWrapper.object : nil;
 
+  // Streaming fast path: skip re-measuring when no new height update was
+  // requested (receivedCounter <= lastExactMeasurementCounter). Yoga calls
+  // measureContent several times per layout pass; the first call does the exact
+  // measure and bumps lastExactMeasurementCounter, so later calls in the *same*
+  // pass land here. Return the size that exact measure just produced, not the
+  // view's committed size — the frame isn't committed until Yoga finishes, so
+  // the mailbox is still one generation stale and would clobber the fresh
+  // measurement (freezing the height while streaming).
   if (typedProps.streamingAnimation && view && receivedCounter <= lastExactMeasurementCounter) {
+    if (lastExactMeasurementSize.width > 0 && lastExactMeasurementSize.height > 0) {
+      return ENRMClampMeasuredSize(lastExactMeasurementSize, layoutConstraints);
+    }
     CGSize currentSize = [view lastCommittedLayoutSize];
     if (currentSize.width > 0 && currentSize.height > 0) {
       return ENRMClampMeasuredSize(currentSize, layoutConstraints);
@@ -124,6 +135,7 @@ ENRMMeasureMarkdownContent(const PropsT &typedProps, const std::shared_ptr<void>
 
   if (typedProps.streamingAnimation) {
     lastExactMeasurementCounter = receivedCounter;
+    lastExactMeasurementSize = size;
   }
 
   return ENRMClampMeasuredSize(size, layoutConstraints);

--- a/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ShadowMeasurementUtils.h
@@ -97,14 +97,10 @@ ENRMMeasureMarkdownContent(const PropsT &typedProps, const std::shared_ptr<void>
   RCTInternalGenericWeakWrapper *weakWrapper = (RCTInternalGenericWeakWrapper *)unwrapManagedObject(componentViewRef);
   ViewT *view = weakWrapper ? (ViewT *)weakWrapper.object : nil;
 
-  // Streaming fast path: skip re-measuring when no new height update was
-  // requested (receivedCounter <= lastExactMeasurementCounter). Yoga calls
-  // measureContent several times per layout pass; the first call does the exact
-  // measure and bumps lastExactMeasurementCounter, so later calls in the *same*
-  // pass land here. Return the size that exact measure just produced, not the
-  // view's committed size — the frame isn't committed until Yoga finishes, so
-  // the mailbox is still one generation stale and would clobber the fresh
-  // measurement (freezing the height while streaming).
+  // Streaming fast path. Yoga re-measures several times per pass; the first call
+  // bumps lastExactMeasurementCounter, the rest land here. Return the freshly
+  // measured size, not the view's mailbox — mid-pass the frame isn't committed,
+  // so the mailbox is a generation stale and would freeze the height.
   if (typedProps.streamingAnimation && view && receivedCounter <= lastExactMeasurementCounter) {
     if (lastExactMeasurementSize.width > 0 && lastExactMeasurementSize.height > 0) {
       return ENRMClampMeasuredSize(lastExactMeasurementSize, layoutConstraints);

--- a/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.h
+++ b/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.h
@@ -9,11 +9,21 @@ typedef NS_ENUM(NSInteger, ENRMTableStreamingMode) {
   ENRMTableStreamingModeProgressive,
 };
 
+typedef NS_ENUM(NSInteger, ENRMCodeBlockStreamingMode) {
+  ENRMCodeBlockStreamingModeHidden = 0,
+  ENRMCodeBlockStreamingModeProgressive,
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStreamingMode tableMode);
+NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStreamingMode tableMode,
+                                             ENRMCodeBlockStreamingMode codeBlockMode);
+
+// Whether the markdown ends inside a still-open fenced code block, so the
+// renderer can defer highlighting and header chrome on the trailing block.
+BOOL ENRMMarkdownEndsInsideOpenCodeFence(NSString *markdown);
 
 #ifdef __cplusplus
 }

--- a/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.h
+++ b/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.h
@@ -21,8 +21,7 @@ extern "C" {
 NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStreamingMode tableMode,
                                              ENRMCodeBlockStreamingMode codeBlockMode);
 
-// Whether the markdown ends inside a still-open fenced code block, so the
-// renderer can defer highlighting and header chrome on the trailing block.
+// Whether the markdown ends inside a still-open fenced code block.
 BOOL ENRMMarkdownEndsInsideOpenCodeFence(NSString *markdown);
 
 #ifdef __cplusplus

--- a/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.h
+++ b/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.h
@@ -18,11 +18,12 @@ typedef NS_ENUM(NSInteger, ENRMCodeBlockStreamingMode) {
 extern "C" {
 #endif
 
+// Filtered markdown for the current streaming tick. When non-NULL,
+// outEndsInsideOpenCodeFence reports whether the result ends inside a still-open
+// fenced code block (the trailing block whose chrome the renderer defers).
 NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStreamingMode tableMode,
-                                             ENRMCodeBlockStreamingMode codeBlockMode);
-
-// Whether the markdown ends inside a still-open fenced code block.
-BOOL ENRMMarkdownEndsInsideOpenCodeFence(NSString *markdown);
+                                             ENRMCodeBlockStreamingMode codeBlockMode,
+                                             BOOL *_Nullable outEndsInsideOpenCodeFence);
 
 #ifdef __cplusplus
 }

--- a/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.m
+++ b/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.m
@@ -164,8 +164,7 @@ static NSString *ENRMRemovePendingTablesAndMath(NSString *markdown, ENRMTableStr
   return ENRMRemovePendingStreamingTableBlock(afterMath, linesForTable, tableMode);
 }
 
-// A fenced code block marker: fence character (`` ` `` or `~`), run length and
-// the info string after the run. Returns NO for a line that is not a marker.
+// Parses a fence marker into char/length/info; NO if the line isn't one.
 static BOOL ENRMParseFenceMarker(NSString *line, unichar *outChar, NSUInteger *outLength, NSString **outInfo)
 {
   NSUInteger i = 0;

--- a/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.m
+++ b/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.m
@@ -155,9 +155,12 @@ static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown, NSArra
   return result;
 }
 
-static NSString *ENRMRemovePendingTablesAndMath(NSString *markdown, ENRMTableStreamingMode tableMode)
+static NSString *ENRMRemovePendingTablesAndMath(NSString *markdown, ENRMTableStreamingMode tableMode,
+                                                NSArray<NSString *> *lines)
 {
-  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
+  if (!lines) {
+    lines = [markdown componentsSeparatedByString:@"\n"];
+  }
   NSString *afterMath = ENRMRemovePendingStreamingMathBlock(markdown, lines);
   NSArray<NSString *> *linesForTable =
       (afterMath.length == markdown.length) ? lines : [afterMath componentsSeparatedByString:@"\n"];
@@ -226,19 +229,17 @@ static NSInteger ENRMFindOpenCodeFenceLineIndex(NSArray<NSString *> *lines)
   return openIndex;
 }
 
-BOOL ENRMMarkdownEndsInsideOpenCodeFence(NSString *markdown)
-{
-  return ENRMFindOpenCodeFenceLineIndex([markdown componentsSeparatedByString:@"\n"]) != -1;
-}
-
 NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStreamingMode tableMode,
-                                             ENRMCodeBlockStreamingMode codeBlockMode)
+                                             ENRMCodeBlockStreamingMode codeBlockMode, BOOL *outEndsInsideOpenCodeFence)
 {
   NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
   NSInteger openFenceIndex = ENRMFindOpenCodeFenceLineIndex(lines);
 
   if (openFenceIndex == -1) {
-    return ENRMRemovePendingTablesAndMath(markdown, tableMode);
+    if (outEndsInsideOpenCodeFence) {
+      *outEndsInsideOpenCodeFence = NO;
+    }
+    return ENRMRemovePendingTablesAndMath(markdown, tableMode, lines);
   }
 
   NSUInteger *offsets = ENRMBuildLineOffsets(lines, lines.count);
@@ -247,8 +248,14 @@ NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStream
 
   NSString *head = [markdown substringToIndex:fenceOffset];
   if (codeBlockMode == ENRMCodeBlockStreamingModeHidden) {
-    return ENRMRemovePendingTablesAndMath(head, tableMode);
+    if (outEndsInsideOpenCodeFence) {
+      *outEndsInsideOpenCodeFence = NO;
+    }
+    return ENRMRemovePendingTablesAndMath(head, tableMode, nil);
+  }
+  if (outEndsInsideOpenCodeFence) {
+    *outEndsInsideOpenCodeFence = YES;
   }
   NSString *tail = [markdown substringFromIndex:fenceOffset];
-  return [ENRMRemovePendingTablesAndMath(head, tableMode) stringByAppendingString:tail];
+  return [ENRMRemovePendingTablesAndMath(head, tableMode, nil) stringByAppendingString:tail];
 }

--- a/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.m
+++ b/packages/react-native-enriched-markdown/ios/utils/StreamingMarkdownFilter.m
@@ -155,11 +155,101 @@ static NSString *ENRMRemovePendingStreamingTableBlock(NSString *markdown, NSArra
   return result;
 }
 
-NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStreamingMode tableMode)
+static NSString *ENRMRemovePendingTablesAndMath(NSString *markdown, ENRMTableStreamingMode tableMode)
 {
   NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
   NSString *afterMath = ENRMRemovePendingStreamingMathBlock(markdown, lines);
   NSArray<NSString *> *linesForTable =
       (afterMath.length == markdown.length) ? lines : [afterMath componentsSeparatedByString:@"\n"];
   return ENRMRemovePendingStreamingTableBlock(afterMath, linesForTable, tableMode);
+}
+
+// A fenced code block marker: fence character (`` ` `` or `~`), run length and
+// the info string after the run. Returns NO for a line that is not a marker.
+static BOOL ENRMParseFenceMarker(NSString *line, unichar *outChar, NSUInteger *outLength, NSString **outInfo)
+{
+  NSUInteger i = 0;
+  while (i < line.length && [line characterAtIndex:i] == ' ' && i < 3) {
+    i++;
+  }
+  if (i >= line.length) {
+    return NO;
+  }
+  unichar ch = [line characterAtIndex:i];
+  if (ch != '`' && ch != '~') {
+    return NO;
+  }
+  NSUInteger runLength = 0;
+  while (i < line.length && [line characterAtIndex:i] == ch) {
+    i++;
+    runLength++;
+  }
+  if (runLength < 3) {
+    return NO;
+  }
+  NSString *info = [line substringFromIndex:i];
+  if (ch == '`' && [info rangeOfString:@"`"].location != NSNotFound) {
+    return NO;
+  }
+  if (outChar) {
+    *outChar = ch;
+  }
+  if (outLength) {
+    *outLength = runLength;
+  }
+  if (outInfo) {
+    *outInfo = info;
+  }
+  return YES;
+}
+
+static NSInteger ENRMFindOpenCodeFenceLineIndex(NSArray<NSString *> *lines)
+{
+  NSInteger openIndex = -1;
+  unichar openChar = 0;
+  NSUInteger openLength = 0;
+  for (NSUInteger i = 0; i < lines.count; i++) {
+    unichar ch = 0;
+    NSUInteger length = 0;
+    NSString *info = nil;
+    BOOL isMarker = ENRMParseFenceMarker(lines[i], &ch, &length, &info);
+    if (openIndex == -1) {
+      if (isMarker) {
+        openIndex = (NSInteger)i;
+        openChar = ch;
+        openLength = length;
+      }
+    } else if (isMarker && ch == openChar && length >= openLength &&
+               [info stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]].length == 0) {
+      openIndex = -1;
+    }
+  }
+  return openIndex;
+}
+
+BOOL ENRMMarkdownEndsInsideOpenCodeFence(NSString *markdown)
+{
+  return ENRMFindOpenCodeFenceLineIndex([markdown componentsSeparatedByString:@"\n"]) != -1;
+}
+
+NSString *ENRMRenderableMarkdownForStreaming(NSString *markdown, ENRMTableStreamingMode tableMode,
+                                             ENRMCodeBlockStreamingMode codeBlockMode)
+{
+  NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
+  NSInteger openFenceIndex = ENRMFindOpenCodeFenceLineIndex(lines);
+
+  if (openFenceIndex == -1) {
+    return ENRMRemovePendingTablesAndMath(markdown, tableMode);
+  }
+
+  NSUInteger *offsets = ENRMBuildLineOffsets(lines, lines.count);
+  NSUInteger fenceOffset = offsets[(NSUInteger)openFenceIndex];
+  free(offsets);
+
+  NSString *head = [markdown substringToIndex:fenceOffset];
+  if (codeBlockMode == ENRMCodeBlockStreamingModeHidden) {
+    return ENRMRemovePendingTablesAndMath(head, tableMode);
+  }
+  NSString *tail = [markdown substringFromIndex:fenceOffset];
+  return [ENRMRemovePendingTablesAndMath(head, tableMode) stringByAppendingString:tail];
 }

--- a/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.h
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.h
@@ -22,6 +22,11 @@ typedef void (^ENRMCodeBlockCopyBlock)(NSString *code, NSString *language);
 
 @property (nonatomic, strong) StyleConfig *config;
 
+// True while this block's closing fence has not streamed in yet: syntax
+// highlighting and the header chrome (language label, copy button) are held
+// back so they appear once atomically when the block completes.
+@property (nonatomic, assign) BOOL pending;
+
 // Renamed getters avoid the Cocoa `copy` method family (which signals +1
 // retained returns). Property names are unchanged so call sites stay the same.
 @property (nonatomic, copy, nullable, getter=menuCopyLabel) NSString *copyLabel;

--- a/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.h
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.h
@@ -22,9 +22,8 @@ typedef void (^ENRMCodeBlockCopyBlock)(NSString *code, NSString *language);
 
 @property (nonatomic, strong) StyleConfig *config;
 
-// True while this block's closing fence has not streamed in yet: syntax
-// highlighting and the header chrome (language label, copy button) are held
-// back so they appear once atomically when the block completes.
+// True until the closing fence arrives: highlighting is deferred and copying is
+// disabled, while the header stays visible.
 @property (nonatomic, assign) BOOL pending;
 
 // Renamed getters avoid the Cocoa `copy` method family (which signals +1

--- a/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
@@ -175,6 +175,22 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
   _copyButton.accessibilityLabel = _copyLabel;
 }
 
+- (void)setPending:(BOOL)pending
+{
+  if (_pending == pending) {
+    return;
+  }
+  _pending = pending;
+  // The header (language label + copy button) stays visible while streaming;
+  // only copying is held back until the closing fence arrives.
+  _copyButton.enabled = !pending;
+#if !TARGET_OS_OSX
+  [self setNeedsDisplay];
+#else
+  [self setNeedsDisplay:YES];
+#endif
+}
+
 - (instancetype)initWithConfig:(StyleConfig *)config
 {
   self = [super initWithFrame:CGRectZero];
@@ -331,7 +347,8 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
   }
 
   NSAttributedString *plainCode = [self plainAttributedCode];
-  NSAttributedString *highlighted = ENRMHighlightedAttributedCode(plainCode, _cachedCode, _cachedLanguage, _config);
+  NSAttributedString *highlighted =
+      _pending ? nil : ENRMHighlightedAttributedCode(plainCode, _cachedCode, _cachedLanguage, _config);
   _attributedCode = highlighted ?: plainCode;
 
   _codeSize = ENRMCodeBlockCodeSize(_attributedCode);
@@ -458,6 +475,9 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
 - (UIContextMenuConfiguration *)contextMenuInteraction:(UIContextMenuInteraction *)interaction
                         configurationForMenuAtLocation:(CGPoint)location
 {
+  if (_pending) {
+    return nil;
+  }
   return [UIContextMenuConfiguration
       configurationWithIdentifier:nil
                   previewProvider:nil
@@ -482,6 +502,9 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
 #if TARGET_OS_OSX
 - (NSMenu *)buildContextMenu
 {
+  if (_pending) {
+    return nil;
+  }
   NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
   [menu addItem:ENRMCreateMenuItem(self.copyLabel, ^{ [self copyCodeToPasteboard]; })];
   [menu addItem:ENRMCreateMenuItem(self.copyAsMarkdownLabel, ^{ [self copyMarkdownToPasteboard]; })];
@@ -509,7 +532,7 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
 // button subview from VoiceOver; expose the copy action explicitly instead.
 - (NSArray<UIAccessibilityCustomAction *> *)accessibilityCustomActions
 {
-  if (self.copyLabel.length == 0) {
+  if (_pending || self.copyLabel.length == 0) {
     return @[];
   }
   UIAccessibilityCustomAction *copyAction =

--- a/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
@@ -183,10 +183,17 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
   _pending = pending;
   // Header stays visible while streaming; only copying is held back.
   _copyButton.enabled = !pending;
+  // The reconciler can reuse an unchanged block without re-applying the node, so
+  // re-derive here to pick up highlighting once the block closes.
+  [self rebuildAttributedCode];
 #if !TARGET_OS_OSX
+  [self setNeedsLayout];
   [self setNeedsDisplay];
+  [_codeContentView setNeedsDisplay];
 #else
+  self.needsLayout = YES;
   [self setNeedsDisplay:YES];
+  [_codeContentView setNeedsDisplay:YES];
 #endif
 }
 
@@ -332,6 +339,17 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
 }
 #endif
 
+// Highlighting is deferred while pending, applied once the block closes.
+- (void)rebuildAttributedCode
+{
+  NSAttributedString *plainCode = [self plainAttributedCode];
+  NSAttributedString *highlighted =
+      _pending ? nil : ENRMHighlightedAttributedCode(plainCode, _cachedCode, _cachedLanguage, _config);
+  _attributedCode = highlighted ?: plainCode;
+  _codeSize = ENRMCodeBlockCodeSize(_attributedCode);
+  _codeContentView.attributedCode = _attributedCode;
+}
+
 - (void)applyCodeBlockNode:(MarkdownASTNode *)node
 {
   _cachedCode = ENRMCodeBlockExtractCode(node);
@@ -345,13 +363,7 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
     [self rebuildLanguageLabel];
   }
 
-  NSAttributedString *plainCode = [self plainAttributedCode];
-  NSAttributedString *highlighted =
-      _pending ? nil : ENRMHighlightedAttributedCode(plainCode, _cachedCode, _cachedLanguage, _config);
-  _attributedCode = highlighted ?: plainCode;
-
-  _codeSize = ENRMCodeBlockCodeSize(_attributedCode);
-  _codeContentView.attributedCode = _attributedCode;
+  [self rebuildAttributedCode];
 
 #if !TARGET_OS_OSX
   [self setNeedsLayout];

--- a/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
@@ -181,8 +181,7 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
     return;
   }
   _pending = pending;
-  // The header (language label + copy button) stays visible while streaming;
-  // only copying is held back until the closing fence arrives.
+  // Header stays visible while streaming; only copying is held back.
   _copyButton.enabled = !pending;
 #if !TARGET_OS_OSX
   [self setNeedsDisplay];

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
@@ -353,6 +353,7 @@ export interface Md4cFlagsInternal {
 
 interface StreamingConfigInternal {
   tableMode: string;
+  codeBlockMode: string;
 }
 
 export interface NativeProps extends ViewProps {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
@@ -354,6 +354,7 @@ export interface Md4cFlagsInternal {
 
 interface StreamingConfigInternal {
   tableMode: string;
+  codeBlockMode: string;
 }
 
 export interface NativeProps extends ViewProps {

--- a/packages/react-native-enriched-markdown/src/native/EnrichedMarkdownText.tsx
+++ b/packages/react-native-enriched-markdown/src/native/EnrichedMarkdownText.tsx
@@ -238,7 +238,11 @@ export const EnrichedMarkdownText = ({
   );
 
   const tableMode = streamingConfig?.tableMode ?? 'progressive';
-  const normalizedStreamingConfig = useMemo(() => ({ tableMode }), [tableMode]);
+  const codeBlockMode = streamingConfig?.codeBlockMode ?? 'progressive';
+  const normalizedStreamingConfig = useMemo(
+    () => ({ tableMode, codeBlockMode }),
+    [tableMode, codeBlockMode]
+  );
   const normalizedSelectionMenuConfig = useMemo(() => {
     // The boolean acceptance is confined to this wrapper boundary via a single
     // `as unknown` cast; the public type only exposes the object shape.

--- a/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
@@ -99,6 +99,18 @@ export interface StreamingConfig {
    * @platform ios, android
    */
   tableMode?: 'hidden' | 'progressive';
+  /**
+   * Controls how a fenced code block whose closing fence has not arrived yet
+   * is handled during streaming.
+   * - `'hidden'`: hide the entire code block until its closing fence arrives.
+   * - `'progressive'` (default): show the code as it streams in with its header
+   *   visible but non-interactive (copying is disabled); syntax highlighting is
+   *   deferred until the closing fence arrives, so it appears once atomically.
+   * Only effective when `streamingAnimation` is `true`.
+   * @default 'progressive'
+   * @platform ios, android
+   */
+  codeBlockMode?: 'hidden' | 'progressive';
 }
 
 export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {


### PR DESCRIPTION
### What/Why?

Adds **streaming support for fenced code blocks** (GitHub flavor), mirroring the existing table/math streaming model, plus a measurement fix that surfaced while building it.

**New `streamingConfig.codeBlockMode` prop** (`'progressive'` default | `'hidden'`), only active with `streamingAnimation`:
- **`progressive`** — the code streams in line-by-line. Its header (language label + copy button) stays visible but **non-interactive** (copy is disabled), and **syntax highlighting is deferred** until the closing fence arrives, so it applies once instead of flickering on every token.
- **`hidden`** — the whole block stays hidden until its closing fence arrives, then appears complete (same all-or-nothing
behavior as block math).

### Additional fix
Yoga calls `measureContent` several times per layout pass. The first call did the exact measure and bumped `lastExactMeasurementCounter`; later calls in the same pass took the streaming fast-path and returned the view's *not-yet-committed* (stale) mailbox size, clobbering the fresh measurement. With content that changes every tick (a streaming code block), this froze the committed height permanently → the region below the code block went invisible / twitched. Fixed by caching the last exact size and returning that from the fast-path. This also makes existing
text/table/math streaming measurement strictly more correct.

### Testing
Run example app's streaming test

#### Screenshots
| | iOS | Android |
| - | - | - |
| progresive (default) | <video src="https://github.com/user-attachments/assets/e53369f4-5ded-4f7f-9e88-8f40695aa360" width="300" /> | <video src="https://github.com/user-attachments/assets/43a3664b-8ae5-4d60-9fe1-8e107acb8bf8" width="300" /> |
| hidden | <video src="https://github.com/user-attachments/assets/d50d7a74-c1c2-4681-9134-dda426c0957a" width="300" /> | <video src="https://github.com/user-attachments/assets/60abba49-dd74-4d6d-a657-d92fb5acb079" width="300" /> |


### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)