### PR TITLE
feat: allow opting out of tree-sitter & RaTeX downloads via package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ yarn add react-native-enriched-markdown
 > and iOS LaTeX math (kept out of the npm tarball to keep it ~1 MB). This needs network access to
 > `registry.npmjs.org` and `github.com`. If you install offline, with `--ignore-scripts`, or with
 > **pnpm** (which blocks dependency scripts by default), see
-> [Native assets](docs/NATIVE_ASSETS.md) for how to restore them.
+> [Native assets](docs/NATIVE_ASSETS.md) for how to restore them. If you don't use a feature, skip
+> its download with an `"enriched-markdown": { "enableCodeHighlight": false, "enableMath": false }`
+> block in your app's `package.json` — see [Skipping the download](docs/NATIVE_ASSETS.md#skipping-the-download-opt-out).
 
 #### 2. Install iOS / macOS dependencies
 

--- a/docs/CODE_HIGHLIGHT.md
+++ b/docs/CODE_HIGHLIGHT.md
@@ -69,6 +69,12 @@ A block whose language is not compiled in simply renders as plain (uncolored) co
 Only the grammars you compile end up in your binary, so trimming the list is the main size lever.
 The seam degrades to plain code whenever a grammar is absent, so nothing breaks when you remove one.
 
+> [!TIP]
+> To also skip the install-time grammar download (not just the build-time linking), set
+> `"enriched-markdown": { "enableCodeHighlight": false }` in your app's `package.json`. This
+> auto-disables highlighting at build time too, so it's an alternative to the build flags below.
+> See [Skipping the download](./NATIVE_ASSETS.md#skipping-the-download-opt-out).
+
 ### iOS
 
 Add to your `Podfile` and re-run `pod install`:

--- a/docs/LATEX_MATH.md
+++ b/docs/LATEX_MATH.md
@@ -90,6 +90,12 @@ ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] = '0'
 
 This excludes **RaTeX** from the build. Rebuild the app after running `pod install`.
 
