### PR TITLE
feat(ios): add local image sources and decode-time downsampling

### DIFF
--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
@@ -58,6 +58,9 @@ struct PlaygroundScreen: View {
                     ) {
                         acceptImageType = acceptImageType == "image/png" ? "image/jpeg" : "image/png"
                     }
+                    PlaygroundButton(label: "Insert Data URI Image", accessibilityId: "insert-data-uri-image-button") {
+                        insertDataURIImage()
+                    }
                 }
 
                 setMarkdownButton
@@ -153,6 +156,19 @@ struct PlaygroundScreen: View {
     private func insertInlineImage() {
         guard let uri = inlineImageURI else { return }
         markdown = "Enriched Markdown is a library for ![icon](\(uri)) React Native."
+    }
+
+    private func insertDataURIImage() {
+        guard
+            let url = Bundle.main.url(forResource: "logo_icon", withExtension: "png"),
+            let data = try? Data(contentsOf: url)
+        else { return }
+        let imageMarkdown = "Rendered from a data URI: ![data uri icon](data:image/png;base64,\(data.base64EncodedString()))"
+        if markdown.isEmpty {
+            markdown = imageMarkdown
+        } else {
+            markdown += "\n\n\(imageMarkdown)"
+        }
     }
 
     // httpbingo.org negotiates the response image from the Accept header (and

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/ImageDecoder.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/ImageDecoder.swift
@@ -1,0 +1,34 @@
+import ImageIO
+import UIKit
+
+enum ImageDecoder {
+    /// Decodes image data downsampled so its longer side is at most
+    /// `maxPixelSize` (screen pixel width by default), mirroring the Android
+    /// package's decode-time `inSampleSize` downsampling. Never upscales.
+    /// The result carries the screen scale so point-size math downstream is
+    /// unchanged, and EXIF orientation is baked in.
+    static func decodeDownsampled(
+        _ data: Data,
+        maxPixelSize: CGFloat = UIScreen.main.bounds.width * UIScreen.main.scale,
+        scale: CGFloat = UIScreen.main.scale
+    ) -> UIImage? {
+        guard !data.isEmpty else { return nil }
+
+        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
+            return nil
+        }
+
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+        ] as CFDictionary
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) else {
+            return nil
+        }
+
+        return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/ImageDownloader.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/ImageDownloader.swift
@@ -47,6 +47,15 @@ final class ImageDownloader: ImageDownloading {
         inFlightRequests[requestKey] = [completion]
         lock.unlock()
 
+        let scheme = URLComponents(string: url)?.scheme?.lowercased()
+        guard scheme == "http" || scheme == "https" else {
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                let image = LocalImageLoader.load(url)
+                self?.cacheAndDispatch(image, for: requestKey)
+            }
+            return
+        }
+
         guard let requestURL = URL(string: url) else {
             dispatchCallbacks(for: requestKey, image: nil)
             return
@@ -58,16 +67,20 @@ final class ImageDownloader: ImageDownloading {
         }
 
         session.dataTask(with: request) { [weak self] data, _, error in
-            let image = (data != nil && error == nil) ? UIImage(data: data!) : nil
-            if let image {
-                MarkdownImageAttachment.originalImageCache.setObject(
-                    image,
-                    forKey: requestKey as NSString,
-                    cost: Self.byteCost(for: image)
-                )
-            }
-            self?.dispatchCallbacks(for: requestKey, image: image)
+            let image = (data != nil && error == nil) ? data.flatMap { ImageDecoder.decodeDownsampled($0) } : nil
+            self?.cacheAndDispatch(image, for: requestKey)
         }.resume()
+    }
+
+    private func cacheAndDispatch(_ image: UIImage?, for requestKey: String) {
+        if let image {
+            MarkdownImageAttachment.originalImageCache.setObject(
+                image,
+                forKey: requestKey as NSString,
+                cost: Self.byteCost(for: image)
+            )
+        }
+        dispatchCallbacks(for: requestKey, image: image)
     }
 
     private func dispatchCallbacks(for requestKey: String, image: UIImage?) {

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/LocalImageLoader.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Utils/LocalImageLoader.swift
@@ -1,0 +1,103 @@
+import UIKit
+import os.log
+
+/// Loads markdown images from non-network sources, mirroring the Android
+/// package's `LocalImageLoader`:
+/// - `file://` URIs (including percent-encoded paths)
+/// - absolute file paths
+/// - `data:` URIs (base64 payloads)
+/// - bare names resolved as bundled image resources, with Android's name
+///   normalization (lowercase, `-` → `_`) applied as a fallback so
+///   cross-platform markdown resolves on both OSes
+///
+/// Android-only sources (`content://`, `asset://`, `res://`) have no iOS
+/// equivalent and return nil. All decodes are downsampled to screen width
+/// like the network path; asset-catalog images are the exception (no file
+/// URL to decode from) and load through `UIImage(named:)` as-is.
+enum LocalImageLoader {
+    private static let base64Marker = "base64,"
+    private static let resourceExtensions = ["png", "jpg", "jpeg", "gif", "heic"]
+
+    static func load(_ source: String, bundle: Bundle = .main) -> UIImage? {
+        guard !source.isEmpty else { return nil }
+
+        if source.hasPrefix("/") {
+            return decodeFile(atPath: source)
+        }
+
+        switch URLComponents(string: source)?.scheme?.lowercased() {
+        case nil:
+            return decodeResource(named: source, bundle: bundle)
+        case "file":
+            guard let path = URL(string: source)?.path, !path.isEmpty else { return nil }
+            return decodeFile(atPath: path)
+        case "data":
+            return decodeDataURI(source)
+        default:
+            os_log(.info, "EnrichedMarkdown: unsupported image URI scheme: %{public}@", source)
+            return nil
+        }
+    }
+
+    /// Android resource-name normalization (`ResourceDrawableIdHelper`):
+    /// lowercase with `-` replaced by `_`.
+    static func normalizedResourceName(_ name: String) -> String {
+        name.lowercased().replacingOccurrences(of: "-", with: "_")
+    }
+
+    private static func decodeFile(atPath path: String) -> UIImage? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return nil }
+        return ImageDecoder.decodeDownsampled(data)
+    }
+
+    private static func decodeDataURI(_ source: String) -> UIImage? {
+        guard let marker = source.range(of: base64Marker) else { return nil }
+        let payload = String(source[marker.upperBound...])
+        guard let data = Data(base64Encoded: payload, options: .ignoreUnknownCharacters) else {
+            return nil
+        }
+        return ImageDecoder.decodeDownsampled(data)
+    }
+
+    private static func decodeResource(named name: String, bundle: Bundle) -> UIImage? {
+        var candidates = [name]
+        let normalized = normalizedResourceName(name)
+        if normalized != name {
+            candidates.append(normalized)
+        }
+
+        for candidate in candidates {
+            if let url = resourceURL(for: candidate, bundle: bundle),
+               let data = try? Data(contentsOf: url) {
+                return ImageDecoder.decodeDownsampled(data)
+            }
+        }
+
+        // Asset catalogs expose no file URL to decode from; UIImage(named:)
+        // covers them (right-sized variants, no downsampling needed).
+        for candidate in candidates {
+            if let image = UIImage(named: candidate, in: bundle, compatibleWith: nil) {
+                return image
+            }
+        }
+
+        os_log(.info, "EnrichedMarkdown: no bundled image resource named: %{public}@", name)
+        return nil
+    }
+
+    private static func resourceURL(for name: String, bundle: Bundle) -> URL? {
+        let ext = (name as NSString).pathExtension
+        guard ext.isEmpty else {
+            return bundle.url(
+                forResource: (name as NSString).deletingPathExtension,
+                withExtension: ext
+            )
+        }
+        for candidateExtension in resourceExtensions {
+            if let url = bundle.url(forResource: name, withExtension: candidateExtension) {
+                return url
+            }
+        }
+        return nil
+    }
+}

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/ImageDecoderTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/ImageDecoderTests.swift
@@ -1,0 +1,57 @@
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+final class ImageDecoderTests: XCTestCase {
+    private func makePNGData(width: CGFloat, height: CGFloat) -> Data {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height), format: format)
+        let image = renderer.image { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        }
+        return image.pngData()!
+    }
+
+    func testLargeImageIsDownsampledToMaxPixelSize() {
+        let data = makePNGData(width: 2000, height: 1000)
+
+        let decoded = ImageDecoder.decodeDownsampled(data, maxPixelSize: 500, scale: 1)
+
+        XCTAssertNotNil(decoded)
+        XCTAssertLessThanOrEqual(decoded!.cgImage!.width, 500)
+        XCTAssertLessThanOrEqual(decoded!.cgImage!.height, 500)
+    }
+
+    func testDownsamplingPreservesAspectRatio() {
+        let data = makePNGData(width: 2000, height: 1000)
+
+        let decoded = ImageDecoder.decodeDownsampled(data, maxPixelSize: 500, scale: 1)!
+
+        let ratio = CGFloat(decoded.cgImage!.width) / CGFloat(decoded.cgImage!.height)
+        XCTAssertEqual(ratio, 2.0, accuracy: 0.05)
+    }
+
+    func testSmallImageIsNotUpscaled() {
+        let data = makePNGData(width: 40, height: 40)
+
+        let decoded = ImageDecoder.decodeDownsampled(data, maxPixelSize: 500, scale: 1)
+
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded!.cgImage!.width, 40)
+    }
+
+    func testResultCarriesRequestedScale() {
+        let data = makePNGData(width: 100, height: 100)
+
+        let decoded = ImageDecoder.decodeDownsampled(data, maxPixelSize: 500, scale: 2)
+
+        XCTAssertEqual(decoded?.scale, 2)
+    }
+
+    func testInvalidDataReturnsNil() {
+        XCTAssertNil(ImageDecoder.decodeDownsampled(Data()))
+        XCTAssertNil(ImageDecoder.decodeDownsampled(Data("not an image".utf8)))
+    }
+}

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/LocalImageLoaderTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/LocalImageLoaderTests.swift
@@ -1,0 +1,73 @@
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+final class LocalImageLoaderTests: XCTestCase {
+    private func makePNGData(width: CGFloat = 8, height: CGFloat = 8) -> Data {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height), format: format)
+        let image = renderer.image { context in
+            UIColor.systemGreen.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        }
+        return image.pngData()!
+    }
+
+    private func writeTempPNG(named name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(name)
+        try makePNGData().write(to: url)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+
+    func testDataURIRoundTrip() {
+        let dataURI = "data:image/png;base64,\(makePNGData().base64EncodedString())"
+
+        XCTAssertNotNil(LocalImageLoader.load(dataURI))
+    }
+
+    func testDataURIWithoutBase64MarkerReturnsNil() {
+        XCTAssertNil(LocalImageLoader.load("data:image/png,rawpayload"))
+    }
+
+    func testFileURIRoundTrip() throws {
+        let url = try writeTempPNG(named: "local-loader-test.png")
+
+        XCTAssertNotNil(LocalImageLoader.load(url.absoluteString))
+    }
+
+    func testPercentEncodedFileURIRoundTrip() throws {
+        let url = try writeTempPNG(named: "local loader spaced.png")
+
+        let uri = url.absoluteString
+        XCTAssertTrue(uri.contains("%20"))
+        XCTAssertNotNil(LocalImageLoader.load(uri))
+    }
+
+    func testAbsolutePathRoundTrip() throws {
+        let url = try writeTempPNG(named: "local-loader-path.png")
+
+        XCTAssertNotNil(LocalImageLoader.load(url.path))
+    }
+
+    func testUnsupportedSchemesReturnNil() {
+        XCTAssertNil(LocalImageLoader.load("content://media/external/images/1"))
+        XCTAssertNil(LocalImageLoader.load("asset://images/logo.png"))
+        XCTAssertNil(LocalImageLoader.load("res://drawable/logo"))
+    }
+
+    func testMissingResourceNameReturnsNil() {
+        XCTAssertNil(LocalImageLoader.load("definitely-not-a-bundled-image"))
+        XCTAssertNil(LocalImageLoader.load(""))
+    }
+
+    func testResourceNameNormalizationMatchesAndroid() {
+        XCTAssertEqual(LocalImageLoader.normalizedResourceName("My-Logo"), "my_logo")
+        XCTAssertEqual(LocalImageLoader.normalizedResourceName("SRC-Assets-Logo"), "src_assets_logo")
+        XCTAssertEqual(LocalImageLoader.normalizedResourceName("already_normal"), "already_normal")
+    }
+}


### PR DESCRIPTION
Matches the Android package's LocalImageLoader and inSampleSize downsampling. Non-network image sources now load: file:// URIs (including percent-encoded paths), absolute paths, base64 data: URIs, and bare names resolved as bundled resources with Android's name normalization (lowercase, dash to underscore) so cross-platform markdown resolves on both OSes. Android-only schemes (content://, asset://, res://) log and return nil.

All decodes, including network bytes, now go through CGImageSource thumbnailing capped at the screen's pixel width, so large images no longer decode at full size. EXIF orientation is baked in and results carry the screen scale, leaving point-size math unchanged.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

