### PR TITLE
feat(ios): add image request headers

### DIFF
--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
@@ -13,6 +13,7 @@ struct PlaygroundScreen: View {
     @State private var inlineImageURI: String?
     @State private var longPressedLink: String = ""
     @State private var linkAlertVisible: Bool = false
+    @State private var acceptImageType: String = "image/png"
 
     // MARK: - Views
 
@@ -46,6 +47,19 @@ struct PlaygroundScreen: View {
                     }
                 }
 
+                HStack(spacing: 8) {
+                    PlaygroundButton(label: "Insert Header Image", accessibilityId: "insert-header-image-button") {
+                        insertHeaderImage()
+                    }
+                    PlaygroundButton(
+                        label: "Accept: \(acceptImageType == "image/png" ? "PNG" : "JPEG")",
+                        accessibilityId: "accept-header-button",
+                        isActive: acceptImageType == "image/png"
+                    ) {
+                        acceptImageType = acceptImageType == "image/png" ? "image/jpeg" : "image/png"
+                    }
+                }
+
                 setMarkdownButton
                 preview
             }
@@ -57,6 +71,7 @@ struct PlaygroundScreen: View {
         .markdownSelectionMenu(MarkdownSelectionMenuConfig())
         .markdownSelectable(selectableEnabled)
         .markdownSelectionColor(.orange)
+        .markdownImageRequestHeaders(["Accept": acceptImageType])
         .onLinkLongPress { url in
             longPressedLink = url.absoluteString
             linkAlertVisible = true
@@ -138,6 +153,19 @@ struct PlaygroundScreen: View {
     private func insertInlineImage() {
         guard let uri = inlineImageURI else { return }
         markdown = "Enriched Markdown is a library for ![icon](\(uri)) React Native."
+    }
+
+    // httpbingo.org negotiates the response image from the Accept header (and
+    // rejects requests without one), so this image only renders because
+    // markdownImageRequestHeaders reaches the wire — and toggling the header
+    // shows a different image for the same URL via the header-aware cache.
+    private func insertHeaderImage() {
+        let imageMarkdown = "![header image](https://httpbingo.org/image)"
+        if markdown.isEmpty {
+            markdown = imageMarkdown
+        } else {
+            markdown += "\n\n\(imageMarkdown)"
+        }
     }
 }
 

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Attachments/MarkdownImageAttachment.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Attachments/MarkdownImageAttachment.swift
@@ -9,12 +9,13 @@ final class MarkdownImageAttachment: NSTextAttachment {
     }()
 
     private static let processedImageCache = NSCache<NSString, UIImage>()
-    private static let registry = NSMapTable<NSString, MarkdownImageAttachment>.strongToWeakObjects()
 
     let imageURL: String
+    let requestHeaders: [String: String]
     let isInline: Bool
     let cachedHeight: CGFloat
     let cachedBorderRadius: CGFloat
+    private let requestKey: String
     private let downloader: ImageDownloading
 
     private var originalImage: UIImage?
@@ -22,27 +23,28 @@ final class MarkdownImageAttachment: NSTextAttachment {
     private weak var textContainer: NSTextContainer?
     private var lastProcessedKey: String?
 
+    /// Always returns a fresh attachment: an NSTextAttachment carries
+    /// per-position layout state (bounds, text container, refresh range), so
+    /// instances must never be shared between string positions or views.
+    /// Re-renders stay flicker-free through the original/processed image
+    /// caches, which hit synchronously.
     static func attachment(
         for url: String,
         config: MarkdownStyleConfig,
         isInline: Bool,
         altText: String,
+        requestHeaders: [String: String] = [:],
         downloader: ImageDownloading = ImageDownloader.shared
     ) -> MarkdownImageAttachment {
-        let key = "\(url)_\(isInline)" as NSString
-        if let existing = registry.object(forKey: key), existing.loadedImage != nil {
-            return existing
-        }
-
-        let attachment = MarkdownImageAttachment(
+        MarkdownImageAttachment(
             url: url,
             config: config,
             isInline: isInline,
             altText: altText,
+            requestHeaders: requestHeaders,
+            requestKey: ImageCacheKey.requestKey(url: url, headers: requestHeaders),
             downloader: downloader
         )
-        registry.setObject(attachment, forKey: key)
-        return attachment
     }
 
     private init(
@@ -50,9 +52,13 @@ final class MarkdownImageAttachment: NSTextAttachment {
         config: MarkdownStyleConfig,
         isInline: Bool,
         altText: String,
+        requestHeaders: [String: String],
+        requestKey: String,
         downloader: ImageDownloading
     ) {
         imageURL = url
+        self.requestHeaders = requestHeaders
+        self.requestKey = requestKey
         self.isInline = isInline
         self.downloader = downloader
         cachedHeight = isInline
@@ -126,7 +132,7 @@ final class MarkdownImageAttachment: NSTextAttachment {
 
     private func startDownloadingImage() {
         guard !imageURL.isEmpty else { return }
-        downloader.download(url: imageURL) { [weak self] image in
+        downloader.download(url: imageURL, headers: requestHeaders) { [weak self] image in
             self?.handleLoadedImage(image)
         }
     }
@@ -144,7 +150,7 @@ final class MarkdownImageAttachment: NSTextAttachment {
     private func processAndApplyImage(_ image: UIImage, targetWidth: CGFloat) {
         guard targetWidth > 0 else { return }
 
-        let processedKey = "\(imageURL)_w\(targetWidth)_h\(cachedHeight)_r\(cachedBorderRadius)"
+        let processedKey = "\(requestKey)_w\(targetWidth)_h\(cachedHeight)_r\(cachedBorderRadius)"
         if processedKey == lastProcessedKey { return }
         lastProcessedKey = processedKey
 

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/AttributedRenderer.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/AttributedRenderer.swift
@@ -4,9 +4,9 @@ final class AttributedRenderer {
     private let config: MarkdownStyleConfig
     private let factory: RendererFactory
 
-    init(config: MarkdownStyleConfig) {
+    init(config: MarkdownStyleConfig, imageRequestHeaders: [String: String] = [:]) {
         self.config = config
-        self.factory = RendererFactory(config: config)
+        self.factory = RendererFactory(config: config, imageRequestHeaders: imageRequestHeaders)
     }
 
     func renderRoot(_ root: MarkdownASTNode) -> NSMutableAttributedString {

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/MarkdownRenderer.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/MarkdownRenderer.swift
@@ -4,10 +4,11 @@ public enum MarkdownRenderer {
     public static func render(
         _ markdown: String,
         config: MarkdownStyleConfig,
-        flags: Md4cFlags = .commonMark
+        flags: Md4cFlags = .commonMark,
+        imageRequestHeaders: [String: String] = [:]
     ) -> NSAttributedString {
         let ast = Parser.shared.parseMarkdown(markdown, flags: flags)
-        let renderer = AttributedRenderer(config: config)
+        let renderer = AttributedRenderer(config: config, imageRequestHeaders: imageRequestHeaders)
         return renderer.renderRoot(ast)
     }
 }

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
@@ -2,11 +2,13 @@ import UIKit
 
 final class RendererFactory {
     private let config: MarkdownStyleConfig
+    private let imageRequestHeaders: [String: String]
     private var cache: [NodeType: NodeRenderer] = [:]
     private lazy var childrenOnlyRenderer = ChildrenOnlyRenderer(factory: self)
 
-    init(config: MarkdownStyleConfig) {
+    init(config: MarkdownStyleConfig, imageRequestHeaders: [String: String] = [:]) {
         self.config = config
+        self.imageRequestHeaders = imageRequestHeaders
     }
 
     func renderer(for type: NodeType) -> NodeRenderer {
@@ -60,7 +62,7 @@ final class RendererFactory {
         case .code:
             return CodeRenderer(factory: self, config: config)
         case .image:
-            return ImageRenderer(config: config)
+            return ImageRenderer(config: config, requestHeaders: imageRequestHeaders)
         default:
             return nil
         }

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/ImageRenderer.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Rendering/Renderers/ImageRenderer.swift
@@ -2,9 +2,11 @@ import UIKit
 
 final class ImageRenderer: NodeRenderer {
     private let config: MarkdownStyleConfig
+    private let requestHeaders: [String: String]
 
-    init(config: MarkdownStyleConfig) {
+    init(config: MarkdownStyleConfig, requestHeaders: [String: String] = [:]) {
         self.config = config
+        self.requestHeaders = requestHeaders
     }
 
     func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
@@ -16,7 +18,8 @@ final class ImageRenderer: NodeRenderer {
             for: url,
             config: config,
             isInline: isInline,
-            altText: altText
+            altText: altText,
+            requestHeaders: requestHeaders
         )
 
         let imageString = NSAttributedString(attachment: attachment)

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/ImageCacheKey.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/ImageCacheKey.swift
@@ -1,0 +1,20 @@
+import CryptoKit
+import Foundation
+
+enum ImageCacheKey {
+    /// Returns the URL unchanged when no headers are set; otherwise appends a
+    /// SHA-256 digest of the sorted header pairs, so the same URL fetched with
+    /// different headers is cached and deduplicated separately without
+    /// embedding header values in the key. Matches the Android
+    /// implementation (`ImageCache.requestKey`) byte for byte.
+    static func requestKey(url: String, headers: [String: String]) -> String {
+        guard !headers.isEmpty else { return url }
+        let joined = headers
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key):\($0.value)" }
+            .joined(separator: "\n")
+        let digest = SHA256.hash(data: Data(joined.utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return url + "|" + hex
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/ImageDownloader.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/ImageDownloader.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Abstraction over image fetching so consumers of attachments can inject
 /// a stub in tests and previews instead of hitting the network.
 protocol ImageDownloading: AnyObject {
-    func download(url: String, completion: @escaping (UIImage?) -> Void)
+    func download(url: String, headers: [String: String], completion: @escaping (UIImage?) -> Void)
 }
 
 final class ImageDownloader: ImageDownloading {
@@ -25,48 +25,54 @@ final class ImageDownloader: ImageDownloading {
         session = URLSession(configuration: configuration)
     }
 
-    func download(url: String, completion: @escaping (UIImage?) -> Void) {
+    func download(url: String, headers: [String: String], completion: @escaping (UIImage?) -> Void) {
         guard !url.isEmpty else {
             completion(nil)
             return
         }
 
-        if let cached = MarkdownImageAttachment.originalImageCache.object(forKey: url as NSString) {
+        let requestKey = ImageCacheKey.requestKey(url: url, headers: headers)
+        if let cached = MarkdownImageAttachment.originalImageCache.object(forKey: requestKey as NSString) {
             completion(cached)
             return
         }
 
         lock.lock()
-        if var existing = inFlightRequests[url] {
+        if var existing = inFlightRequests[requestKey] {
             existing.append(completion)
-            inFlightRequests[url] = existing
+            inFlightRequests[requestKey] = existing
             lock.unlock()
             return
         }
-        inFlightRequests[url] = [completion]
+        inFlightRequests[requestKey] = [completion]
         lock.unlock()
 
         guard let requestURL = URL(string: url) else {
-            dispatchCallbacks(for: url, image: nil)
+            dispatchCallbacks(for: requestKey, image: nil)
             return
         }
 
-        session.dataTask(with: requestURL) { [weak self] data, _, error in
+        var request = URLRequest(url: requestURL)
+        for (field, value) in headers {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+
+        session.dataTask(with: request) { [weak self] data, _, error in
             let image = (data != nil && error == nil) ? UIImage(data: data!) : nil
             if let image {
                 MarkdownImageAttachment.originalImageCache.setObject(
                     image,
-                    forKey: url as NSString,
+                    forKey: requestKey as NSString,
                     cost: Self.byteCost(for: image)
                 )
             }
-            self?.dispatchCallbacks(for: url, image: image)
+            self?.dispatchCallbacks(for: requestKey, image: image)
         }.resume()
     }
 
-    private func dispatchCallbacks(for url: String, image: UIImage?) {
+    private func dispatchCallbacks(for requestKey: String, image: UIImage?) {
         lock.lock()
-        let callbacks = inFlightRequests.removeValue(forKey: url) ?? []
+        let callbacks = inFlightRequests.removeValue(forKey: requestKey) ?? []
         lock.unlock()
         DispatchQueue.main.async {
             callbacks.forEach { $0(image) }

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -13,6 +13,7 @@ public struct EnrichedMarkdownText: View {
     @Environment(\.markdownSelectionMenu) private var selectionMenuConfig
     @Environment(\.markdownSelectable) private var isSelectionEnabled
     @Environment(\.markdownSelectionColor) private var selectionColor
+    @Environment(\.markdownImageRequestHeaders) private var imageRequestHeaders
     @StateObject private var renderStore = MarkdownRenderStore()
 
     public init(_ markdown: String, flags: Md4cFlags = .commonMark) {
@@ -41,16 +42,47 @@ public struct EnrichedMarkdownText: View {
         )
         .fixedSize(horizontal: false, vertical: true)
         .onAppear {
-            renderStore.schedule(markdown: markdown, config: styleConfig, flags: flags)
+            renderStore.schedule(
+                markdown: markdown,
+                config: styleConfig,
+                flags: flags,
+                imageRequestHeaders: imageRequestHeaders
+            )
         }
+        // The onChange closures run against the previous view value, so the
+        // changed value must come from the closure parameter — reading the
+        // view property would render one update behind.
         .onChange(of: markdown) { newValue in
-            renderStore.schedule(markdown: newValue, config: styleConfig, flags: flags)
+            renderStore.schedule(
+                markdown: newValue,
+                config: styleConfig,
+                flags: flags,
+                imageRequestHeaders: imageRequestHeaders
+            )
         }
         .onChange(of: styleConfig) { newValue in
-            renderStore.schedule(markdown: markdown, config: newValue, flags: flags)
+            renderStore.schedule(
+                markdown: markdown,
+                config: newValue,
+                flags: flags,
+                imageRequestHeaders: imageRequestHeaders
+            )
         }
         .onChange(of: flags) { newValue in
-            renderStore.schedule(markdown: markdown, config: styleConfig, flags: newValue)
+            renderStore.schedule(
+                markdown: markdown,
+                config: styleConfig,
+                flags: newValue,
+                imageRequestHeaders: imageRequestHeaders
+            )
+        }
+        .onChange(of: imageRequestHeaders) { newValue in
+            renderStore.schedule(
+                markdown: markdown,
+                config: styleConfig,
+                flags: flags,
+                imageRequestHeaders: newValue
+            )
         }
         .onDisappear {
             renderStore.invalidate()

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Environment+ImageRequestHeaders.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Environment+ImageRequestHeaders.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+private struct MarkdownImageRequestHeadersKey: EnvironmentKey {
+    static let defaultValue: [String: String] = [:]
+}
+
+public extension EnvironmentValues {
+    var markdownImageRequestHeaders: [String: String] {
+        get { self[MarkdownImageRequestHeadersKey.self] }
+        set { self[MarkdownImageRequestHeadersKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Custom HTTP headers sent with every markdown image request, e.g. for
+    /// authenticated CDNs. The same URL fetched with different headers is
+    /// cached separately.
+    func markdownImageRequestHeaders(_ headers: [String: String]) -> some View {
+        environment(\.markdownImageRequestHeaders, headers)
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownRenderStore.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownRenderStore.swift
@@ -13,7 +13,8 @@ final class MarkdownRenderStore: ObservableObject {
     func schedule(
         markdown: String,
         config: MarkdownStyleConfig,
-        flags: Md4cFlags = .commonMark
+        flags: Md4cFlags = .commonMark,
+        imageRequestHeaders: [String: String] = [:]
     ) {
         if isBlank(markdown) {
             attributedText = NSAttributedString()
@@ -22,7 +23,12 @@ final class MarkdownRenderStore: ObservableObject {
         }
 
         coordinator.scheduleRender {
-            MarkdownRenderer.render(markdown, config: config, flags: flags)
+            MarkdownRenderer.render(
+                markdown,
+                config: config,
+                flags: flags,
+                imageRequestHeaders: imageRequestHeaders
+            )
         } apply: { [weak self] result in
             self?.attributedText = result
             self?.sourceMarkdown = markdown

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/ImageCacheKeyTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/ImageCacheKeyTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import EnrichedMarkdown
+
+final class ImageCacheKeyTests: XCTestCase {
+    private let url = "https://example.com/image.png"
+
+    func testNoHeadersReturnsURLUnchanged() {
+        XCTAssertEqual(ImageCacheKey.requestKey(url: url, headers: [:]), url)
+    }
+
+    func testHeadersAppendPipeAndHexDigest() {
+        let key = ImageCacheKey.requestKey(url: url, headers: ["Authorization": "Bearer token"])
+
+        XCTAssertTrue(key.hasPrefix(url + "|"))
+        let digest = key.dropFirst(url.count + 1)
+        XCTAssertEqual(digest.count, 64)
+        XCTAssertTrue(digest.allSatisfy(\.isHexDigit))
+    }
+
+    func testMatchesAndroidDigestFormat() {
+        // SHA-256 of "Authorization:Bearer token" — pinned so the key stays
+        // byte-identical to Android's ImageCache.requestKey.
+        XCTAssertEqual(
+            ImageCacheKey.requestKey(url: url, headers: ["Authorization": "Bearer token"]),
+            url + "|06a97d81903f645b2b8286be8e5251b3ed323a07533a0609bbb87e66d7a40821"
+        )
+    }
+
+    func testHeadersAreSortedByKeyBeforeHashing() {
+        // SHA-256 of "Accept:image/png\nAuthorization:Bearer token" — pairs
+        // joined with \n in key order regardless of dictionary order.
+        let headers = ["Authorization": "Bearer token", "Accept": "image/png"]
+
+        XCTAssertEqual(
+            ImageCacheKey.requestKey(url: url, headers: headers),
+            url + "|c046ce6860d64c050dd077d13a03cb285900e2fad36c5959c05aab094f838a29"
+        )
+    }
+
+    func testDistinctHeadersProduceDistinctKeys() {
+        let first = ImageCacheKey.requestKey(url: url, headers: ["Authorization": "Bearer a"])
+        let second = ImageCacheKey.requestKey(url: url, headers: ["Authorization": "Bearer b"])
+
+        XCTAssertNotEqual(first, second)
+        XCTAssertNotEqual(first, url)
+    }
+}

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/MarkdownImageAttachmentTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/MarkdownImageAttachmentTests.swift
@@ -4,10 +4,12 @@ import XCTest
 
 private final class MockImageDownloader: ImageDownloading {
     var requestedURLs: [String] = []
+    var requestedHeaders: [[String: String]] = []
     var stubbedImage: UIImage?
 
-    func download(url: String, completion: @escaping (UIImage?) -> Void) {
+    func download(url: String, headers: [String: String], completion: @escaping (UIImage?) -> Void) {
         requestedURLs.append(url)
+        requestedHeaders.append(headers)
         completion(stubbedImage)
     }
 }
@@ -79,6 +81,64 @@ final class MarkdownImageAttachmentTests: XCTestCase {
         )
 
         XCTAssertEqual(attachment.accessibilityLabel, "A red square")
+    }
+
+    func testRequestHeadersReachDownloader() {
+        let downloader = MockImageDownloader()
+        let url = "https://example.com/\(#function).png"
+        let headers = ["Authorization": "Bearer token"]
+
+        _ = MarkdownImageAttachment.attachment(
+            for: url,
+            config: makeConfig(),
+            isInline: false,
+            altText: "",
+            requestHeaders: headers,
+            downloader: downloader
+        )
+
+        XCTAssertEqual(downloader.requestedHeaders, [headers])
+    }
+
+    func testEveryCallYieldsFreshAttachmentInstance() {
+        // Attachments carry per-position layout state, so instances must
+        // never be shared — even for identical URL + headers.
+        let downloader = MockImageDownloader()
+        downloader.stubbedImage = makeImage()
+        let url = "https://example.com/\(#function).png"
+
+        func attachment() -> MarkdownImageAttachment {
+            MarkdownImageAttachment.attachment(
+                for: url,
+                config: makeConfig(),
+                isInline: true,
+                altText: "",
+                requestHeaders: ["Authorization": "Bearer a"],
+                downloader: downloader
+            )
+        }
+
+        XCTAssertFalse(attachment() === attachment())
+    }
+
+    func testDuplicateImageURLsRenderAsIndependentAttachments() {
+        // Regression: with a shared instance, only the first occurrence of a
+        // repeated image URL would draw and refresh.
+        let url = "https://example.invalid/repeated.png"
+        let result = MarkdownRenderer.render(
+            "![a](\(url))\n\n![a](\(url))",
+            config: makeConfig()
+        )
+
+        var attachments: [MarkdownImageAttachment] = []
+        result.enumerateAttribute(.attachment, in: NSRange(location: 0, length: result.length)) { value, _, _ in
+            if let attachment = value as? MarkdownImageAttachment {
+                attachments.append(attachment)
+            }
+        }
+
+        XCTAssertEqual(attachments.count, 2)
+        XCTAssertFalse(attachments[0] === attachments[1])
     }
 
     func testEmptyURLDoesNotHitDownloader() {


### PR DESCRIPTION
Adds a .markdownImageRequestHeaders(_:) environment modifier matching the Android package's imageRequestHeaders. Headers are sent with every image request and join the cache identity: cache keys append a SHA-256 digest of the sorted header pairs, byte-identical to Android's ImageCache.requestKey and pinned by test vectors.

Also fixes two bugs surfaced by the playground header demo:
- Duplicate image URLs in one document rendered only their first occurrence: the attachment registry returned a single shared NSTextAttachment instance, whose per-position layout state cannot serve two ranges. The registry is removed; every position gets a fresh attachment while the original/processed image caches keep re-renders flicker-free.
- Renders lagged one update behind their trigger: the onChange closures run against the previous view value, so the changed value must come from the closure parameter rather than the view property.

The playground demo uses httpbingo.org/image, which rejects requests without an Accept header and serves a different image per value, so it exercises both the header delivery and the header-aware cache.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