+> [!TIP]
+> To also skip the install-time RaTeX download (not just the build-time linking), set
+> `"enriched-markdown": { "enableMath": false }` in your app's `package.json`. Because the iOS build
+> auto-disables math when the framework is absent, this opt-out needs no Podfile edit. See
+> [Skipping the download](./NATIVE_ASSETS.md#skipping-the-download-opt-out).
+
 > [!NOTE]
 > When math is **enabled** (the default), no special Podfile configuration is required.
 > RaTeX ships as a prebuilt static XCFramework vendored into the pod, so it links under
@@ -99,10 +105,12 @@ This excludes **RaTeX** from the build. Rebuild the app after running `pod insta
 
 > [!NOTE]
 > The RaTeX XCFramework is **not** bundled in the npm tarball — it is downloaded at install time by
-> a `postinstall` script (see [Native assets](./NATIVE_ASSETS.md)). If `pod install` fails with a
-> missing `ios/vendor/RaTeX.xcframework`, the download did not run (offline, `--ignore-scripts`, or
-> pnpm); restore it with `node node_modules/react-native-enriched-markdown/postinstall.mjs`, or
-> disable math as shown below.
+> a `postinstall` script (see [Native assets](./NATIVE_ASSETS.md)). If `ios/vendor/RaTeX.xcframework`
+> is missing (offline install, `--ignore-scripts`, pnpm, or a `package.json` opt-out), `pod install`
+> auto-disables math and prints a warning instead of failing. To restore math, run
+> `node node_modules/react-native-enriched-markdown/postinstall.mjs` and re-run `pod install`, or
+> force it with `ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] = '1'` (which turns the missing framework back
+> into a hard error).
 
 > [!IMPORTANT]
 > **Upgrading from a version that used `use_frameworks! :linkage => :dynamic` for math?**

--- a/docs/NATIVE_ASSETS.md
+++ b/docs/NATIVE_ASSETS.md
@@ -34,9 +34,11 @@ them.
   Windows, but RaTeX is iOS-only so this only affects Windows dev machines and is non-fatal.
 
 The postinstall step **never fails the install**: if a download does not complete it prints a warning
-and exits successfully. The missing assets only surface later, as a clear error when the native build
-runs (the iOS podspec, for example, raises an actionable message if `ios/vendor/RaTeX.xcframework` is
-absent while math is enabled).
+and exits successfully. When an asset is missing the native build treats the corresponding feature as
+disabled (code highlighting compiles a no-op stub; iOS math is skipped with a CocoaPods warning), so
+the build stays green. To turn a feature back on after fixing the download, re-run the recovery command
+below, or force it via its build flag (`ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] = '1'` /
+`enrichedMarkdown.enableCodeHighlight=true`), which restores the actionable missing-asset error.
 
 ## Re-running or recovering
 
@@ -67,10 +69,33 @@ Then re-run `pod install` (iOS) or rebuild (Android).
   (`nodeLinker: node-modules`), which is the norm for React Native projects anyway.
 - **`--ignore-scripts`**: the assets will not download. Run the recovery command above afterward.
 
-## Disabling the features
+## Skipping the download (opt out)
 
-If you don't use a feature you can turn it off so its assets are never compiled/linked (a failed or
-skipped download then never matters):
+If you don't use a feature, opt out in **your app's `package.json`** so the postinstall never
+downloads its assets. Add an `enriched-markdown` block (both fields default to `true`):
+
+```json
+{
+  "enriched-markdown": {
+    "enableCodeHighlight": false,
+    "enableMath": false
+  }
+}
+```
+
+`enableCodeHighlight: false` skips the tree-sitter runtime + grammar download (iOS and Android);
+`enableMath: false` skips the RaTeX download (iOS; Android math uses a Maven dependency and is
+unaffected). Because the native build keys off whether the assets are present on disk, a
+`package.json` opt-out **also disables the feature at build time** — no Podfile or `gradle.properties`
+edit needed. Re-run the install (or the recovery command above) after changing these values.
+
+This is read from the consumer project only (via `INIT_CWD`); it has no effect inside this repo's own
+monorepo development.
+
+## Disabling the features at build time
+
+You can also disable a feature purely at build time (assets stay downloaded but are never
+compiled/linked):
 
 - Code highlighting: see [Choosing languages / reducing binary size](./CODE_HIGHLIGHT.md#choosing-languages--reducing-binary-size).
 - LaTeX math: see [Disabling LaTeX Math](./LATEX_MATH.md#disabling-latex-math-reducing-bundle-size).

--- a/packages/core/cpp/highlight/code_highlight_podspec.rb
+++ b/packages/core/cpp/highlight/code_highlight_podspec.rb
@@ -43,10 +43,11 @@ module EnrichedMarkdownCodeHighlight
     return disabled if ENV['ENRICHED_MARKDOWN_ENABLE_CODE_HIGHLIGHT'] == '0'
 
     # Code highlighting compiles the vendored tree-sitter runtime + grammar sources,
-    # downloaded at postinstall. If the consumer opted out (`enriched-markdown`.
-    # enableCodeHighlight = false skips that download), the runtime is absent -- fall
-    # back to the no-op stub instead of feeding missing files to clang.
-    return disabled unless File.exist?(File.join(podspec_dir, 'cpp/highlight/vendor/tree-sitter/src/lib.c'))
+    # downloaded at postinstall. The grammars/.stamp marker is written only after every
+    # grammar source is fully vendored, so gating on it (rather than the runtime lib.c,
+    # which is fetched first) also falls back to the no-op stub on a partial/failed
+    # download -- not just a `enriched-markdown`.enableCodeHighlight = false opt-out.
+    return disabled unless File.exist?(File.join(podspec_dir, 'cpp/highlight/vendor/grammars/.stamp'))
 
     defaults = default_languages(podspec_dir)
     langs = (ENV['ENRICHED_MARKDOWN_CODE_HIGHLIGHT_LANGUAGES'] || '')

--- a/packages/core/cpp/highlight/code_highlight_podspec.rb
+++ b/packages/core/cpp/highlight/code_highlight_podspec.rb
@@ -42,6 +42,12 @@ module EnrichedMarkdownCodeHighlight
   def self.config(podspec_dir)
     return disabled if ENV['ENRICHED_MARKDOWN_ENABLE_CODE_HIGHLIGHT'] == '0'
 
+    # Code highlighting compiles the vendored tree-sitter runtime + grammar sources,
+    # downloaded at postinstall. If the consumer opted out (`enriched-markdown`.
+    # enableCodeHighlight = false skips that download), the runtime is absent -- fall
+    # back to the no-op stub instead of feeding missing files to clang.
+    return disabled unless File.exist?(File.join(podspec_dir, 'cpp/highlight/vendor/tree-sitter/src/lib.c'))
+
     defaults = default_languages(podspec_dir)
     langs = (ENV['ENRICHED_MARKDOWN_CODE_HIGHLIGHT_LANGUAGES'] || '')
             .split(',').map(&:strip).reject(&:empty?)

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -31,11 +31,25 @@ Pod::Spec.new do |s|
     s.preserve_paths = "cpp/highlight/vendor/**/*" if code_highlight[:enabled]
   end
 
-  # To disable LaTeX math rendering (RaTeX, iOS only), add ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] = '0' to your Podfile.
-  # RaTeX ships as a prebuilt static XCFramework vendored under ios/vendor (restored by
-  # vendor/vendor-ratex.mjs); it links under CocoaPods default static linkage and needs
-  # neither `use_frameworks!` nor SPM interop.
-  enable_math = ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] != '0'
+  # LaTeX math rendering (RaTeX, iOS only). RaTeX ships as a prebuilt static XCFramework
+  # vendored under ios/vendor (restored by vendor/vendor-ratex.mjs at postinstall); it
+  # links under CocoaPods default static linkage and needs neither `use_frameworks!` nor
+  # SPM interop.
+  #
+  # Resolution: ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] forces the choice ('0' off, '1' on).
+  # Otherwise math tracks whether the consumer actually downloaded the framework, so a
+  # package.json opt-out (`enriched-markdown`.enableMath = false skips the postinstall
+  # download) yields a clean build with no Podfile edit. To disable explicitly, set
+  # ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] = '0' in your Podfile.
+  ratex_present = File.directory?(File.join(__dir__, 'ios/vendor/RaTeX.xcframework'))
+  math_flag = ENV['ENRICHED_MARKDOWN_ENABLE_MATH']
+  enable_math = math_flag == '1' || (math_flag != '0' && ratex_present)
+  if !enable_math && math_flag != '0' && !ratex_present
+    Pod::UI.warn '[ReactNativeEnrichedMarkdown] LaTeX math disabled: the vendored RaTeX ' \
+      'XCFramework was not found at ios/vendor/RaTeX.xcframework. If this is unintended, re-run ' \
+      '`node node_modules/react-native-enriched-markdown/postinstall.mjs` ' \
+      "(or set ENV['ENRICHED_MARKDOWN_ENABLE_MATH'] = '1' in your Podfile)."
+  end
 
   # The RaTeX XCFramework bundles its own module.modulemap and headers; never let the
   # broad ios/**/*.h and ios/**/*.swift globs treat its internals as pod sources.
@@ -48,11 +62,11 @@ Pod::Spec.new do |s|
   preprocessor_defs = "$(inherited) MD4C_USE_UTF8=1#{code_highlight[:defines]}"
   if enable_math
     preprocessor_defs += ' ENRICHED_MARKDOWN_MATH=1'
-    # The vendored tree (ios/vendor) is gitignored and restored by vendor/vendor-ratex.mjs
-    # on `prepare`/`prepack`. Published tarballs already bundle it; a fresh monorepo clone
-    # that skips `yarn prepare` would otherwise fail later with a confusing missing-file
-    # error. Fail early with an actionable message instead.
-    unless File.directory?(File.join(__dir__, 'ios/vendor/RaTeX.xcframework'))
+    # Reachable only when math is force-enabled (ENRICHED_MARKDOWN_ENABLE_MATH='1') but the
+    # vendored tree is missing; the unforced path already auto-disables above. Published
+    # tarballs bundle ios/vendor, and postinstall/`yarn prepare` restore it otherwise, so
+    # fail early with an actionable message instead of a confusing missing-file error.
+    unless ratex_present
       raise '[ReactNativeEnrichedMarkdown] LaTeX math is enabled but the vendored RaTeX ' \
         'XCFramework is missing at ios/vendor/RaTeX.xcframework. ' \
         'For published installs, re-run: node node_modules/react-native-enriched-markdown/postinstall.mjs ' \

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -63,9 +63,10 @@ Pod::Spec.new do |s|
   if enable_math
     preprocessor_defs += ' ENRICHED_MARKDOWN_MATH=1'
     # Reachable only when math is force-enabled (ENRICHED_MARKDOWN_ENABLE_MATH='1') but the
-    # vendored tree is missing; the unforced path already auto-disables above. Published
-    # tarballs bundle ios/vendor, and postinstall/`yarn prepare` restore it otherwise, so
-    # fail early with an actionable message instead of a confusing missing-file error.
+    # vendored tree is missing; the unforced path already auto-disables above. ios/vendor is
+    # kept out of the npm tarball and restored on the consumer's machine by postinstall (or
+    # by `yarn prepare` in the monorepo), so fail early with an actionable message instead of
+    # a confusing missing-file error.
     unless ratex_present
       raise '[ReactNativeEnrichedMarkdown] LaTeX math is enabled but the vendored RaTeX ' \
         'XCFramework is missing at ios/vendor/RaTeX.xcframework. ' \

--- a/packages/react-native-enriched-markdown/android/build.gradle
+++ b/packages/react-native-enriched-markdown/android/build.gradle
@@ -40,13 +40,13 @@ if (grammarManifest == null) {
 def defaultCodeHighlightLanguages = new groovy.json.JsonSlurper().parse(grammarManifest)
   .grammars.findAll { id, spec -> spec['default'] }.collect { id, spec -> id }
 // The enrichedMarkdown.enableCodeHighlight gradle property forces the choice. Otherwise
-// code highlighting tracks whether the vendored tree-sitter runtime + grammars were
-// downloaded at postinstall, so a package.json opt-out (`enriched-markdown`.
-// enableCodeHighlight = false skips that download) auto-disables here instead of feeding
-// missing sources to CMake -- no gradle.properties edit required.
+// code highlighting tracks the vendored grammars/.stamp marker, which postinstall writes
+// only after every grammar source is fully vendored. Gating on the stamp (rather than the
+// runtime lib.c, fetched first) auto-disables here -- feeding no missing sources to CMake --
+// on a `enriched-markdown`.enableCodeHighlight = false opt-out or a partial/failed download.
 def codeHighlightProp = rootProject.findProperty("enrichedMarkdown.enableCodeHighlight") ?: findProperty("enrichedMarkdown.enableCodeHighlight")
-def codeHighlightRuntime = new File(projectDir, "../cpp/highlight/vendor/tree-sitter/src/lib.c")
-def enableCodeHighlight = codeHighlightProp != null ? codeHighlightProp.toString().toBoolean() : codeHighlightRuntime.exists()
+def codeHighlightStamp = new File(projectDir, "../cpp/highlight/vendor/grammars/.stamp")
+def enableCodeHighlight = codeHighlightProp != null ? codeHighlightProp.toString().toBoolean() : codeHighlightStamp.exists()
 def codeHighlightLanguagesProp = rootProject.findProperty("enrichedMarkdown.codeHighlightLanguages") ?: findProperty("enrichedMarkdown.codeHighlightLanguages")
 def codeHighlightLanguages = codeHighlightLanguagesProp ? codeHighlightLanguagesProp.toString().split(",").collect { it.trim() }.findAll { it } : defaultCodeHighlightLanguages
 def codeHighlightActive = enableCodeHighlight && !codeHighlightLanguages.isEmpty()

--- a/packages/react-native-enriched-markdown/android/build.gradle
+++ b/packages/react-native-enriched-markdown/android/build.gradle
@@ -39,7 +39,14 @@ if (grammarManifest == null) {
 }
 def defaultCodeHighlightLanguages = new groovy.json.JsonSlurper().parse(grammarManifest)
   .grammars.findAll { id, spec -> spec['default'] }.collect { id, spec -> id }
-def enableCodeHighlight = (rootProject.findProperty("enrichedMarkdown.enableCodeHighlight") ?: findProperty("enrichedMarkdown.enableCodeHighlight") ?: "true").toString().toBoolean()
+// The enrichedMarkdown.enableCodeHighlight gradle property forces the choice. Otherwise
+// code highlighting tracks whether the vendored tree-sitter runtime + grammars were
+// downloaded at postinstall, so a package.json opt-out (`enriched-markdown`.
+// enableCodeHighlight = false skips that download) auto-disables here instead of feeding
+// missing sources to CMake -- no gradle.properties edit required.
+def codeHighlightProp = rootProject.findProperty("enrichedMarkdown.enableCodeHighlight") ?: findProperty("enrichedMarkdown.enableCodeHighlight")
+def codeHighlightRuntime = new File(projectDir, "../cpp/highlight/vendor/tree-sitter/src/lib.c")
+def enableCodeHighlight = codeHighlightProp != null ? codeHighlightProp.toString().toBoolean() : codeHighlightRuntime.exists()
 def codeHighlightLanguagesProp = rootProject.findProperty("enrichedMarkdown.codeHighlightLanguages") ?: findProperty("enrichedMarkdown.codeHighlightLanguages")
 def codeHighlightLanguages = codeHighlightLanguagesProp ? codeHighlightLanguagesProp.toString().split(",").collect { it.trim() }.findAll { it } : defaultCodeHighlightLanguages
 def codeHighlightActive = enableCodeHighlight && !codeHighlightLanguages.isEmpty()

--- a/packages/react-native-enriched-markdown/postinstall.mjs
+++ b/packages/react-native-enriched-markdown/postinstall.mjs
@@ -21,6 +21,41 @@ if (!fs.existsSync(grammarManifest)) {
   process.exit(0);
 }
 
+// Consumer opt-out. npm/yarn/pnpm set INIT_CWD to the project root running the
+// install, so the consumer declares which heavy native assets to skip downloading
+// via an `enriched-markdown` block in their own package.json:
+//
+//   { "enriched-markdown": { "enableCodeHighlight": false, "enableMath": false } }
+//
+// Both features default to enabled (opt-out, not opt-in). Any resolution failure
+// (INIT_CWD unset, unreadable/malformed JSON, absent key) falls back to downloading
+// everything -- a skipped download is far cheaper to recover from than a silently
+// missing feature. The native build mirrors this by keying off asset presence on
+// disk (see the podspecs and android/build.gradle), so a package.json opt-out alone
+// yields a clean build with no Podfile/gradle edits.
+function resolveConsumerConfig() {
+  const initCwd = process.env.INIT_CWD;
+  if (!initCwd) {
+    return {};
+  }
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(initCwd, 'package.json'), 'utf8'));
+    const config = pkg['enriched-markdown'];
+    return config && typeof config === 'object' ? config : {};
+  } catch {
+    return {};
+  }
+}
+
+const consumerConfig = resolveConsumerConfig();
+const enableCodeHighlight = consumerConfig.enableCodeHighlight !== false;
+const enableMath = consumerConfig.enableMath !== false;
+
+if (!enableCodeHighlight && !enableMath) {
+  console.log(`${LOG} both code highlighting and math are disabled via package.json ("enriched-markdown"); skipping postinstall.`);
+  process.exit(0);
+}
+
 console.log(`${LOG} restoring vendored native assets ...`);
 
 const vendorGrammars = path.join(PKG_ROOT, 'vendor-grammars.mjs');
@@ -32,19 +67,25 @@ const iosVendor = path.join(PKG_ROOT, 'ios/vendor');
 let failed = false;
 
 // Tree-sitter runtime + grammar C sources
-const r1 = spawnSync(process.execPath, [
-  vendorGrammars,
-  '--from-npm',
-  '--vendor-dir', vendorDir,
-  '--manifest', grammarManifest,
-], { stdio: 'inherit' });
-if (r1.status !== 0) {
-  console.warn(`${LOG} WARNING: vendor-grammars failed. Code highlighting may not work.`);
-  failed = true;
+if (enableCodeHighlight) {
+  const r1 = spawnSync(process.execPath, [
+    vendorGrammars,
+    '--from-npm',
+    '--vendor-dir', vendorDir,
+    '--manifest', grammarManifest,
+  ], { stdio: 'inherit' });
+  if (r1.status !== 0) {
+    console.warn(`${LOG} WARNING: vendor-grammars failed. Code highlighting may not work.`);
+    failed = true;
+  }
+} else {
+  console.log(`${LOG} code highlighting disabled via package.json ("enriched-markdown".enableCodeHighlight = false); skipping tree-sitter grammars.`);
 }
 
 // RaTeX XCFramework + Swift sources + fonts (iOS math)
-if (fs.existsSync(ratexManifest) && fs.existsSync(vendorRatex)) {
+if (!enableMath) {
+  console.log(`${LOG} math disabled via package.json ("enriched-markdown".enableMath = false); skipping RaTeX.`);
+} else if (fs.existsSync(ratexManifest) && fs.existsSync(vendorRatex)) {
   const r2 = spawnSync(process.execPath, [
     vendorRatex,
     '--manifest', ratexManifest,


### PR DESCRIPTION
### What/Why?

Consumers can now skip the heavy install-time native asset downloads (tree-sitter grammars ~169 MB, RaTeX XCFramework ~47 MB, added in #660) when they don't use code highlighting and/or LaTeX math. Following Reanimated's convention, the opt-out is a declarative block in the consumer's own `package.json`:

```json
{
  "enriched-markdown": {
    "enableCodeHighlight": false,
    "enableMath": false
  }
}
```

Both fields default to true (opt-out, not opt-in), and are read from the consumer project only (via INIT_CWD), so
there's no effect on this repo's own monorepo development.

Two parts:

1. Gate the downloads (postinstall.mjs) — reads the enriched-markdown block from ${INIT_CWD}/package.json and skips
the grammar and/or RaTeX download accordingly; early-exits when both are disabled. Any resolution failure (no INIT_CWD, malformed JSON, missing key) falls back to downloading everything — a skipped download is cheaper to recover from than a silently missing feature.
2. Native build keys off asset presence — so a single package.json edit builds cleanly with no Podfile / gradle.properties change required. Previously, skipping a download while the build flag stayed enabled broke the build (the iOS podspec raised on the missing RaTeX XCFramework; iOS/Android fed absent grammar sources to the compiler). Now:
  - ReactNativeEnrichedMarkdown.podspec — enable_math is three-state: ENRICHED_MARKDOWN_ENABLE_MATH=0 off, =1 on (keeps the missing-framework raise as a force-on safety net), unset → tracks whether the framework was downloaded, with a Pod::UI.warn when auto-disabled.
  - code_highlight_podspec.rb — returns the no-op stub when the vendored tree-sitter runtime is absent.
  - android/build.gradle — enableCodeHighlight defaults to vendor-runtime presence when the enrichedMarkdown.enableCodeHighlight gradle property is unset; the property still overrides.

Existing ENRICHED_MARKDOWN_ENABLE_* env / enrichedMarkdown.enable* gradle overrides are unchanged. Android math is unaffected (it uses a Maven dependency, not the vendored XCFramework).

Testing

Built the real publish tarball (npm pack) and installed it into throwaway /tmp consumer projects with different


Verified the native-side auto-disable against the installed layouts:
- iOS code-highlight podspec (real require): assets absent → enabled=false, 0 sources; present → enabled=true, 26
sources, ENRICHED_MARKDOWN_CODE_HIGHLIGHT=1.
- iOS math resolution: absent + env unset → off (+warn); present → on; absent + =1 → on then raise.
- Android enableCodeHighlight default: absent → false, present → true.

Also ran postinstall.mjs directly against a published-layout sandbox across all config permutations (no key / both off / each off / malformed JSON / no INIT_CWD) — all gate as designed. ruby -c clean on both podspecs.

PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)