### PR TITLE
feat(ios): add onLinkLongPress handler

### DIFF
--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
@@ -11,6 +11,8 @@ struct PlaygroundScreen: View {
     @State private var rawInput: String = ""
     @State private var blockImageURI: String?
     @State private var inlineImageURI: String?
+    @State private var longPressedLink: String = ""
+    @State private var linkAlertVisible: Bool = false
 
     // MARK: - Views
 
@@ -55,6 +57,15 @@ struct PlaygroundScreen: View {
         .markdownSelectionMenu(MarkdownSelectionMenuConfig())
         .markdownSelectable(selectableEnabled)
         .markdownSelectionColor(.orange)
+        .onLinkLongPress { url in
+            longPressedLink = url.absoluteString
+            linkAlertVisible = true
+        }
+        .alert("Link long-pressed", isPresented: $linkAlertVisible) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(longPressedLink)
+        }
         .onAppear(perform: loadBundledImages)
         .sheet(isPresented: $setMarkdownSheetVisible) {
             SetMarkdownSheet(

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -9,6 +9,7 @@ public struct EnrichedMarkdownText: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.markdownLinkPressHandler) private var onLinkPress
+    @Environment(\.markdownLinkLongPressHandler) private var onLinkLongPress
     @Environment(\.markdownSelectionMenu) private var selectionMenuConfig
     @Environment(\.markdownSelectable) private var isSelectionEnabled
     @Environment(\.markdownSelectionColor) private var selectionColor
@@ -33,6 +34,7 @@ public struct EnrichedMarkdownText: View {
             sourceMarkdown: renderStore.sourceMarkdown,
             styleConfig: styleConfig,
             onLinkPress: onLinkPress,
+            onLinkLongPress: onLinkLongPress,
             selectionMenuConfig: selectionMenuConfig,
             isSelectionEnabled: isSelectionEnabled,
             selectionColor: selectionColor

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Environment+LinkPress.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Environment+LinkPress.swift
@@ -4,15 +4,31 @@ private struct MarkdownLinkPressHandlerKey: EnvironmentKey {
     static let defaultValue: ((URL) -> Void)? = nil
 }
 
+private struct MarkdownLinkLongPressHandlerKey: EnvironmentKey {
+    static let defaultValue: ((URL) -> Void)? = nil
+}
+
 public extension EnvironmentValues {
     var markdownLinkPressHandler: ((URL) -> Void)? {
         get { self[MarkdownLinkPressHandlerKey.self] }
         set { self[MarkdownLinkPressHandlerKey.self] = newValue }
+    }
+
+    var markdownLinkLongPressHandler: ((URL) -> Void)? {
+        get { self[MarkdownLinkLongPressHandlerKey.self] }
+        set { self[MarkdownLinkLongPressHandlerKey.self] = newValue }
     }
 }
 
 public extension View {
     func onLinkPress(_ action: @escaping (URL) -> Void) -> some View {
         environment(\.markdownLinkPressHandler, action)
+    }
+
+    /// Called when a link is long-pressed, replacing the system link menu.
+    /// Without this handler, a long-press behaves like a press when
+    /// `onLinkPress` is set.
+    func onLinkLongPress(_ action: @escaping (URL) -> Void) -> some View {
+        environment(\.markdownLinkLongPressHandler, action)
     }
 }

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -6,6 +6,7 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
     let sourceMarkdown: String?
     let styleConfig: MarkdownStyleConfig
     let onLinkPress: ((URL) -> Void)?
+    let onLinkLongPress: ((URL) -> Void)?
     let selectionMenuConfig: MarkdownSelectionMenuConfig
     let isSelectionEnabled: Bool
     let selectionColor: Color?
@@ -23,6 +24,7 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
 
     func updateUIView(_ textView: MarkdownTextView, context: Context) {
         context.coordinator.onLinkPress = onLinkPress
+        context.coordinator.onLinkLongPress = onLinkLongPress
         context.coordinator.sourceMarkdown = sourceMarkdown
         context.coordinator.selectionMenuConfig = selectionMenuConfig
         textView.styleConfig = styleConfig
@@ -44,20 +46,70 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
 
     final class Coordinator: NSObject, UITextViewDelegate {
         var onLinkPress: ((URL) -> Void)?
+        var onLinkLongPress: ((URL) -> Void)?
         var sourceMarkdown: String?
         var selectionMenuConfig = MarkdownSelectionMenuConfig()
 
+        /// Routes a link tap; returns true when a handler consumed it.
+        func handleLinkPress(_ url: URL) -> Bool {
+            guard let onLinkPress else { return false }
+            onLinkPress(url)
+            return true
+        }
+
+        /// Routes a link long-press; returns true when a handler consumed it.
+        /// Without a long-press handler, a press handler consumes every link
+        /// interaction (pre-existing behavior: suppresses the system
+        /// menu/preview and fires the press).
+        func handleLinkLongPress(_ url: URL) -> Bool {
+            if let onLinkLongPress {
+                onLinkLongPress(url)
+                return true
+            }
+            return handleLinkPress(url)
+        }
+
+        // iOS 15–16 (and 17+ fallback when the UITextItem methods are
+        // unavailable): tap arrives as .invokeDefaultAction, long-press as
+        // .presentActions or .preview.
         func textView(
             _ textView: UITextView,
             shouldInteractWith URL: URL,
             in characterRange: NSRange,
             interaction: UITextItemInteraction
         ) -> Bool {
-            if let onLinkPress {
-                onLinkPress(URL)
-                return false
+            switch interaction {
+            case .invokeDefaultAction:
+                return !handleLinkPress(URL)
+            case .presentActions, .preview:
+                return !handleLinkLongPress(URL)
+            @unknown default:
+                return true
             }
-            return true
+        }
+
+        @available(iOS 17.0, *)
+        func textView(
+            _ textView: UITextView,
+            primaryActionFor textItem: UITextItem,
+            defaultAction: UIAction
+        ) -> UIAction? {
+            guard case .link(let url) = textItem.content, let onLinkPress else {
+                return defaultAction
+            }
+            return UIAction { _ in onLinkPress(url) }
+        }
+
+        @available(iOS 17.0, *)
+        func textView(
+            _ textView: UITextView,
+            menuConfigurationFor textItem: UITextItem,
+            defaultMenu: UIMenu
+        ) -> UITextItem.MenuConfiguration? {
+            guard case .link(let url) = textItem.content else {
+                return UITextItem.MenuConfiguration(menu: defaultMenu)
+            }
+            return handleLinkLongPress(url) ? nil : UITextItem.MenuConfiguration(menu: defaultMenu)
         }
 
         @available(iOS 16.0, *)

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/LinkInteractionTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/LinkInteractionTests.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+final class LinkInteractionTests: XCTestCase {
+    private var coordinator: MarkdownTextViewRepresentable.Coordinator!
+    private var textView: UITextView!
+    private let url = URL(string: "https://swmansion.com")!
+    private let range = NSRange(location: 0, length: 4)
+
+    override func setUp() {
+        super.setUp()
+        coordinator = MarkdownTextViewRepresentable.Coordinator()
+        textView = UITextView()
+    }
+
+    private func interact(_ interaction: UITextItemInteraction) -> Bool {
+        coordinator.textView(textView, shouldInteractWith: url, in: range, interaction: interaction)
+    }
+
+    func testTapFiresPressHandlerAndConsumesInteraction() {
+        var pressedURL: URL?
+        coordinator.onLinkPress = { pressedURL = $0 }
+
+        XCTAssertFalse(interact(.invokeDefaultAction))
+        XCTAssertEqual(pressedURL, url)
+    }
+
+    func testTapWithoutHandlersKeepsSystemBehavior() {
+        XCTAssertTrue(interact(.invokeDefaultAction))
+    }
+
+    func testLongPressPrefersLongPressHandler() {
+        var pressed = false
+        var longPressedURL: URL?
+        coordinator.onLinkPress = { _ in pressed = true }
+        coordinator.onLinkLongPress = { longPressedURL = $0 }
+
+        XCTAssertFalse(interact(.presentActions))
+        XCTAssertEqual(longPressedURL, url)
+        XCTAssertFalse(pressed)
+    }
+
+    func testLongPressFallsBackToPressHandler() {
+        // Pre-existing behavior: with only a press handler, every link
+        // interaction fires it and suppresses the system menu.
+        var pressedURL: URL?
+        coordinator.onLinkPress = { pressedURL = $0 }
+
+        XCTAssertFalse(interact(.presentActions))
+        XCTAssertEqual(pressedURL, url)
+    }
+
+    func testLongPressWithoutHandlersKeepsSystemBehavior() {
+        XCTAssertTrue(interact(.presentActions))
+    }
+
+    func testPreviewRoutesLikeLongPress() {
+        var longPressedURL: URL?
+        coordinator.onLinkLongPress = { longPressedURL = $0 }
+
+        XCTAssertFalse(interact(.preview))
+        XCTAssertEqual(longPressedURL, url)
+    }
+
+    func testHandleLinkLongPressReportsConsumption() {
+        XCTAssertFalse(coordinator.handleLinkLongPress(url))
+
+        coordinator.onLinkLongPress = { _ in }
+        XCTAssertTrue(coordinator.handleLinkLongPress(url))
+    }
+
+    func testEnvironmentDefaultsToNoLongPressHandler() {
+        XCTAssertNil(EnvironmentValues().markdownLinkLongPressHandler)
+    }
+}


### PR DESCRIPTION
Adds an .onLinkLongPress(_:) environment modifier matching the Android package's onLinkLongPress callback. Link interactions route through the UITextViewDelegate on both generations: the legacy shouldInteractWith path (iOS 15-16) switches on the interaction type, and the iOS 17 UITextItem methods return a primary action for taps and suppress the system link menu when a long-press handler consumes the gesture.

With only a press handler set, a long-press keeps the pre-existing behavior of firing the press and suppressing the menu.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

