### PR TITLE
feat(ios): add VoiceOver element tree for rendered markdown

### DIFF
--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElement.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElement.swift
@@ -1,0 +1,55 @@
+import UIKit
+
+/// VoiceOver element for one segment of the rendered markdown. The frame is
+/// resolved lazily from TextKit 2 layout on every query, so scrolling and
+/// Dynamic Type changes never leave stale bounds.
+@available(iOS 16.0, *)
+class MarkdownAccessibilityElement: UIAccessibilityElement {
+    private(set) weak var textView: MarkdownTextView?
+    let range: NSRange
+
+    init(textView: MarkdownTextView, spec: MarkdownAccessibilityElementSpec) {
+        self.textView = textView
+        self.range = spec.range
+        super.init(accessibilityContainer: textView)
+
+        accessibilityLabel = spec.label
+        accessibilityValue = spec.listAnnouncement
+
+        switch spec.kind {
+        case .text:
+            accessibilityTraits = .staticText
+        case .heading(let level):
+            accessibilityTraits = [.staticText, .header]
+            accessibilityAttributedLabel = NSAttributedString(
+                string: spec.label,
+                attributes: [.accessibilityTextHeadingLevel: level]
+            )
+        case .link:
+            accessibilityTraits = .link
+        case .image:
+            accessibilityTraits = .image
+        }
+    }
+
+    override var accessibilityFrame: CGRect {
+        get { textView?.accessibilityScreenFrame(for: range) ?? .zero }
+        set { super.accessibilityFrame = newValue }
+    }
+}
+
+@available(iOS 16.0, *)
+final class MarkdownLinkAccessibilityElement: MarkdownAccessibilityElement {
+    let url: URL
+
+    init(textView: MarkdownTextView, spec: MarkdownAccessibilityElementSpec, url: URL) {
+        self.url = url
+        super.init(textView: textView, spec: spec)
+    }
+
+    override func accessibilityActivate() -> Bool {
+        guard let textView, let onLinkPress = textView.onLinkPress else { return false }
+        onLinkPress(url)
+        return true
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElementBuilder.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElementBuilder.swift
@@ -1,0 +1,255 @@
+import UIKit
+
+/// A VoiceOver element description derived from the rendered attributed
+/// string. Pure data so the segmentation logic is unit-testable; frames are
+/// resolved lazily by `MarkdownAccessibilityElement` at query time.
+struct MarkdownAccessibilityElementSpec: Equatable {
+    enum Kind: Equatable {
+        case text
+        case heading(level: Int)
+        case link(URL)
+        case image
+    }
+
+    let kind: Kind
+    let label: String
+    /// Trimmed character range used for frame calculation.
+    let range: NSRange
+    /// Spoken list context ("bullet point", "list item 2", "nested …"),
+    /// matching the Android package's TalkBack announcements.
+    let listAnnouncement: String?
+}
+
+/// Segments the rendered attributed string into VoiceOver elements the way
+/// Android's `MarkdownAccessibilityHelper` segments its Spanned: split into
+/// paragraphs, drop spacer-only paragraphs, and carve heading/link/image
+/// runs into their own elements with plain text between them.
+enum MarkdownAccessibilityElementBuilder {
+    /// Zero-width space (list marker anchors) and line separator join plain
+    /// whitespace as "invisible" for trimming; U+FFFC attachment characters
+    /// count as content.
+    private static let skippable: CharacterSet = {
+        var set = CharacterSet.whitespacesAndNewlines
+        set.insert(charactersIn: "\u{200B}\u{2028}")
+        return set
+    }()
+
+    static func specs(for text: NSAttributedString) -> [MarkdownAccessibilityElementSpec] {
+        let string = text.string as NSString
+        guard string.length > 0 else { return [] }
+
+        var specs: [MarkdownAccessibilityElementSpec] = []
+        var paragraphStart = 0
+        while paragraphStart < string.length {
+            let searchRange = NSRange(location: paragraphStart, length: string.length - paragraphStart)
+            let newline = string.range(of: "\n", options: [], range: searchRange)
+            let paragraphEnd = newline.location == NSNotFound ? string.length : newline.location + 1
+            appendSpecs(
+                for: NSRange(location: paragraphStart, length: paragraphEnd - paragraphStart),
+                in: text,
+                to: &specs
+            )
+            paragraphStart = paragraphEnd
+        }
+        return specs
+    }
+
+    // MARK: - Paragraph segmentation
+
+    private struct SemanticRun {
+        let range: NSRange
+        let kind: MarkdownAccessibilityElementSpec.Kind
+        let imageLabel: String?
+    }
+
+    private static func appendSpecs(
+        for paragraphRange: NSRange,
+        in text: NSAttributedString,
+        to specs: inout [MarkdownAccessibilityElementSpec]
+    ) {
+        guard trimmedRange(of: paragraphRange, in: text) != nil else { return }
+
+        let runs = semanticRuns(in: paragraphRange, of: text)
+        guard !runs.isEmpty else {
+            appendTextSpec(for: paragraphRange, in: text, to: &specs)
+            return
+        }
+
+        var segmentStart = paragraphRange.location
+        for run in runs {
+            guard run.range.location >= segmentStart else { continue }
+
+            if run.range.location > segmentStart {
+                appendTextSpec(
+                    for: NSRange(location: segmentStart, length: run.range.location - segmentStart),
+                    in: text,
+                    to: &specs,
+                    requireLetterOrDigit: true
+                )
+            }
+
+            appendRunSpec(run, in: text, to: &specs)
+            segmentStart = run.range.location + run.range.length
+        }
+
+        let paragraphEnd = paragraphRange.location + paragraphRange.length
+        if segmentStart < paragraphEnd {
+            appendTextSpec(
+                for: NSRange(location: segmentStart, length: paragraphEnd - segmentStart),
+                in: text,
+                to: &specs,
+                requireLetterOrDigit: true
+            )
+        }
+    }
+
+    private static func semanticRuns(in range: NSRange, of text: NSAttributedString) -> [SemanticRun] {
+        var runs: [SemanticRun] = []
+
+        text.enumerateAttribute(MarkdownAttribute.headingLevel, in: range) { value, runRange, _ in
+            guard let level = value as? Int else { return }
+            runs.append(SemanticRun(range: runRange, kind: .heading(level: level), imageLabel: nil))
+        }
+        text.enumerateAttribute(.link, in: range) { value, runRange, _ in
+            let url = value as? URL ?? (value as? String).flatMap(URL.init(string:))
+            guard let url else { return }
+            runs.append(SemanticRun(range: runRange, kind: .link(url), imageLabel: nil))
+        }
+        text.enumerateAttribute(.attachment, in: range) { value, runRange, _ in
+            guard let attachment = value as? MarkdownImageAttachment else { return }
+            let label = attachment.accessibilityLabel.flatMap { $0.isEmpty ? nil : $0 } ?? "Image"
+            runs.append(SemanticRun(range: runRange, kind: .image, imageLabel: label))
+        }
+
+        return runs.sorted { $0.range.location < $1.range.location }
+    }
+
+    private static func appendRunSpec(
+        _ run: SemanticRun,
+        in text: NSAttributedString,
+        to specs: inout [MarkdownAccessibilityElementSpec]
+    ) {
+        let label: String
+        let announcement: String?
+
+        switch run.kind {
+        case .image:
+            label = run.imageLabel ?? "Image"
+            announcement = nil
+        case .heading:
+            guard let visible = trimmedRange(of: run.range, in: text) else { return }
+            label = (text.string as NSString).substring(with: visible)
+            announcement = nil
+        case .link:
+            guard let visible = trimmedRange(of: run.range, in: text) else { return }
+            label = (text.string as NSString).substring(with: visible)
+            // Links announce their list context even mid-item (Android:
+            // requireStart is false for links).
+            announcement = listAnnouncement(in: text, at: run.range.location, requireStart: false)
+        case .text:
+            return
+        }
+
+        specs.append(MarkdownAccessibilityElementSpec(
+            kind: run.kind,
+            label: label,
+            range: trimmedRange(of: run.range, in: text) ?? run.range,
+            listAnnouncement: announcement
+        ))
+    }
+
+    private static func appendTextSpec(
+        for range: NSRange,
+        in text: NSAttributedString,
+        to specs: inout [MarkdownAccessibilityElementSpec],
+        requireLetterOrDigit: Bool = false
+    ) {
+        guard let visible = trimmedRange(of: range, in: text) else { return }
+        let label = (text.string as NSString).substring(with: visible)
+
+        if requireLetterOrDigit, label.rangeOfCharacter(from: .alphanumerics) == nil {
+            return
+        }
+
+        specs.append(MarkdownAccessibilityElementSpec(
+            kind: .text,
+            label: label,
+            range: visible,
+            listAnnouncement: listAnnouncement(in: text, at: visible.location, requireStart: true)
+        ))
+    }
+
+    // MARK: - List context
+
+    private static func listAnnouncement(
+        in text: NSAttributedString,
+        at position: Int,
+        requireStart: Bool
+    ) -> String? {
+        guard position < text.length else { return nil }
+
+        var numberRun = NSRange()
+        let fullRange = NSRange(location: 0, length: text.length)
+        guard let number = MarkdownAttributeValue.intValue(from: text.attribute(
+            MarkdownAttribute.listItemNumber,
+            at: position,
+            longestEffectiveRange: &numberRun,
+            in: fullRange
+        )) else {
+            return nil
+        }
+        var depthRun = numberRun
+        let depth = MarkdownAttributeValue.intValue(from: text.attribute(
+            MarkdownAttribute.listDepth,
+            at: position,
+            longestEffectiveRange: &depthRun,
+            in: fullRange
+        )) ?? 0
+        let type = MarkdownAttributeValue.intValue(
+            from: text.attribute(MarkdownAttribute.listType, at: position, effectiveRange: nil)
+        )
+
+        if requireStart {
+            // Only the first segment of a list item announces its position
+            // (Android's requireStart rule): the item's first visible
+            // character must be at, or just before, this position. The item's
+            // extent is where BOTH number and depth are constant — number
+            // alone merges across nesting levels (outer item 1 / inner item
+            // 1 are adjacent equal values), depth alone merges siblings.
+            let itemRange = NSIntersectionRange(numberRun, depthRun)
+            let firstVisible = trimmedRange(of: itemRange, in: text)?.location ?? itemRange.location
+            if position > firstVisible + 1 {
+                return nil
+            }
+        }
+
+        let prefix = depth > 0 ? "nested " : ""
+        if type == ListType.ordered.rawValue {
+            return "\(prefix)list item \(number)"
+        }
+        return "\(prefix)bullet point"
+    }
+
+    // MARK: - Trimming
+
+    private static func trimmedRange(of range: NSRange, in text: NSAttributedString) -> NSRange? {
+        let string = text.string as NSString
+        var start = range.location
+        var end = range.location + range.length
+
+        while start < end, isSkippable(string.character(at: start)) {
+            start += 1
+        }
+        while end > start, isSkippable(string.character(at: end - 1)) {
+            end -= 1
+        }
+
+        guard end > start else { return nil }
+        return NSRange(location: start, length: end - start)
+    }
+
+    private static func isSkippable(_ character: unichar) -> Bool {
+        guard let scalar = Unicode.Scalar(character) else { return false }
+        return skippable.contains(scalar)
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -27,6 +27,7 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
         context.coordinator.onLinkLongPress = onLinkLongPress
         context.coordinator.sourceMarkdown = sourceMarkdown
         context.coordinator.selectionMenuConfig = selectionMenuConfig
+        textView.onLinkPress = onLinkPress
         textView.styleConfig = styleConfig
         textView.isSelectionEnabled = isSelectionEnabled
         textView.tintColor = selectionColor.map { UIColor($0) }
@@ -220,6 +221,25 @@ final class MarkdownTextView: UITextView {
         }
     }
 
+    /// Mirrored from the representable so VoiceOver link elements can invoke
+    /// the press handler via accessibilityActivate.
+    var onLinkPress: ((URL) -> Void)?
+
+    /// VoiceOver elements built from the attributed string; frames resolve
+    /// lazily against TextKit 2 layout. Empty (default UITextView behavior)
+    /// below iOS 16, where the decoration/text-layout stack is unavailable.
+    private var markdownAccessibilityElements: [UIAccessibilityElement] = []
+
+    override var accessibilityElements: [Any]? {
+        get { markdownAccessibilityElements.isEmpty ? super.accessibilityElements : markdownAccessibilityElements }
+        set { super.accessibilityElements = newValue }
+    }
+
+    override var isAccessibilityElement: Bool {
+        get { markdownAccessibilityElements.isEmpty ? super.isAccessibilityElement : false }
+        set { super.isAccessibilityElement = newValue }
+    }
+
     /// Gates the selection UI while keeping `isSelectable` on, so link taps
     /// keep working when selection is disabled. Selection requires first
     /// responder; link interaction does not.
@@ -280,7 +300,42 @@ final class MarkdownTextView: UITextView {
         invalidateIntrinsicContentSize()
         if #available(iOS 16.0, *) {
             setDecorationNeedsDisplay()
+            rebuildAccessibilityElements()
         }
+    }
+
+    @available(iOS 16.0, *)
+    private func rebuildAccessibilityElements() {
+        let specs = MarkdownAccessibilityElementBuilder.specs(for: attributedText ?? NSAttributedString())
+        markdownAccessibilityElements = specs.map { spec in
+            if case .link(let url) = spec.kind {
+                return MarkdownLinkAccessibilityElement(textView: self, spec: spec, url: url)
+            }
+            return MarkdownAccessibilityElement(textView: self, spec: spec)
+        }
+    }
+
+    /// Screen-coordinate frame for a character range, unioned over its
+    /// TextKit 2 layout fragments.
+    @available(iOS 16.0, *)
+    func accessibilityScreenFrame(for range: NSRange) -> CGRect {
+        guard let textLayoutManager,
+              let contentManager = textLayoutManager.textContentManager,
+              let textRange = TextLayoutHelpers.textRange(range, in: contentManager) else {
+            return .zero
+        }
+
+        textLayoutManager.ensureLayout(for: textRange)
+        var union = CGRect.null
+        textLayoutManager.enumerateTextSegments(in: textRange, type: .standard, options: []) { _, frame, _, _ in
+            union = union.union(frame)
+            return true
+        }
+        guard !union.isNull else { return .zero }
+
+        union.origin.x += textContainerInset.left
+        union.origin.y += textContainerInset.top
+        return UIAccessibility.convertToScreenCoordinates(union, in: self)
     }
 
     override func layoutSubviews() {

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/AccessibilityElementBuilderTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/AccessibilityElementBuilderTests.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+final class AccessibilityElementBuilderTests: XCTestCase {
+    private var config: MarkdownStyleConfig!
+
+    override func setUp() {
+        super.setUp()
+        config = MarkdownStyleConfig.resolve(layers: [.default], traitCollection: .current)
+    }
+
+    private func specs(for markdown: String) -> [MarkdownAccessibilityElementSpec] {
+        MarkdownAccessibilityElementBuilder.specs(for: MarkdownRenderer.render(markdown, config: config))
+    }
+
+    func testEmptyStringYieldsNoSpecs() {
+        XCTAssertTrue(MarkdownAccessibilityElementBuilder.specs(for: NSAttributedString()).isEmpty)
+    }
+
+    func testHeadingBecomesSingleHeadingSpec() {
+        let result = specs(for: "# Title\n\nBody paragraph")
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].kind, .heading(level: 1))
+        XCTAssertEqual(result[0].label, "Title")
+        XCTAssertEqual(result[1].kind, .text)
+        XCTAssertEqual(result[1].label, "Body paragraph")
+    }
+
+    func testHeadingLevelsAreReported() {
+        let result = specs(for: "### Third level")
+
+        XCTAssertEqual(result.first?.kind, .heading(level: 3))
+    }
+
+    func testSpacerParagraphsAreSkipped() {
+        let result = specs(for: "First\n\nSecond\n\nThird")
+
+        XCTAssertEqual(result.map(\.label), ["First", "Second", "Third"])
+    }
+
+    func testLinksInterleaveWithText() {
+        let result = specs(for: "Start [alpha](https://a.example) middle [beta](https://b.example) end")
+
+        XCTAssertEqual(result.count, 5)
+        XCTAssertEqual(result[0].kind, .text)
+        XCTAssertEqual(result[0].label, "Start")
+        XCTAssertEqual(result[1].kind, .link(URL(string: "https://a.example")!))
+        XCTAssertEqual(result[1].label, "alpha")
+        XCTAssertEqual(result[2].label, "middle")
+        XCTAssertEqual(result[3].kind, .link(URL(string: "https://b.example")!))
+        XCTAssertEqual(result[4].label, "end")
+    }
+
+    func testImageUsesAltTextAsLabel() {
+        let result = specs(for: "![company logo](https://example.invalid/logo.png)")
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].kind, .image)
+        XCTAssertEqual(result[0].label, "company logo")
+    }
+
+    func testImageWithoutAltTextFallsBackToImage() {
+        let result = specs(for: "![](https://example.invalid/logo.png)")
+
+        XCTAssertEqual(result.first?.kind, .image)
+        XCTAssertEqual(result.first?.label, "Image")
+    }
+
+    func testUnorderedListItemsAnnounceBulletPoint() {
+        let result = specs(for: "- one\n- two")
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].listAnnouncement, "bullet point")
+        XCTAssertEqual(result[1].listAnnouncement, "bullet point")
+    }
+
+    func testOrderedListItemsAnnouncePosition() {
+        let result = specs(for: "1. one\n2. two\n3. three")
+
+        XCTAssertEqual(result.map(\.listAnnouncement), ["list item 1", "list item 2", "list item 3"])
+    }
+
+    func testNestedListItemsAnnounceNesting() {
+        let result = specs(for: "- outer\n  - inner")
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].listAnnouncement, "bullet point")
+        XCTAssertEqual(result[1].listAnnouncement, "nested bullet point")
+    }
+
+    func testLinkInsideListItemCarriesListContext() {
+        let result = specs(for: "- see [docs](https://d.example) here")
+
+        let link = result.first { spec in
+            if case .link = spec.kind { return true }
+            return false
+        }
+        XCTAssertEqual(link?.listAnnouncement, "bullet point")
+    }
+
+    func testNonListParagraphHasNoAnnouncement() {
+        let result = specs(for: "Plain paragraph")
+
+        XCTAssertNil(result.first?.listAnnouncement)
+    }
+
+    func testBlockquoteContentIsStillRepresented() {
+        let result = specs(for: "> quoted words")
+
+        XCTAssertEqual(result.first?.label, "quoted words")
+    }
+}
+
+@available(iOS 16.0, *)
+final class MarkdownTextViewAccessibilityTests: XCTestCase {
+    private var config: MarkdownStyleConfig!
+
+    override func setUp() {
+        super.setUp()
+        config = MarkdownStyleConfig.resolve(layers: [.default], traitCollection: .current)
+    }
+
+    private func makeTextView(markdown: String) -> MarkdownTextView {
+        let textView = MarkdownTextView()
+        textView.setMarkdownAttributedText(MarkdownRenderer.render(markdown, config: config))
+        return textView
+    }
+
+    func testElementsReplaceHostAccessibility() {
+        let textView = makeTextView(markdown: "# Title\n\nBody")
+
+        XCTAssertFalse(textView.isAccessibilityElement)
+        XCTAssertEqual((textView.accessibilityElements ?? []).count, 2)
+    }
+
+    func testHeadingElementCarriesHeaderTrait() {
+        let textView = makeTextView(markdown: "## Section")
+
+        let element = textView.accessibilityElements?.first as? MarkdownAccessibilityElement
+        XCTAssertNotNil(element)
+        XCTAssertTrue(element!.accessibilityTraits.contains(.header))
+        XCTAssertEqual(element!.accessibilityLabel, "Section")
+    }
+
+    func testLinkElementActivatesPressHandler() {
+        let textView = makeTextView(markdown: "[press me](https://swmansion.com)")
+        var pressedURL: URL?
+        textView.onLinkPress = { pressedURL = $0 }
+
+        let link = textView.accessibilityElements?
+            .compactMap { $0 as? MarkdownLinkAccessibilityElement }
+            .first
+        XCTAssertNotNil(link)
+        XCTAssertTrue(link!.accessibilityActivate())
+        XCTAssertEqual(pressedURL, URL(string: "https://swmansion.com"))
+    }
+
+    func testLinkElementWithoutHandlerDoesNotActivate() {
+        let textView = makeTextView(markdown: "[press me](https://swmansion.com)")
+
+        let link = textView.accessibilityElements?
+            .compactMap { $0 as? MarkdownLinkAccessibilityElement }
+            .first
+        XCTAssertEqual(link?.accessibilityActivate(), false)
+    }
+
+    func testEmptyContentKeepsDefaultAccessibility() {
+        let textView = MarkdownTextView()
+        textView.setMarkdownAttributedText(NSAttributedString())
+
+        XCTAssertTrue((textView.accessibilityElements as? [UIAccessibilityElement])?.isEmpty ?? true)
+    }
+}


### PR DESCRIPTION
Matches the Android package's TalkBack virtual view hierarchy. The rendered attributed string is segmented into per-element VoiceOver nodes: paragraphs split on newlines with spacer lines dropped, and heading, link, and image runs carved into their own elements with plain text between them.

Headings carry the header trait plus the heading-level text attribute ("heading, level N"), links activate the onLinkPress handler via accessibilityActivate, images read their alt text, and list items announce their position ("bullet point", "list item N", with a "nested" prefix) exactly like Android. A list item's extent is the intersection of its number and depth attribute runs, since either alone merges with a neighbor.

Element frames resolve lazily from TextKit 2 layout on every query, so scrolling and Dynamic Type changes never leave stale bounds. Requires iOS 16 (frame math goes through textLayoutManager); iOS 15 keeps the stock single-element behavior.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

