### PR TITLE
feat(ios): put styled HTML on the clipboard when copying

### DIFF
--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator.swift
@@ -1,0 +1,570 @@
+import UIKit
+
+/// Generates semantic HTML with inline styles from the rendered attributed
+/// string by walking the custom `MarkdownAttribute` keys. Used by Copy to
+/// put a rich `public.html` flavor on the pasteboard alongside plain text.
+///
+/// The system attributed-string HTML exporter is deliberately not used: it
+/// drops image URLs, loses list markers and block chrome (drawn by
+/// decoration views, absent from the text), and emits unstable Apple CSS.
+///
+/// Hard line breaks (U+2028 within a paragraph) emit `<br>`.
+enum MarkdownHTMLGenerator {
+    // Fixed values not driven by the style config.
+    private enum Fixed {
+        static let blockquotePaddingVertical = "8px"
+        static let blockquoteBorderRadiusCorners = "border-start-end-radius: 8px; border-end-end-radius: 8px"
+        static let blockquoteNestedMargin = "8px 0 0 0"
+        static let blockquoteParagraphMargin = "0 0 4px 0"
+        static let inlineImageHeight = "1.2em"
+        static let inlineImageVerticalAlign = "-0.2em"
+        static let codePadding = "2px 4px"
+        static let codeBorderRadius = "4px"
+        static let codeFontSize = "1em"
+        static let monospaceFamily = "Menlo, Monaco, Consolas, monospace"
+    }
+
+    static func generateHTML(
+        from attributedText: NSAttributedString,
+        in range: NSRange,
+        config: MarkdownStyleConfig,
+        isRTL: Bool = false
+    ) -> String {
+        guard range.location != NSNotFound,
+              range.length > 0,
+              range.location < attributedText.length
+        else {
+            return "<html></html>"
+        }
+        let clamped = NSRange(
+            location: range.location,
+            length: min(range.length, attributedText.length - range.location)
+        )
+        let text = attributedText.attributedSubstring(from: clamped)
+        guard text.length > 0 else { return "<html></html>" }
+
+        let styles = CachedStyles(config: config)
+        var state = State()
+        var html = ""
+
+        if isRTL {
+            html += "<html dir=\"rtl\"><div dir=\"rtl\" style=\"direction: rtl; text-align: right;\">"
+        } else {
+            html += "<html>"
+        }
+
+        for paragraph in collectParagraphs(in: text) {
+            process(paragraph, in: text, into: &html, styles: styles, state: &state)
+        }
+
+        closeCodeBlockIfOpen(&html, state: &state, styles: styles)
+        closeAllBlockquotes(&html, state: &state)
+        closeListsIfOpen(&html, state: &state)
+
+        if isRTL {
+            html += "</div>"
+        }
+        html += "</html>"
+        return html
+    }
+
+    // MARK: - Paragraph classification
+
+    private enum ParagraphType: Equatable {
+        case normal
+        case heading(Int)
+        case codeBlock
+        case blockquote(depth: Int)
+        case list(depth: Int, ordered: Bool)
+    }
+
+    private struct Paragraph {
+        let range: NSRange
+        let type: ParagraphType
+    }
+
+    private struct State {
+        var inCodeBlock = false
+        var codeBlockLines: [String] = []
+        var blockquoteDepth = -1
+        var previousWasBlockquote = false
+        var openListOrdered: [Bool] = []
+        var listDepth = -1
+    }
+
+    private static func collectParagraphs(in text: NSAttributedString) -> [Paragraph] {
+        let string = text.string as NSString
+        var paragraphs: [Paragraph] = []
+        var index = 0
+
+        while index < string.length {
+            let searchRange = NSRange(location: index, length: string.length - index)
+            let newline = string.range(of: "\n", options: [], range: searchRange)
+            let lineEnd = newline.location == NSNotFound ? string.length : newline.location + 1
+            paragraphs.append(Paragraph(
+                range: NSRange(location: index, length: lineEnd - index),
+                type: paragraphType(at: index, in: text)
+            ))
+            index = lineEnd
+        }
+        return paragraphs
+    }
+
+    private static func paragraphType(at index: Int, in text: NSAttributedString) -> ParagraphType {
+        let attrs = text.attributes(at: index, effectiveRange: nil)
+
+        if MarkdownAttributeValue.boolValue(from: attrs[MarkdownAttribute.codeBlock]) {
+            return .codeBlock
+        }
+        if let level = MarkdownAttributeValue.intValue(from: attrs[MarkdownAttribute.headingLevel]) {
+            return .heading(min(max(level, 1), 6))
+        }
+        if let depth = MarkdownAttributeValue.intValue(from: attrs[MarkdownAttribute.blockquoteDepth]) {
+            return .blockquote(depth: depth)
+        }
+        if let depth = MarkdownAttributeValue.intValue(from: attrs[MarkdownAttribute.listDepth]) {
+            let ordered = MarkdownAttributeValue.intValue(
+                from: attrs[MarkdownAttribute.listType]
+            ) == ListType.ordered.rawValue
+            return .list(depth: depth, ordered: ordered)
+        }
+        return .normal
+    }
+
+    // MARK: - Paragraph emission
+
+    private static func process(
+        _ paragraph: Paragraph,
+        in text: NSAttributedString,
+        into html: inout String,
+        styles: CachedStyles,
+        state: inout State
+    ) {
+        let string = text.string as NSString
+        let raw = string.substring(with: paragraph.range)
+        let visible = raw.trimmingCharacters(in: CharacterSet(charactersIn: "\n\u{200B}"))
+
+        if visible.isEmpty, paragraph.type == .normal {
+            closeAllBlockquotes(&html, state: &state)
+            state.previousWasBlockquote = false
+            return
+        }
+
+        var contentRange = paragraph.range
+        if contentRange.length > 0, string.character(at: NSMaxRange(contentRange) - 1) == 0x0A {
+            contentRange.length -= 1
+        }
+        let isCodeBlock = paragraph.type == .codeBlock
+        let inline = inlineHTML(in: text, range: contentRange, styles: styles, isCodeBlock: isCodeBlock)
+
+        switch paragraph.type {
+        case .codeBlock:
+            collectCodeBlockLine(inline, state: &state)
+        case .blockquote(let depth):
+            emitBlockquote(inline, depth: depth, into: &html, styles: styles, state: &state)
+        case .list(let depth, let ordered):
+            emitList(inline, depth: depth, ordered: ordered, into: &html, styles: styles, state: &state)
+        case .heading(let level):
+            emitHeading(inline, level: level, into: &html, styles: styles, state: &state)
+        case .normal:
+            emitParagraph(inline, into: &html, styles: styles, state: &state)
+        }
+    }
+
+    private static func collectCodeBlockLine(_ line: String, state: inout State) {
+        if !state.inCodeBlock {
+            state.inCodeBlock = true
+            state.codeBlockLines.removeAll()
+        }
+        state.codeBlockLines.append(line)
+        state.previousWasBlockquote = false
+    }
+
+    private static func emitHeading(
+        _ content: String,
+        level: Int,
+        into html: inout String,
+        styles: CachedStyles,
+        state: inout State
+    ) {
+        closeCodeBlockIfOpen(&html, state: &state, styles: styles)
+        closeAllBlockquotes(&html, state: &state)
+        closeListsIfOpen(&html, state: &state)
+
+        let idx = level - 1
+        html += "<h\(level) style=\"font-size: \(styles.headingFontSizes[idx])px; "
+            + "font-weight: \(styles.headingFontWeights[idx]); "
+            + "color: \(styles.headingColors[idx]); "
+            + "margin: 0 0 \(styles.headingMarginBottoms[idx])px 0;\">\(content)</h\(level)>"
+        state.previousWasBlockquote = false
+    }
+
+    private static func emitParagraph(
+        _ content: String,
+        into html: inout String,
+        styles: CachedStyles,
+        state: inout State
+    ) {
+        closeCodeBlockIfOpen(&html, state: &state, styles: styles)
+        closeAllBlockquotes(&html, state: &state)
+        closeListsIfOpen(&html, state: &state)
+
+        html += "<p style=\"margin: 0 0 \(styles.paragraphMarginBottom)px 0; "
+            + "color: \(styles.paragraphColor); "
+            + "font-size: \(styles.paragraphFontSize)px;\">\(content)</p>"
+        state.previousWasBlockquote = false
+    }
+
+    private static func emitBlockquote(
+        _ content: String,
+        depth: Int,
+        into html: inout String,
+        styles: CachedStyles,
+        state: inout State
+    ) {
+        closeCodeBlockIfOpen(&html, state: &state, styles: styles)
+
+        if !state.previousWasBlockquote, state.blockquoteDepth >= 0 {
+            closeAllBlockquotes(&html, state: &state)
+        }
+
+        while state.blockquoteDepth > depth {
+            html += "</blockquote>"
+            state.blockquoteDepth -= 1
+        }
+
+        while state.blockquoteDepth < depth {
+            state.blockquoteDepth += 1
+            if state.blockquoteDepth == 0 {
+                html += "<blockquote style=\"background-color: \(styles.blockquoteBgColor); "
+                    + "border-inline-start: \(styles.blockquoteBorderWidth)px solid \(styles.blockquoteBorderColor); "
+                    + "padding: \(Fixed.blockquotePaddingVertical) \(styles.blockquoteGapWidth)px; "
+                    + "margin: 0 0 \(styles.blockquoteMarginBottom)px 0; "
+                    + "\(Fixed.blockquoteBorderRadiusCorners);\">"
+            } else {
+                html += "<blockquote style=\"border-inline-start: \(styles.blockquoteBorderWidth)px solid \(styles.blockquoteBorderColor); "
+                    + "padding-inline-start: \(styles.blockquoteGapWidth)px; "
+                    + "margin: \(Fixed.blockquoteNestedMargin);\">"
+            }
+        }
+
+        html += "<p style=\"margin: \(Fixed.blockquoteParagraphMargin); "
+            + "color: \(styles.blockquoteColor); "
+            + "font-size: \(styles.blockquoteFontSize)px;\">\(content)</p>"
+        state.previousWasBlockquote = true
+    }
+
+    private static func emitList(
+        _ content: String,
+        depth: Int,
+        ordered: Bool,
+        into html: inout String,
+        styles: CachedStyles,
+        state: inout State
+    ) {
+        closeCodeBlockIfOpen(&html, state: &state, styles: styles)
+        closeAllBlockquotes(&html, state: &state)
+
+        while state.listDepth > depth {
+            html += state.openListOrdered.last == true ? "</ol>" : "</ul>"
+            if !state.openListOrdered.isEmpty {
+                state.openListOrdered.removeLast()
+            }
+            state.listDepth -= 1
+        }
+
+        if state.listDepth == depth, let last = state.openListOrdered.last, last != ordered {
+            html += last ? "</ol>" : "</ul>"
+            state.openListOrdered.removeLast()
+            state.listDepth -= 1
+        }
+
+        while state.listDepth < depth {
+            state.listDepth += 1
+            let margin = state.listDepth == 0 ? "margin: 0 0 \(styles.paragraphMarginBottom)px 0; " : "margin: 0; "
+            if ordered {
+                html += "<ol style=\"\(margin)padding-inline-start: \(styles.listMarginLeft)px;\">"
+                state.openListOrdered.append(true)
+            } else {
+                html += "<ul style=\"\(margin)padding-inline-start: \(styles.listMarginLeft)px; list-style-type: disc;\">"
+                state.openListOrdered.append(false)
+            }
+        }
+
+        html += "<li style=\"margin-bottom: \(styles.listMarginBottom)px; "
+            + "color: \(styles.listColor); "
+            + "font-size: \(styles.listFontSize)px;\">\(content)</li>"
+        state.previousWasBlockquote = false
+    }
+
+    private static func closeCodeBlockIfOpen(_ html: inout String, state: inout State, styles: CachedStyles) {
+        guard state.inCodeBlock else { return }
+        state.inCodeBlock = false
+
+        // iOS code blocks carry padding spacer lines; trim empty leading and
+        // trailing lines but keep interior blank lines.
+        var lines = state.codeBlockLines
+        while lines.first?.isEmpty == true { lines.removeFirst() }
+        while lines.last?.isEmpty == true { lines.removeLast() }
+        state.codeBlockLines.removeAll()
+        guard !lines.isEmpty else { return }
+
+        html += "<pre dir=\"ltr\" style=\"background-color: \(styles.codeBlockBgColor); "
+            + "padding: \(styles.codeBlockPadding)px; "
+            + "border-radius: \(styles.codeBlockBorderRadius)px; "
+            + "margin: 0 0 \(styles.codeBlockMarginBottom)px 0; "
+            + "overflow-x: auto; text-align: left;\">"
+            + "<code style=\"font-family: \(Fixed.monospaceFamily); "
+            + "font-size: \(styles.codeBlockFontSize)px; "
+            + "color: \(styles.codeBlockColor);\">"
+        html += lines.joined(separator: "\n")
+        html += "</code></pre>"
+    }
+
+    private static func closeAllBlockquotes(_ html: inout String, state: inout State) {
+        while state.blockquoteDepth >= 0 {
+            html += "</blockquote>"
+            state.blockquoteDepth -= 1
+        }
+    }
+
+    private static func closeListsIfOpen(_ html: inout String, state: inout State) {
+        while let last = state.openListOrdered.popLast() {
+            html += last ? "</ol>" : "</ul>"
+        }
+        state.listDepth = -1
+    }
+
+    // MARK: - Inline emission
+
+    private static func inlineHTML(
+        in text: NSAttributedString,
+        range: NSRange,
+        styles: CachedStyles,
+        isCodeBlock: Bool
+    ) -> String {
+        guard range.length > 0 else { return "" }
+        var html = ""
+        let string = text.string as NSString
+
+        text.enumerateAttributes(in: range, options: []) { attrs, runRange, _ in
+            let content = string.substring(with: runRange)
+
+            if let attachment = attrs[.attachment] as? MarkdownImageAttachment {
+                appendImage(attachment, into: &html, styles: styles)
+                return
+            }
+            if attrs[.attachment] != nil || content == "\u{FFFC}" {
+                return
+            }
+
+            let cleaned = content
+                .replacingOccurrences(of: "\u{200B}", with: "")
+                .trimmingCharacters(in: .newlines)
+            guard !cleaned.isEmpty else { return }
+
+            appendStyledSegment(cleaned, attrs: attrs, into: &html, styles: styles, isCodeBlock: isCodeBlock)
+        }
+        return html
+    }
+
+    private static func appendImage(
+        _ attachment: MarkdownImageAttachment,
+        into html: inout String,
+        styles: CachedStyles
+    ) {
+        guard !attachment.imageURL.isEmpty else { return }
+        let escapedURL = escapeHTML(attachment.imageURL)
+
+        if attachment.isInline {
+            html += "<img src=\"\(escapedURL)\" style=\"height: \(Fixed.inlineImageHeight); "
+                + "width: auto; vertical-align: \(Fixed.inlineImageVerticalAlign);\">"
+        } else {
+            html += "</p><div style=\"margin-bottom: \(styles.imageMarginBottom)px;\">"
+                + "<img src=\"\(escapedURL)\" style=\"max-width: 100%; border-radius: \(styles.imageBorderRadius)px;\">"
+                + "</div><p>"
+        }
+    }
+
+    private static func appendStyledSegment(
+        _ content: String,
+        attrs: [NSAttributedString.Key: Any],
+        into html: inout String,
+        styles: CachedStyles,
+        isCodeBlock: Bool
+    ) {
+        let isStrong = MarkdownAttributeValue.boolValue(from: attrs[MarkdownAttribute.strong])
+        let isEmphasis = MarkdownAttributeValue.boolValue(from: attrs[MarkdownAttribute.emphasis])
+        let isStrikethrough = (MarkdownAttributeValue.intValue(from: attrs[.strikethroughStyle]) ?? 0) != 0
+        let isUnderline = (MarkdownAttributeValue.intValue(from: attrs[.underlineStyle]) ?? 0) != 0
+        let isCode = MarkdownAttributeValue.boolValue(from: attrs[MarkdownAttribute.inlineCode]) && !isCodeBlock
+
+        let linkURL: String?
+        switch attrs[.link] {
+        case let url as URL: linkURL = url.absoluteString
+        case let string as String: linkURL = string
+        default: linkURL = nil
+        }
+
+        if let linkURL {
+            html += "<a href=\"\(escapeHTML(linkURL))\" style=\"color: \(styles.linkColor); "
+                + "text-decoration: \(styles.linkUnderline ? "underline" : "none");\">"
+        }
+        if isCode {
+            html += "<code style=\"background-color: \(styles.codeBgColor); "
+                + "color: \(styles.codeColor); "
+                + "padding: \(Fixed.codePadding); "
+                + "border-radius: \(Fixed.codeBorderRadius); "
+                + "font-size: \(Fixed.codeFontSize); "
+                + "font-family: \(Fixed.monospaceFamily);\">"
+        }
+        if isStrong {
+            html += styles.strongColor.map { "<strong style=\"color: \($0);\">" } ?? "<strong>"
+        }
+        if isEmphasis {
+            html += styles.emphasisColor.map { "<em style=\"color: \($0);\">" } ?? "<em>"
+        }
+        if isUnderline, linkURL == nil {
+            html += "<u>"
+        }
+        if isStrikethrough {
+            html += "<s>"
+        }
+
+        html += escapeHTML(content).replacingOccurrences(of: "\u{2028}", with: "<br>")
+
+        if isStrikethrough { html += "</s>" }
+        if isUnderline, linkURL == nil { html += "</u>" }
+        if isEmphasis { html += "</em>" }
+        if isStrong { html += "</strong>" }
+        if isCode { html += "</code>" }
+        if linkURL != nil { html += "</a>" }
+    }
+
+    // MARK: - Styles
+
+    private struct CachedStyles {
+        let paragraphColor: String
+        let paragraphFontSize: Int
+        let paragraphMarginBottom: Int
+
+        let codeBlockColor: String
+        let codeBlockBgColor: String
+        let codeBlockFontSize: Int
+        let codeBlockPadding: Int
+        let codeBlockBorderRadius: Int
+        let codeBlockMarginBottom: Int
+
+        let codeColor: String
+        let codeBgColor: String
+
+        let blockquoteColor: String
+        let blockquoteBgColor: String
+        let blockquoteBorderColor: String
+        let blockquoteBorderWidth: Int
+        let blockquoteGapWidth: Int
+        let blockquoteMarginBottom: Int
+        let blockquoteFontSize: Int
+
+        let listColor: String
+        let listFontSize: Int
+        let listMarginBottom: Int
+        let listMarginLeft: Int
+
+        let linkColor: String
+        let linkUnderline: Bool
+
+        let strongColor: String?
+        let emphasisColor: String?
+
+        let imageMarginBottom: Int
+        let imageBorderRadius: Int
+
+        let headingFontSizes: [Int]
+        let headingFontWeights: [String]
+        let headingColors: [String]
+        let headingMarginBottoms: [Int]
+
+        init(config: MarkdownStyleConfig) {
+            let bodySize = Int(UIFont.preferredFont(forTextStyle: .body).pointSize)
+
+            paragraphColor = cssColor(config.paragraph.foregroundColor)
+            paragraphFontSize = config.paragraph.font.map { Int($0.pointSize) } ?? bodySize
+            paragraphMarginBottom = Int(config.paragraph.marginBottom ?? 0)
+
+            codeBlockColor = cssColor(config.codeBlock.foregroundColor)
+            codeBlockBgColor = cssColor(config.codeBlock.backgroundColor)
+            codeBlockFontSize = config.codeBlock.font.map { Int($0.pointSize) } ?? bodySize
+            codeBlockPadding = Int(config.codeBlock.padding ?? 0)
+            codeBlockBorderRadius = Int(config.codeBlock.borderRadius ?? 0)
+            codeBlockMarginBottom = Int(config.codeBlock.marginBottom ?? 0)
+
+            codeColor = cssColor(config.code.foregroundColor)
+            codeBgColor = cssColor(config.code.backgroundColor)
+
+            blockquoteColor = cssColor(config.blockquote.foregroundColor)
+            blockquoteBgColor = cssColor(config.blockquote.backgroundColor)
+            blockquoteBorderColor = cssColor(config.blockquote.borderColor)
+            blockquoteBorderWidth = Int(config.blockquote.borderWidth ?? 0)
+            blockquoteGapWidth = Int(config.blockquote.gapWidth ?? 0)
+            blockquoteMarginBottom = Int(config.blockquote.marginBottom ?? 0)
+            blockquoteFontSize = config.blockquote.font.map { Int($0.pointSize) } ?? bodySize
+
+            listColor = cssColor(config.list.foregroundColor)
+            listFontSize = config.list.font.map { Int($0.pointSize) } ?? bodySize
+            listMarginBottom = Int(config.list.marginBottom ?? 0)
+            listMarginLeft = Int(config.list.marginLeft ?? 24)
+
+            linkColor = cssColor(config.link.foregroundColor)
+            linkUnderline = config.link.underline ?? true
+
+            strongColor = config.strong.foregroundColor.map(cssColor)
+            emphasisColor = config.emphasis.foregroundColor.map(cssColor)
+
+            imageMarginBottom = Int(config.image.marginBottom ?? 0)
+            imageBorderRadius = Int(config.image.borderRadius ?? 0)
+
+            let headings = [
+                config.heading1, config.heading2, config.heading3,
+                config.heading4, config.heading5, config.heading6,
+            ]
+            headingFontSizes = headings.map { $0.font.map { Int($0.pointSize) } ?? bodySize }
+            headingFontWeights = headings.map { heading in
+                let isBold = heading.font?.fontDescriptor.symbolicTraits.contains(.traitBold) ?? true
+                return isBold ? "700" : "normal"
+            }
+            headingColors = headings.map { cssColor($0.foregroundColor) }
+            headingMarginBottoms = headings.map { Int($0.marginBottom ?? 0) }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func cssColor(_ color: UIColor?) -> String {
+        guard let color else { return "inherit" }
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return "inherit" }
+
+        let r = Int(round(min(max(red, 0), 1) * 255))
+        let g = Int(round(min(max(green, 0), 1) * 255))
+        let b = Int(round(min(max(blue, 0), 1) * 255))
+        if alpha < 1 {
+            let alphaString = String(format: "%.2f", alpha)
+            return "rgba(\(r), \(g), \(b), \(alphaString))"
+        }
+        return String(format: "#%02X%02X%02X", r, g, b)
+    }
+
+    private static func escapeHTML(_ text: String) -> String {
+        guard text.contains(where: { "&<>\"'".contains($0) }) else { return text }
+        return text
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+}

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -294,6 +294,39 @@ final class MarkdownTextView: UITextView {
         }
     }
 
+    /// Injectable so tests avoid UIPasteboard.general, which a headless test
+    /// process is not authorized to access.
+    var pasteboard: UIPasteboard = .general
+
+    /// System Copy puts plain text plus a styled HTML flavor on the
+    /// pasteboard, so rich-text targets keep the formatting.
+    override func copy(_ sender: Any?) {
+        guard let attributedText,
+              attributedText.length > 0,
+              selectedRange.length > 0,
+              selectedRange.location != NSNotFound,
+              selectedRange.location < attributedText.length
+        else {
+            super.copy(sender)
+            return
+        }
+
+        let clamped = NSRange(
+            location: selectedRange.location,
+            length: min(selectedRange.length, attributedText.length - selectedRange.location)
+        )
+        let plain = (attributedText.string as NSString).substring(with: clamped)
+        let html = MarkdownHTMLGenerator.generateHTML(
+            from: attributedText,
+            in: clamped,
+            config: styleConfig
+        )
+        pasteboard.items = [[
+            "public.utf8-plain-text": plain,
+            "public.html": html,
+        ]]
+    }
+
     func setMarkdownAttributedText(_ attributedText: NSAttributedString) {
         guard !(self.attributedText?.isEqual(to: attributedText) ?? false) else { return }
         self.attributedText = attributedText

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/HTMLGeneratorTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/HTMLGeneratorTests.swift
@@ -1,0 +1,272 @@
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+final class HTMLGeneratorTests: XCTestCase {
+    private var config: MarkdownStyleConfig!
+
+    override func setUp() {
+        super.setUp()
+        config = MarkdownStyleConfig.resolve(layers: [.default], traitCollection: .current)
+    }
+
+    private func html(for markdown: String, flags: Md4cFlags = .commonMark) -> String {
+        let rendered = MarkdownRenderer.render(markdown, config: config, flags: flags)
+        return MarkdownHTMLGenerator.generateHTML(
+            from: rendered,
+            in: NSRange(location: 0, length: rendered.length),
+            config: config
+        )
+    }
+
+    func testEmptyRangeYieldsEmptyDocument() {
+        XCTAssertEqual(
+            MarkdownHTMLGenerator.generateHTML(
+                from: NSAttributedString(),
+                in: NSRange(location: 0, length: 0),
+                config: config
+            ),
+            "<html></html>"
+        )
+    }
+
+    func testDocumentIsWrappedInHTMLTags() {
+        let result = html(for: "Hello")
+
+        XCTAssertTrue(result.hasPrefix("<html>"))
+        XCTAssertTrue(result.hasSuffix("</html>"))
+    }
+
+    func testParagraphCarriesConfiguredStyles() {
+        let result = html(for: "Hello world")
+
+        XCTAssertTrue(result.contains("<p style=\""))
+        XCTAssertTrue(result.contains("Hello world</p>"))
+        XCTAssertTrue(result.contains("font-size:"))
+        XCTAssertTrue(result.contains("color:"))
+    }
+
+    func testHeadingsUseSemanticTagsWithFontSize() {
+        let result = html(for: "# First\n\n### Third")
+
+        XCTAssertTrue(result.contains("<h1 style=\"font-size:"))
+        XCTAssertTrue(result.contains("First</h1>"))
+        XCTAssertTrue(result.contains("<h3 style=\"font-size:"))
+        XCTAssertTrue(result.contains("Third</h3>"))
+    }
+
+    func testBoldAndItalic() {
+        let result = html(for: "**bold** and *italic*")
+
+        XCTAssertTrue(result.contains("<strong>bold</strong>"))
+        XCTAssertTrue(result.contains("<em>italic</em>"))
+    }
+
+    func testStrikethroughEmitsS() {
+        let result = html(for: "~~gone~~")
+
+        XCTAssertTrue(result.contains("<s>gone</s>"))
+    }
+
+    func testUnderlineEmitsU() {
+        let result = html(for: "__under__", flags: Md4cFlags(underline: true))
+
+        XCTAssertTrue(result.contains("<u>under</u>"))
+    }
+
+    func testLinkCarriesHrefAndStyle() {
+        let result = html(for: "[press](https://swmansion.com)")
+
+        XCTAssertTrue(result.contains("<a href=\"https://swmansion.com\" style=\"color:"))
+        XCTAssertTrue(result.contains("press</a>"))
+        XCTAssertTrue(result.contains("text-decoration: underline"))
+    }
+
+    func testLinkTextIsNotDoubleUnderlined() {
+        let result = html(for: "[press](https://swmansion.com)")
+
+        XCTAssertFalse(result.contains("<u><a"))
+        XCTAssertFalse(result.contains("<a href=\"https://swmansion.com\" style=\"color: inherit\"><u>"))
+    }
+
+    func testInlineCodeUsesCodeTag() {
+        let result = html(for: "run `swift test` now")
+
+        XCTAssertTrue(result.contains("<code style=\"background-color:"))
+        XCTAssertTrue(result.contains("swift test</code>"))
+    }
+
+    func testCodeBlockUsesPreAndCode() {
+        let result = html(for: "```\nlet x = 1\nlet y = 2\n```")
+
+        XCTAssertTrue(result.contains("<pre dir=\"ltr\" style=\"background-color:"))
+        XCTAssertTrue(result.contains("<code style=\"font-family: Menlo"))
+        XCTAssertTrue(result.contains("let x = 1\nlet y = 2</code></pre>"))
+    }
+
+    func testCodeBlockPaddingSpacersAreTrimmed() {
+        let result = html(for: "```\ncontent\n```")
+
+        XCTAssertTrue(result.contains("<code style=\"font-family: Menlo, Monaco, Consolas, monospace; font-size:"))
+        XCTAssertFalse(result.contains(">\ncontent"))
+        XCTAssertTrue(result.contains("content</code></pre>"))
+    }
+
+    func testCodeBlockContentIsEscapedNotStyled() {
+        let result = html(for: "```\na < b && c > d\n```")
+
+        XCTAssertTrue(result.contains("a &lt; b &amp;&amp; c &gt; d"))
+    }
+
+    func testBlockquoteEmitsBorderAndInnerParagraph() {
+        let result = html(for: "> quoted text")
+
+        XCTAssertTrue(result.contains("<blockquote style=\"background-color:"))
+        XCTAssertTrue(result.contains("border-inline-start:"))
+        XCTAssertTrue(result.contains("quoted text</p>"))
+        XCTAssertTrue(result.contains("</blockquote>"))
+    }
+
+    func testNestedBlockquotes() {
+        let result = html(for: "> outer\n>> inner")
+
+        XCTAssertEqual(result.components(separatedBy: "<blockquote").count - 1, 2)
+        XCTAssertEqual(result.components(separatedBy: "</blockquote>").count - 1, 2)
+        XCTAssertTrue(result.contains("padding-inline-start:"))
+    }
+
+    func testUnorderedList() {
+        let result = html(for: "- one\n- two")
+
+        XCTAssertTrue(result.contains("<ul style=\""))
+        XCTAssertTrue(result.contains("list-style-type: disc"))
+        XCTAssertTrue(result.contains("<li style=\""))
+        XCTAssertTrue(result.contains("one</li>"))
+        XCTAssertTrue(result.contains("two</li>"))
+        XCTAssertTrue(result.contains("</ul>"))
+    }
+
+    func testOrderedList() {
+        let result = html(for: "1. first\n2. second")
+
+        XCTAssertTrue(result.contains("<ol style=\""))
+        XCTAssertTrue(result.contains("first</li>"))
+        XCTAssertTrue(result.contains("second</li>"))
+        XCTAssertTrue(result.contains("</ol>"))
+    }
+
+    func testNestedListsOpenSecondContainer() {
+        let result = html(for: "- outer\n  - inner")
+
+        XCTAssertEqual(result.components(separatedBy: "<ul").count - 1, 2)
+        XCTAssertEqual(result.components(separatedBy: "</ul>").count - 1, 2)
+    }
+
+    func testListTypeChangeAtSameDepthClosesContainer() {
+        let result = html(for: "- bullet\n\n1. number")
+
+        XCTAssertTrue(result.contains("</ul>"))
+        XCTAssertTrue(result.contains("<ol"))
+        XCTAssertLessThan(
+            result.range(of: "</ul>")!.lowerBound,
+            result.range(of: "<ol")!.lowerBound
+        )
+    }
+
+    func testBlockImageEmitsImgWithMaxWidth() {
+        let result = html(for: "![alt](https://example.invalid/pic.png)")
+
+        XCTAssertTrue(result.contains("<img src=\"https://example.invalid/pic.png\""))
+        XCTAssertTrue(result.contains("max-width: 100%"))
+    }
+
+    func testInlineImageUsesEmHeight() {
+        let result = html(for: "text ![icon](https://example.invalid/icon.png) more")
+
+        XCTAssertTrue(result.contains("<img src=\"https://example.invalid/icon.png\" style=\"height: 1.2em;"))
+    }
+
+    func testTextIsHTMLEscaped() {
+        let result = html(for: "a \\<script\\> & \"quote\"")
+
+        XCTAssertTrue(result.contains("&lt;script&gt;"))
+        XCTAssertTrue(result.contains("&amp;"))
+        XCTAssertTrue(result.contains("&quot;quote&quot;"))
+        XCTAssertFalse(result.contains("<script>"))
+    }
+
+    func testHardLineBreakEmitsBr() {
+        let result = html(for: "line one  \nline two")
+
+        XCTAssertTrue(result.contains("<br>"))
+    }
+
+    func testRTLWrapsDocumentInDirectionalDiv() {
+        let rendered = MarkdownRenderer.render("مرحبا", config: config)
+        let result = MarkdownHTMLGenerator.generateHTML(
+            from: rendered,
+            in: NSRange(location: 0, length: rendered.length),
+            config: config,
+            isRTL: true
+        )
+
+        XCTAssertTrue(result.hasPrefix("<html dir=\"rtl\">"))
+        XCTAssertTrue(result.contains("direction: rtl"))
+        XCTAssertTrue(result.hasSuffix("</div></html>"))
+    }
+
+    func testPartialRangeGeneratesOnlySelection() {
+        let rendered = MarkdownRenderer.render("Hello world", config: config)
+        let range = (rendered.string as NSString).range(of: "world")
+
+        let result = MarkdownHTMLGenerator.generateHTML(from: rendered, in: range, config: config)
+
+        XCTAssertTrue(result.contains("world"))
+        XCTAssertFalse(result.contains("Hello"))
+    }
+}
+
+final class MarkdownTextViewCopyTests: XCTestCase {
+    private var config: MarkdownStyleConfig!
+    private var pasteboard: UIPasteboard!
+
+    override func setUp() {
+        super.setUp()
+        config = MarkdownStyleConfig.resolve(layers: [.default], traitCollection: .current)
+        // UIPasteboard.general is not accessible from a headless test process.
+        pasteboard = UIPasteboard.withUniqueName()
+    }
+
+    override func tearDown() {
+        UIPasteboard.remove(withName: pasteboard.name)
+        super.tearDown()
+    }
+
+    private func makeTextView(markdown: String) -> MarkdownTextView {
+        let textView = MarkdownTextView()
+        textView.pasteboard = pasteboard
+        textView.setMarkdownAttributedText(MarkdownRenderer.render(markdown, config: config))
+        return textView
+    }
+
+    func testCopyPutsPlainAndHTMLFlavorsOnPasteboard() {
+        let textView = makeTextView(markdown: "**bold** text")
+        textView.selectedRange = NSRange(location: 0, length: textView.attributedText.length)
+
+        textView.copy(nil)
+
+        let item = pasteboard.items.first
+        XCTAssertNotNil(item)
+        XCTAssertTrue((item?["public.utf8-plain-text"] as? String)?.contains("bold text") == true)
+        XCTAssertTrue((item?["public.html"] as? String)?.contains("<strong>bold</strong>") == true)
+    }
+
+    func testCopyWithEmptySelectionWritesNoFlavors() {
+        let textView = makeTextView(markdown: "plain")
+        textView.selectedRange = NSRange(location: 0, length: 0)
+
+        textView.copy(nil)
+
+        XCTAssertNil(pasteboard.items.first?["public.html"])
+    }
+}


### PR DESCRIPTION
System Copy now writes a public.html flavor alongside plain text, so pasting into rich-text targets keeps headings, inline styles, lists, blockquotes, code blocks, links, and images. The HTML is generated by walking the custom rendering attributes and emitting semantic tags with inline CSS derived from the style config.

The system attributed-string HTML exporter was deliberately not used: it drops image URLs, loses list markers and block chrome (drawn by decoration views, absent from the text), and emits unstable CSS.

The pasteboard is injectable on MarkdownTextView because headless test processes are not authorized to access UIPasteboard.general.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

