### PR TITLE
chore: update repository references and project name to 'enriched-markdown'

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature Request 💡
-    url: https://github.com/software-mansion/react-native-enriched-markdown/discussions/new?category=ideas
+    url: https://github.com/software-mansion/enriched-markdown/discussions/new?category=ideas
     about: If you have a feature request, please create a new discussion on GitHub.
   - name: Discussions on GitHub 💬
-    url: https://github.com/software-mansion/react-native-enriched-markdown/discussions
+    url: https://github.com/software-mansion/enriched-markdown/discussions
     about: If this library works as promised but you need help, please ask questions there.

--- a/.github/workflows/publish-android-maven.yml
+++ b/.github/workflows/publish-android-maven.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   publish-android-maven:
-    if: github.repository == 'software-mansion/react-native-enriched-markdown'
+    if: github.repository == 'software-mansion/enriched-markdown'
     runs-on: ubuntu-latest
 
     concurrency:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   npm-build:
-    if: github.repository == 'software-mansion/react-native-enriched-markdown'
+    if: github.repository == 'software-mansion/enriched-markdown'
     runs-on: ubuntu-latest
 
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ To get started with the project, make sure you have the correct version of [Node
 ### Cloning the Repository
 
 ```sh
-git clone https://github.com/software-mansion/react-native-enriched-markdown.git
-cd react-native-enriched-markdown
+git clone https://github.com/software-mansion/enriched-markdown.git
+cd enriched-markdown
 ```
 
 ## Initial Setup

--- a/README.md
+++ b/README.md
@@ -1,20 +1,65 @@
-<img src="https://github.com/user-attachments/assets/83cb462c-17df-4809-8b8a-fa4abb258cb3" alt="Enriched Markdown by Software Mansion" width="100%">
+<img src="https://github.com/user-attachments/assets/83cb462c-17df-4809-8b8a-fa4abb258cb3" alt="Enriched Markdown by Software Mansion" />
 
-# Enriched Markdown
+A multi-platform SDK for rendering Markdown as native text and editing rich text with Markdown output. Ships as a React Native library with iOS, Android, macOS, and Web support, plus standalone native SDKs for iOS (Swift) and Android (Kotlin).
 
-A multi-platform Markdown rendering and rich text editing SDK for React Native, iOS, and Android.
-Enriched Markdown provides native text rendering from Markdown, a rich text input with Markdown output,
-and standalone native libraries for iOS (Swift) and Android (Kotlin).
+## Features
+
+- **Native text rendering** — High-performance Markdown rendering built on platform text APIs (no WebView)
+- **Rich text input** — Text input with Markdown output, inline formatting, headings, lists, links, and mentions
+- **Cross-platform** — Consistent API across React Native (TypeScript), iOS (Swift), and Android (Kotlin)
+- **CommonMark & GFM** — Full CommonMark compliance with GitHub Flavored Markdown extensions (tables, task lists, strikethrough)
+- **LaTeX math** — Block and inline math rendering powered by [RaTeX](https://github.com/erweixin/RaTeX)
+- **Markdown streaming** — Real-time streaming support for AI/LLM chat interfaces
+- **Code syntax highlighting** — Native syntax highlighting powered by [tree-sitter](https://tree-sitter.github.io/tree-sitter/)
+- **Accessibility** — VoiceOver on iOS, TalkBack on Android, semantic HTML on web
+
+See the [feature comparison table](https://enriched.swmansion.com/markdown) for a detailed breakdown of supported features per platform.
 
 ## Packages
 
-| Platform | Package | Path |
-|----------|---------|------|
-| React Native | [![npm](https://img.shields.io/npm/v/react-native-enriched-markdown)](https://www.npmjs.com/package/react-native-enriched-markdown) | [`packages/react-native-enriched-markdown`](packages/react-native-enriched-markdown) |
-| Android | [![Maven Central](https://img.shields.io/maven-central/v/com.swmansion.enriched.markdown/ui)](https://central.sonatype.com/artifact/com.swmansion.enriched.markdown/ui) | [`packages/android-enriched-markdown`](packages/android-enriched-markdown) |
-| iOS | *Coming soon* | [`packages/ios-enriched-markdown`](packages/ios-enriched-markdown) |
+| Platform | Package | Documentation |
+|----------|---------|---------------|
+| React Native | [![npm](https://img.shields.io/npm/v/react-native-enriched-markdown)](https://www.npmjs.com/package/react-native-enriched-markdown) | [React Native SDK](https://enriched.swmansion.com/markdown) |
+| Android | [![Maven Central](https://img.shields.io/maven-central/v/com.swmansion.enriched.markdown/ui)](https://central.sonatype.com/artifact/com.swmansion.enriched.markdown/ui) | [Android SDK](https://enriched.swmansion.com/markdown) |
+| iOS | *Coming soon* | [iOS SDK](https://enriched.swmansion.com/markdown) |
 
 Full documentation is available at the [documentation site](https://enriched.swmansion.com/markdown).
+
+## Quick start
+
+### React Native
+
+```bash
+yarn add react-native-enriched-markdown
+```
+
+```tsx
+import { EnrichedMarkdownText } from 'react-native-enriched-markdown';
+
+<EnrichedMarkdownText
+  markdown={"# Hello\n\nThis is **enriched** markdown."}
+/>
+```
+
+### Android
+
+```kotlin
+dependencies {
+  implementation("com.swmansion.enriched.markdown:compose:0.1.0")
+}
+```
+
+```kotlin
+import com.swmansion.enriched.markdown.compose.EnrichedMarkdownText
+import com.swmansion.enriched.markdown.compose.MarkdownTheme
+
+MarkdownTheme {
+  EnrichedMarkdownText(
+    markdown = "# Hello\n\nThis is **enriched** markdown.",
+    onLinkPress = { url -> /* open url */ },
+  )
+}
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ See the [feature comparison table](https://enriched.swmansion.com/markdown) for 
 
 | Platform | Package | Documentation |
 |----------|---------|---------------|
-| React Native | [![npm](https://img.shields.io/npm/v/react-native-enriched-markdown)](https://www.npmjs.com/package/react-native-enriched-markdown) | [React Native SDK](https://enriched.swmansion.com/markdown) |
-| Android | [![Maven Central](https://img.shields.io/maven-central/v/com.swmansion.enriched.markdown/ui)](https://central.sonatype.com/artifact/com.swmansion.enriched.markdown/ui) | [Android SDK](https://enriched.swmansion.com/markdown) |
-| iOS | *Coming soon* | [iOS SDK](https://enriched.swmansion.com/markdown) |
+| React Native | [![npm](https://img.shields.io/npm/v/react-native-enriched-markdown)](https://www.npmjs.com/package/react-native-enriched-markdown) | [React Native](https://enriched.swmansion.com/markdown) |
+| Android | [![Maven Central](https://img.shields.io/maven-central/v/com.swmansion.enriched.markdown/ui)](https://central.sonatype.com/artifact/com.swmansion.enriched.markdown/ui) | [Android](https://enriched.swmansion.com/markdown) |
+| iOS | *Coming soon* | [iOS](https://enriched.swmansion.com/markdown) |
 
 Full documentation is available at the [documentation site](https://enriched.swmansion.com/markdown).
 
@@ -35,9 +35,11 @@ yarn add react-native-enriched-markdown
 
 ```tsx
 import { EnrichedMarkdownText } from 'react-native-enriched-markdown';
+import { Linking } from 'react-native';
 
 <EnrichedMarkdownText
-  markdown={"# Hello\n\nThis is **enriched** markdown."}
+  markdown={"# Hello\n\nThis is **enriched** [markdown](https://commonmark.org)."}
+  onLinkPress={({ url }) => Linking.openURL(url)}
 />
 ```
 
@@ -55,7 +57,7 @@ import com.swmansion.enriched.markdown.compose.MarkdownTheme
 
 MarkdownTheme {
   EnrichedMarkdownText(
-    markdown = "# Hello\n\nThis is **enriched** markdown.",
+    markdown = "# Hello\n\nThis is **enriched** [markdown](https://commonmark.org).",
     onLinkPress = { url -> /* open url */ },
   )
 }
@@ -67,7 +69,7 @@ See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the 
 
 ## License
 
-Enriched Markdown library is licensed under [The MIT License](./LICENSE).
+Enriched Markdown is licensed under [The MIT License](./LICENSE).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,220 +1,20 @@
-<img src="https://github.com/user-attachments/assets/83cb462c-17df-4809-8b8a-fa4abb258cb3" alt="react-native-enriched-markdown by Software Mansion" width="100%">
-<a href="https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-enriched-1&n=1"><img src="https://swm-delivery.com/www/images/zone-gh-react-native-enriched-1?n=1" /></a>
-<a href="https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-enriched-2&n=1"><img src="https://swm-delivery.com/www/images/zone-gh-react-native-enriched-2?n=1" /></a>
-<a href="https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-enriched-3&n=1"><img src="https://swm-delivery.com/www/images/zone-gh-react-native-enriched-3?n=1" /></a>
+<img src="https://github.com/user-attachments/assets/83cb462c-17df-4809-8b8a-fa4abb258cb3" alt="Enriched Markdown by Software Mansion" width="100%">
 
-# react-native-enriched-markdown
+# Enriched Markdown
 
-`react-native-enriched-markdown` is a powerful React Native library that renders Markdown content as native text and provides a rich text input with Markdown output. It supports iOS, Android, macOS, and Web, and requires the New Architecture (Fabric) for native platforms.
+A multi-platform Markdown rendering and rich text editing SDK for React Native, iOS, and Android.
+Enriched Markdown provides native text rendering from Markdown, a rich text input with Markdown output,
+and standalone native libraries for iOS (Swift) and Android (Kotlin).
 
-### EnrichedMarkdownText
+## Packages
 
-- ⚡ Fully native text rendering (no WebView)
-- 🌐 Web support via [react-native-web](https://necolas.github.io/react-native-web/) + [md4c](https://github.com/mity/md4c) compiled to WebAssembly
-- 🎯 High-performance Markdown parsing with [md4c](https://github.com/mity/md4c)
-- 📐 CommonMark standard compliant
-- 📊 GitHub Flavored Markdown (GFM)
-- 🧮 LaTeX math rendering (block `$$...$$` with `flavor="github"`, inline `$...$` in all flavors)
-- 🔀 [Markdown Streaming](docs/MARKDOWN_STREAMING.md) support (via [react-native-streamdown](https://github.com/software-mansion-labs/react-native-streamdown))
-- 🎨 Fully customizable styles for all elements
-- ✨ Text selection and copy support
-- 📌 Custom text selection context menu items
-- 🔗 Interactive link handling with [per-URL-pattern styling](docs/MENTIONS.md#link-variants-styling) (`linkVariants`)
-- 👤 Renders mentions as styled links (compatible with `EnrichedMarkdownTextInput` mention output)
-- 🙈 Spoiler text with animated particle overlay and tap-to-reveal
-- 🖼️ Native image interactions (iOS: Copy, Save to Camera Roll)
-- 🌐 Native platform features (Translate, Look Up, Search Web, Share)
-- 🗣️ Accessibility support (VoiceOver on iOS, TalkBack on Android, semantic HTML on web)
-- 🔄 Full RTL (right-to-left) support including text, lists, blockquotes, tables, and task lists
+| Platform | Package | Path |
+|----------|---------|------|
+| React Native | [![npm](https://img.shields.io/npm/v/react-native-enriched-markdown)](https://www.npmjs.com/package/react-native-enriched-markdown) | [`packages/react-native-enriched-markdown`](packages/react-native-enriched-markdown) |
+| Android | [![Maven Central](https://img.shields.io/maven-central/v/com.swmansion.enriched.markdown/ui)](https://central.sonatype.com/artifact/com.swmansion.enriched.markdown/ui) | [`packages/android-enriched-markdown`](packages/android-enriched-markdown) |
+| iOS | *Coming soon* | [`packages/ios-enriched-markdown`](packages/ios-enriched-markdown) |
 
-### EnrichedMarkdownTextInput
-
-- ✏️ Rich text input with Markdown output
-- 🕹️ Imperative API for toggling styles and managing links
-- 📋 Native context menu with formatting submenu
-- 🔍 Real-time style state detection
-- 🔗 Auto-link detection with customizable regex
-- 🔄 Smart copy/paste with Markdown preservation
-- 🎨 Customizable bold, italic, and link colors
-- 👤 [Mentions](docs/MENTIONS.md) with configurable indicators, suggestion lifecycle events, and per-pattern link styling
-
-Since 2012 [Software Mansion](https://swmansion.com) is a software agency with experience in building web and mobile apps. We are Core React Native Contributors and experts in dealing with all kinds of React Native issues.
-We can help you build your next dream product –
-[Hire us](https://swmansion.com/contact/projects?utm_source=react-native-enriched-markdown&utm_medium=readme).
-
-## Table of Contents
-
-- [Prerequisites](#prerequisites)
-- [Installation](#installation)
-- [Native assets (install-time download)](docs/NATIVE_ASSETS.md)
-- [EnrichedMarkdownText](#enrichedmarkdowntext-1)
-  - [Usage](docs/TEXT.md#usage)
-  - [Supported Markdown Elements](docs/TEXT.md#supported-markdown-elements)
-  - [Copy Options](docs/TEXT.md#copy-options)
-  - [Accessibility](docs/TEXT.md#accessibility)
-  - [RTL Support](docs/TEXT.md#rtl-support)
-  - [Customizing Styles](docs/TEXT.md#customizing-styles)
-  - [LaTeX Math](docs/LATEX_MATH.md)
-  - [Image Caching](docs/IMAGE_CACHING.md)
-  - [Markdown Streaming](docs/MARKDOWN_STREAMING.md)
-- [EnrichedMarkdownTextInput](#enrichedmarkdowntextinput-1)
-  - [Usage](docs/INPUT.md#usage)
-  - [Inline Styles](docs/INPUT.md#inline-styles)
-  - [Links](docs/INPUT.md#links)
-  - [Auto-Link Detection](docs/INPUT.md#auto-link-detection)
-  - [Mentions](docs/MENTIONS.md)
-  - [Style Detection](docs/INPUT.md#style-detection)
-  - [Other Events](docs/INPUT.md#other-events)
-  - [Customizing Styles](docs/INPUT.md#customizing-enrichedmarkdowntextinput--styles)
-- [API Reference](#api-reference)
-- [Testing with Jest](docs/TESTING.md)
-- [Web Support](docs/WEB.md)
-- [macOS Support](docs/MACOS.md)
-- [Compatibility Table](#compatibility-table)
-- [Contributing](#contributing)
-- [Future Plans](#future-plans)
-- [License](#license)
-
-## Prerequisites
-
-**Native (iOS / Android / macOS)**
-
-- Requires [the React Native New Architecture (Fabric)](https://reactnative.dev/architecture/landing-page)
-- See [Compatibility Table](#compatibility-table) for supported React Native versions
-- macOS support via [react-native-macos](https://github.com/microsoft/react-native-macos) `0.81+`
-
-**Web**
-
-- Requires [`react-native-web`](https://necolas.github.io/react-native-web/) and Metro (or another bundler with `.web.tsx` platform resolution)
-- No New Architecture requirement — the web renderer runs entirely in JavaScript via WebAssembly
-- Only `EnrichedMarkdownText` is supported on web (`EnrichedMarkdownTextInput` is native-only)
-- LaTeX math requires the optional [`katex`](https://katex.org/) peer dependency
-
-## Installation
-
-### Web
-
-No steps beyond having `react-native-web` configured. For LaTeX math, install the optional peer dependency:
-
-```sh
-npm install katex
-# or
-yarn add katex
-```
-
-See [Web Support](docs/WEB.md) for full setup details, supported features, and prop behaviour.
-
-### Bare React Native app (iOS / Android)
-
-#### 1. Install the library
-
-```sh
-yarn add react-native-enriched-markdown
-```
-
-> [!TIP]
-> To try the latest features before they land in a stable release, install the nightly build:
->
-> ```sh
-> yarn add react-native-enriched-markdown@nightly
-> ```
->
-> Nightly versions are published to npm automatically and may contain breaking changes.
-
-> [!NOTE]
-> On install, a `postinstall` script downloads the large native assets used by code highlighting
-> and iOS LaTeX math (kept out of the npm tarball to keep it ~1 MB). This needs network access to
-> `registry.npmjs.org` and `github.com`. If you install offline, with `--ignore-scripts`, or with
-> **pnpm** (which blocks dependency scripts by default), see
-> [Native assets](docs/NATIVE_ASSETS.md) for how to restore them. If you don't use a feature, skip
-> its download with an `"enriched-markdown": { "enableCodeHighlight": false, "enableMath": false }`
-> block in your app's `package.json` — see [Skipping the download](docs/NATIVE_ASSETS.md#skipping-the-download-opt-out).
-
-#### 2. Install iOS / macOS dependencies
-
-The library includes native code so you will need to re-build the native app.
-
-```sh
-# iOS
-cd ios && bundle install && bundle exec pod install
-
-# macOS (react-native-macos)
-cd macos && bundle install && bundle exec pod install
-```
-
-### Expo app
-
-#### 1. Install the library
-
-```sh
-npx expo install react-native-enriched-markdown
-```
-
-#### 2. Run prebuild
-
-The library includes native code so you will need to re-build the native app.
-
-```sh
-npx expo prebuild
-```
-
-> [!NOTE]
-> The library won't work in Expo Go as it needs native changes.
-
-> [!NOTE]
-> `npx expo install` runs the same `postinstall` asset download described under
-> [Native assets](docs/NATIVE_ASSETS.md); it needs network access and does not work with Yarn PnP.
-
-> [!IMPORTANT]
-> **iOS: Save to Camera Roll**
->
-> If your Markdown content includes images and you want users to save them to their photo library, add the following to your `Info.plist`:
->
-> ```xml
-> <key>NSPhotoLibraryAddUsageDescription</key>
-> <string>This app needs access to your photo library to save images.</string>
-> ```
-
-## EnrichedMarkdownText
-
-See [EnrichedMarkdownText](docs/TEXT.md) for detailed documentation on usage examples, GFM tables, task lists, link handling, supported elements, copy options, accessibility, RTL support, and customizing styles. Mentions created by `EnrichedMarkdownTextInput` render as styled links — use [`linkVariants`](docs/MENTIONS.md#link-variants-styling) to customize their appearance.
-
-## EnrichedMarkdownTextInput
-
-See [EnrichedMarkdownTextInput](docs/INPUT.md) for detailed documentation on usage examples, inline styles, links, style detection, events, and customizing styles.
-
-## API Reference
-
-See the [API Reference](docs/API_REFERENCE.md) for a detailed overview of all the props, methods, and events available.
-
-## Web Support
-
-See [Web Support](docs/WEB.md) for details on supported features, web-specific prop behaviour, and known limitations.
-
-## macOS Support
-
-`react-native-enriched-markdown` supports macOS via [react-native-macos](https://github.com/microsoft/react-native-macos). See [macOS Support](docs/MACOS.md) for details on macOS-specific features, known limitations, and the example app.
-
-## Future Plans
-
-We're actively working on expanding the capabilities of `react-native-enriched-markdown`. Here's what's on the roadmap:
-
-- `EnrichedMarkdownTextInput`: headings, lists, blockquotes, code blocks, inline images
-- `EnrichedMarkdownTextInput` web support
-- macOS: block math rendering, VoiceOver accessibility, tail fade-in animation
-- Web: spoiler text, streaming animation, configurable link `target`, copy options (Copy as Markdown, multi-format clipboard)
-
-## Compatibility Table
-
-|             | 0.82 | 0.83 | 0.84 | 0.85 | 0.86 | 0.87 |
-| ----------- | :--: | :--: | :--: | :--: | :--: | :--: |
-| **nightly** |  ⛔  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
-| **1.0.0**   |  ⛔  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
-| **0.7.0**   |  ⛔  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
-| **0.6.0**   |  ⛔  |  ✅  |  ✅  |  ✅  |  ⛔  |  ⛔  |
-| **0.5.0**   |  ⛔  |  ✅  |  ✅  |  ✅  |  ⛔  |  ⛔  |
-| **0.4.x**   |  ✅  |  ✅  |  ✅  |  ⛔  |  ⛔  |  ⛔  |
-| **0.3.0**   |  ✅  |  ✅  |  ✅  |  ⛔  |  ⛔  |  ⛔  |
+Full documentation is available at the [documentation site](https://enriched.swmansion.com/markdown).
 
 ## Contributing
 
@@ -222,7 +22,7 @@ See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the 
 
 ## License
 
-`react-native-enriched-markdown` library is licensed under [The MIT License](./LICENSE).
+Enriched Markdown library is licensed under [The MIT License](./LICENSE).
 
 ---
 

--- a/apps/react-native-example/ios/Podfile.lock
+++ b/apps/react-native-example/ios/Podfile.lock
@@ -2556,91 +2556,91 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EnrichedMarkdownCore: de5d43b832522f5bcb74ea6431e5d82b37c7ade8
+  EnrichedMarkdownCore: 307fa629311ebe5bc1af294769a5b992fd37a26f
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: 1622a566d44d0dd4d377a1532e3ac82be7a0443c
+  hermes-engine: 24defc72310bc7b45e7797e47e02fe8e627f6ecc
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f
-  RCTSwiftUIWrapper: 1feaf484029fd6294fe8bc401d28e1d803eca142
+  RCTSwiftUIWrapper: ab2ca548be15d63afa95103afc8685a7c3eab78b
   RCTTypeSafety: 3eaed17dbddb0b989208b062ea14c44d412b9780
   React: 2574546f2d017abd14d0c9b48cf2b6a0547c2591
   React-callinvoker: 03cd4b931d1d583d87aae99b8f7b6fe26bf571ee
-  React-Core: b0a0038e05720fb8148759404e9c354e3e60043c
-  React-Core-prebuilt: 7da85c26e5616d52f119b81ce5e3e6fc5c9bda49
-  React-CoreModules: a1121b3182200be11e078940159c67ff95ee98b4
-  React-cxxreact: 8f74977959064bee99af63bb0ad95b6c3dbec921
+  React-Core: 1c824d9c7dd8aa760b5f1b50d5a54c2a3f598f87
+  React-Core-prebuilt: 13924a267683b3d6fa4bde9c80380becf83a9c5c
+  React-CoreModules: 2f9ed75bca7f6dea2b70e8a1f4a5ca9b6be52d76
+  React-cxxreact: 7103d5ba69848c039e11079e74ceede05efe795e
   React-debug: 8cc8d99ccc664ef9e873027f7fc3fb0a50496012
-  React-defaultsnativemodule: 7c8182addbb79ec576c589186b51e3fb405da7da
-  React-domnativemodule: 576bd1e6ad81477997dcb556e6db1f005134356b
-  React-Fabric: 4cbd22315ddb9e33441437f851117d314d1b4ad3
-  React-FabricComponents: efe374aecaf1bbc2fb9a195ece4b50fd9f66bfa0
-  React-FabricImage: cfeffc0b527de8bc2dc5a50618dad119361d0ec3
-  React-featureflags: 98931b22f5f4b861a3985b75bd79c5fcbe4618ab
-  React-featureflagsnativemodule: 518c2e279cdb3835604f7e8fb15f4c2691336b4c
-  React-graphics: ac9ff09da733d98c0e5eddb589dc7f9f082c9531
-  React-hermes: bd1a14a982e63ee75e9c9cb8d11d3d4b5f330196
-  React-idlecallbacksnativemodule: b6378d3bca83d8284e1abaa51251ee1ce570d85a
-  React-ImageManager: 4936349da191d1bc29ed2bbaf5a2dd74bfdf5ed8
-  React-intersectionobservernativemodule: d9a6451f2aa1f1c989d5d5e0d967db2c07d0c48c
-  React-jserrorhandler: 2455567e21fcc036f96015b2b8eb4eb13e0d8d05
-  React-jsi: bf5ec8e7a7b26bddc39ab7f821af5aad8bb94a33
-  React-jsiexecutor: cf6c957f578dd491ec8ae516a39aff2cf7369f1a
-  React-jsinspector: 63e9b9f9a5b6c51bf38deea2b379a63754c0ab0d
-  React-jsinspectorcdp: 327082854cdebb1f500a669c51146b9fd871058c
-  React-jsinspectornetwork: bbc5c2e881252075d63dc679f18cd856c2def94e
-  React-jsinspectortracing: ea6ec857ead0de4e6bbb2e12ee48ae4381938874
-  React-jsitooling: 52e278666b35e856414d613d7dc50d1f0d50d9a5
-  React-jsitracing: 642172314677a1d1780b81f4e2e4a3f4d3ccf238
-  React-logger: 35cda3ab8977c6c4546e3cf6dc8f91bacec25934
-  React-Mapbuffer: c058c051f571589e37a29bce18d0e9b730faa9d0
-  React-microtasksnativemodule: 03752e60738a797bb49f4d6cb0291dfa398099b8
-  React-mutationobservernativemodule: 2e568e13c98bd185fe83266795233fa7ad2cbc19
-  react-native-safe-area-context: 650ba9c4c3ce2d68bbd7c450d08b7250c7b58623
-  react-native-slider: 8824cf332b11bf5149f6576c8c8b32b4f93f82ac
-  React-NativeModulesApple: a4713821c9caae40ae33eef933a6e692a6f4a81d
-  React-networking: b344a1a41a4729ef859123b7a234f3092761cb25
+  React-defaultsnativemodule: 603c108411d39d7bb5ccb8c270f1f50cb6207e10
+  React-domnativemodule: c49a502edc85f515a029c341fe5fba155fa6675c
+  React-Fabric: acc4915d719db793c5853e5c74b54ea5aa48e865
+  React-FabricComponents: aebebc98914a4a8fc962fa7b5b98ebaf250acb68
+  React-FabricImage: 42e99e48ff73c8b20cee229e622977d0b97b6247
+  React-featureflags: c6d8d8d52acf3a956485726076b73eeff7935340
+  React-featureflagsnativemodule: c992de92dcf30dcf09efdec17752abe4128ec55f
+  React-graphics: 239fd9b0512e539d3563f0825618f4e49795eefd
+  React-hermes: ae4685ca9fa5f47003bc594d3f146e29284136d1
+  React-idlecallbacksnativemodule: 10a5be842ab181953c772a3f28cdf94572833eb0
+  React-ImageManager: c36a56c3b13eba92e1d0d30da35d0a1ccf29cd6c
+  React-intersectionobservernativemodule: 71404bfa47d31e4143cc9db3e26178b5cfcd07e1
+  React-jserrorhandler: ca2eeb03c1a77bbfab1b5425b943e3e8d92295f2
+  React-jsi: c4b6daf8a31ac54f2db49cd6cce29720fec1f3a8
+  React-jsiexecutor: acdc1a217b7ea29bcf6315b770d01e6b1c2fca14
+  React-jsinspector: 95d6394efe9fb4a64ed33afc076b32a6384c8514
+  React-jsinspectorcdp: 6ce51378a552feaaaac1a7b0d995fa0c49fa4f8c
+  React-jsinspectornetwork: 0db435c9264f200635fdf294a3b643dd3946d4cf
+  React-jsinspectortracing: 2e4470e1f301ff597bd65299aa95da4bae6e5c4f
+  React-jsitooling: 796bc991cdce68e2cc059d0271a28e0d4f8b0891
+  React-jsitracing: f3008e7b5e1d9de8d9f2ca1b85824ed86b0cea00
+  React-logger: fff73f4ceecad968c97baafdc77dcf84befc38b6
+  React-Mapbuffer: ce449ccdf3b80384415b925606be8a4bdcfc65d3
+  React-microtasksnativemodule: 2eb3f49d0d8e77b5343455eccd057010b8d38b6b
+  React-mutationobservernativemodule: f0a0d5ae9b51caf7becbeabf836d716cfedb6bf2
+  react-native-safe-area-context: 58eeaba7cb5b8e03bfe91a655d995042f89a74df
+  react-native-slider: 08ecfc4e9cc16cc388a56dd9caeca51b55cd9bb7
+  React-NativeModulesApple: a092d89b58f635ebfab88048b0eda9fb516819fd
+  React-networking: 968bbbe73590149feb1e72b2af4f6a68e4796ece
   React-oscompat: 0b72a7e926954a0415ccd83e0748b6561fe45367
-  React-perflogger: a0d581c6cc174e847877107ddac3f4fc9b518dc7
-  React-performancecdpmetrics: 91d3d0dce2e3a239ea68cc2882e75b11a61cbf2e
-  React-performancetimeline: 4b9e04002c1ddba95167276a86424e5face65605
+  React-perflogger: 865984e492514aa6e5279fc3e663132cfa4d5022
+  React-performancecdpmetrics: 2efbf9bdb48c8d8446f4dd10e8bf0dc5d711772f
+  React-performancetimeline: 9d256484bff1513481be9f234baba694dc3b52e2
   React-RCTActionSheet: 902c79deec52f99cc48b1051b59bcbe86787d339
-  React-RCTAnimation: f50eac1c9dbea36c4abc69cb24e2da4364374055
-  React-RCTAppDelegate: a5d746fec869d15a8f6eecce60510c18e52135d5
-  React-RCTBlob: e544dc72edc6f277c67e85493b0a405e1993c250
-  React-RCTFabric: 8003ea99830c294857d41469a888b033e5ad91a6
-  React-RCTFBReactNativeSpec: 8a3506041284fdc75da90e6fa40fb9b575414a39
-  React-RCTImage: fb85496986a53d9e11a835124a083b7c7c33f898
-  React-RCTLinking: b8eafcdedaebf981a18396db61d1190f5279ea81
-  React-RCTNetwork: 03573c4fcc73e28f48fea7aea69310b6955a749c
-  React-RCTRuntime: 08d58920b217b2d7715d5da595794e63520cd2d9
-  React-RCTSettings: f9b278b46e5de1ff8b843bb7aefaee721f06572d
-  React-RCTText: 7266943febf3382dac8adce9ba0de95b90c26e9e
-  React-RCTVibration: 27e1952701ec858922062f25a59b0c48e7153151
+  React-RCTAnimation: 09cf722039ae30ff5d64e2b011ff054ae651c3b6
+  React-RCTAppDelegate: a47de6fddb7eb0c028abba83138a5ce283bd7e77
+  React-RCTBlob: 38c418d067e0c61818223503063310122e44c588
+  React-RCTFabric: 480ca2a105730e1790cfd13291d086cb53725825
+  React-RCTFBReactNativeSpec: 63131378510a5191515a4adfc308e65b465106f4
+  React-RCTImage: 3ce36f82441b76b715818ee7ee95f6f5b34f9ee1
+  React-RCTLinking: 2f7b5ed4983122e5115732d25a4360960eab583c
+  React-RCTNetwork: dcd3b180f33da86f5dc5e928a816eb5464fa7f16
+  React-RCTRuntime: 6ef8e778fbab426b12eb5a9b5f7a0e86313c5a10
+  React-RCTSettings: b97727ec8c55c35bd284457a647c938c040b942b
+  React-RCTText: 4d1b88f6d3e1a43afe46706d956ec6664c87b984
+  React-RCTVibration: 415d14d6a1a64bf947fcef6b193915a494431168
   React-rendererconsistency: ef8519bdd9931261c6561bfad6506356b8108387
-  React-renderercss: edc1b0a18b12d681f8edbc779039dc6db32cf7b2
-  React-rendererdebug: 074ec3420f3bab2bea498da65e5a17e9288c90d0
-  React-RuntimeApple: 180682587e82ae4fc525f7d6636ed5db39c1e78c
-  React-RuntimeCore: 991cdb27072f7885750fdad4a70c2b919533e4ef
-  React-runtimeexecutor: bfec6ca5e62c6b2460a4adf0fddce0c4db0a8748
-  React-RuntimeHermes: dcb07afe0f38c1cbaf48b7a1bf4904e867529726
-  React-runtimescheduler: fdf0b71e519e416ad38c76525df43eba8dd78db2
-  React-timing: 7b538f379678210bf30d8541eb4cf007c000c6f3
-  React-utils: a15da1da76aee3dd0ed9f51d62bf1c09be17c221
-  React-viewtransitionnativemodule: 8556c844dcd691ab3fe1b32bbf8f58c8c9a49c75
-  React-webperformancenativemodule: 4d1d0258107fe0cb8ef5c9ac17a6a099785f2995
-  ReactAppDependencyProvider: adf5403892170fbe996fce485a703f25df08db66
-  ReactCodegen: ee39bbc365b4791c9b5183b52c533ebf586e1d8d
-  ReactCommon: 4d01bfb533b93a2103329dfefc74db6a9e272888
+  React-renderercss: 1aa1bf99fa2ace143eb87d5190fd43609fc1e832
+  React-rendererdebug: 40a4fb3dea21a7ac1759ca0eb6c88a924aecb075
+  React-RuntimeApple: 84fadbb4fe8ca531e15e29a22af05911f17569c6
+  React-RuntimeCore: f4d9af5f16d37e63308cb03b36c89d01e7f68a06
+  React-runtimeexecutor: 4d59410f66af529d04c84c8b152ced07dabc471e
+  React-RuntimeHermes: fd719d8f4d9ce79636fe2e09e94b0ac31b7b263b
+  React-runtimescheduler: 784033620aa5515e2f45a60369eed4d32f9400b8
+  React-timing: a16df9ae98f950396d9ce3abf43cb0cb2f21194c
+  React-utils: b68ee619aef28d8f9b85532d98db0327f7bdf743
+  React-viewtransitionnativemodule: 11fe091101d381451b1542c37b2745900254f096
+  React-webperformancenativemodule: b5d249419f1546663845c82f24de4e18a3180997
+  ReactAppDependencyProvider: dcdd0e1b9559a6d8d8aea05286f4ed085091978e
+  ReactCodegen: afe0d436ee089d7bea6418429d8312b1d23a6801
+  ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
-  ReactNativeEnrichedMarkdown: e99b757d76c562c246e3db4e063dc8669b677f85
-  RNCAsyncStorage: c5cc7057fed9368e15f9ee41d328327a86d30e38
-  RNDateTimePicker: c33c46d089998652b576a58ac08108db8c9af6f1
-  RNGestureHandler: a21ad1bb32b203570440c29b7e406a342a690842
-  RNReanimated: 786fbca32bbd50c274f25af01253a6f33fb4989e
-  RNScreens: 63cc2156368ac1a8239e9131103c2fef901fc381
-  RNSVG: 5a15a0cf553a18ab64bb38eeb4041e7e6d97bcec
-  RNWorklets: cfa6ca17fcc5ea7b6c1e391fb1c7c980e2d69407
+  ReactNativeEnrichedMarkdown: 062067406b8a478956c31aece1dd3e0cb4915d1d
+  RNCAsyncStorage: d0aafe51ea74a65afce26acb739a4ea975a7a884
+  RNDateTimePicker: 7b2738f1e595f83c14580a11c476872755c5befc
+  RNGestureHandler: 92172e79df6e88e0e93b6341f9dcd8b5a02746ba
+  RNReanimated: a9bf68fb5f19ce1c363b7d1413dcf8ee323185b8
+  RNScreens: 01b065ded2dfe7987bcce770ff3a196be417ff41
+  RNSVG: 3fe8590403ac9f107b4d14591bc6e54da4894e5c
+  RNWorklets: ae7f2b95d75b903387e6359583f2fd67bc9a93ff
   Yoga: fe50ab299e578f397fef753cf309c6703a4db29b
 
 PODFILE CHECKSUM: c50941eff996f01b8b4099a0640ffde77228a027

--- a/apps/react-native-macos-example/macos/Podfile.lock
+++ b/apps/react-native-macos-example/macos/Podfile.lock
@@ -2520,7 +2520,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: cea1d4f90a3a59537f3deb03ff5656489d7133dd
   DoubleConversion: d31b1eb37f6d6f456530c4fd9124b857d6889cab
-  EnrichedMarkdownCore: 0709dc23a16a9557e12b5c2daed9e33ef0a50d70
+  EnrichedMarkdownCore: 8d4dfcc7f6acb3585e14072e1e63c7401c483209
   fast_float: 20817c22759af6ac8d4d67e6e059b8b499953656
   FBLazyVector: bee2ce91926aed5131538dbe216219bb688b064c
   fmt: 24e7591456deb60b4a77518f83d9a916ac84223f
@@ -2532,64 +2532,64 @@ SPEC CHECKSUMS:
   RCTTypeSafety: 48826a4d03329e6eaf28b6c0ebade9dd154f53cd
   React: 3eeb24d4e794c7c811af95dc24f32a3a056cadf3
   React-callinvoker: dacab616acde2640fa591642dbccd21b2b6593b9
-  React-Core: f4225f274eda036b99e6987aa0c407b7e4277380
-  React-CoreModules: 79c387ae19097a6830897a7513583f43547bc9e2
-  React-cxxreact: 8124a8083f5894376f6eaa6c3c70fddccc26a77d
+  React-Core: 5b0203b00ccceeaa75955488de534515fed65b8f
+  React-CoreModules: b29e553d99087ab761188996c8e2a3e894e4f124
+  React-cxxreact: 3f05b678cb13109eaad8341568279db02c3d60ea
   React-debug: a0df5913ccca6dca0a216cd74449c074840ddb3a
-  React-defaultsnativemodule: 1c424e15dc2b5b8c3ff57b113dec42866425f31e
-  React-domnativemodule: af5d8ea9c908f4a7a0f8a8d98df91881868caab5
-  React-Fabric: cc9ebc686a32f9cc8dcf1204ff628297871c0115
-  React-FabricComponents: 1bfd2b76ff36b88d5a43712233ab0c464af3d13b
-  React-FabricImage: 5a7d18aeb769d4d4eabe423d9c7cd1d9d7471a6e
-  React-featureflags: 20f5a8db534b3808ab8636719747f8e58acf6513
-  React-featureflagsnativemodule: b7e4c025099bcad7b847c2ea225ac33ee70fccf8
-  React-graphics: 629064fcf2a57a990b8cc035d396dcf5af2eaaad
-  React-hermes: 619e1b458f8935a7fa6180627c2d2cefd0cb513b
-  React-idlecallbacksnativemodule: 685a7b9446b3307e49ed2bfcb9bc5a532960ff53
-  React-ImageManager: 77e5670df5684cf5d10597b6b62197e5dcfe6d40
-  React-jserrorhandler: 02a483deca2ac847aaec04d4a1977beaed7c1fc9
-  React-jsi: 6665c11248f0d5f8cf7dab3fdf2b0778526e6e4a
-  React-jsiexecutor: ec03555254493d3c1812478898a4af2291c015b4
-  React-jsinspector: 281674c6057cf86aa9c28213b9da2fd079ba5f92
-  React-jsinspectorcdp: b054ae19e15cb857182bd244b518e6b9e6e0112d
-  React-jsinspectornetwork: e9d3c0372c33cc3ba1428a23ae39ce423efd7065
-  React-jsinspectortracing: f7bccb70c9100c33efe8a30bc45be481512ca648
-  React-jsitooling: ab8f25bf0d4a39d0b3dc05a730091a146be0cf2e
-  React-jsitracing: 36a6948fbaf5dfd20c71ff12a06079572cf40c00
-  React-logger: 407da14ba957ca8e4a2d68be1a76697cef2dbe0d
-  React-Mapbuffer: 0411c6d9a244c183ea35dc0c421d512efb531809
-  React-microtasksnativemodule: 71ab5df5f6b494945e369d4d18b9dbe9e684b786
-  React-NativeModulesApple: 58d04a4f7ce680c74954c040e993cd213dde2e97
+  React-defaultsnativemodule: a828ccc6b364d0f5c6225532e673ccbd5e7b55f5
+  React-domnativemodule: 1fac8ff98968aeec245c951cfe753f3b94cf0438
+  React-Fabric: 165e09bb7892c5bda641376b5becd8d46b99a28c
+  React-FabricComponents: 50ad20fc7a40e96065fd85ef70fbee10840bc1a4
+  React-FabricImage: f40a6242a3574841fd15eb31c26eab9ad871b245
+  React-featureflags: ddbb67dd529d6f2e1dcf2b0e6b3674325b59017a
+  React-featureflagsnativemodule: ae8e8a455cd0ce133bb80485f92185d66cbf6b0d
+  React-graphics: 87a08f7091f1a9a9e433479b032b44bb4553b137
+  React-hermes: 4cf21c8d42d4e863a232e40ce44183ca11155fcd
+  React-idlecallbacksnativemodule: 2834a9b695e4042d98e25be7cd17a57f65fc00ae
+  React-ImageManager: a53795fd7777dd3cfcae82639d8f5182dbfd87bf
+  React-jserrorhandler: d4a5804a0d89d088f01216e8b90c34924aba55e8
+  React-jsi: a0341ae5aaeb58a9a2ea9445c5304511c8eece30
+  React-jsiexecutor: d841c9ab3f9a2822f4ef808ec2cf60b7ec98d75b
+  React-jsinspector: 2f735c734560d21c654051cf76e51b250a238531
+  React-jsinspectorcdp: 3cb7bad3b56d61523e41545ae6df3d4a1d94b2c7
+  React-jsinspectornetwork: 0225ba893f405ff9cd73e12f7eb71a63b2be61d4
+  React-jsinspectortracing: 4074221cc000049f50feff8b7dce35c52f966c82
+  React-jsitooling: e19ee6ebf93d50d084da55116675295ecc18b317
+  React-jsitracing: 91942116d362100dc82e914456d202ab2825debc
+  React-logger: da2c4bfeac2bb1dc7103842003d1e19496bcbf28
+  React-Mapbuffer: 40e1202a7e2e6e26dc3411fcac91bdf3d662b30c
+  React-microtasksnativemodule: 3cbd54d5944242e67dca0e6ea28ea8b9e155a02c
+  React-NativeModulesApple: 4d21d64a38ddf0c16465440119bfc0dc271b5de2
   React-oscompat: f1bc0c22f3ae3245131c25f9fa4186df1104fe84
-  React-perflogger: 06c4e27a279f786dccb886bfe095258bcec19f85
-  React-performancetimeline: f6203ca95e2d33d87f74291b2613253095f4ae67
+  React-perflogger: e0891de842193f9393a1d88f97c954595d4c44c0
+  React-performancetimeline: cb0cb8f563d8f4e98cb154e8a4b91a81e8b9b247
   React-RCTActionSheet: 076e981fa6b597138cf9c56a86008d9281fb936d
-  React-RCTAnimation: d25f0099f10d6c56819202602834a9280b8f6b51
-  React-RCTAppDelegate: 8fdd6448f294816ca048a0c379089d37bb9d1d81
-  React-RCTBlob: 092cfa4e29385cecf3edac14ca4f3038f39d4a0c
-  React-RCTFabric: e9f4a2c5482d2be25abadc11cc7d61898bd23da4
-  React-RCTFBReactNativeSpec: 5ab3ff7639d7b345760c0925ed820c3394327e41
-  React-RCTImage: a4d2d2ddc5106c2a4632ed65f1e799800fc21605
-  React-RCTLinking: ed8726a5b151325042ab5219d07fe72516cf0d2a
-  React-RCTNetwork: 315a03c3a815e8b927b33e8737b6a106e97c892b
-  React-RCTRuntime: 07ff55cd3521adc73d5a5b84e8de22511fa3cd3b
-  React-RCTSettings: da265186140f04d1611e2f95efb696fd6c3a25e8
-  React-RCTText: 2f5d5f5361442776187fc5fbdf26e45ba3dfe630
-  React-RCTVibration: 2b6a5a52c9655c7c168f2f09ee436885ffaaeb35
+  React-RCTAnimation: c17abbb1bdfd450e34727eac650e6cc977027ea5
+  React-RCTAppDelegate: 315d05c68253eabce33a1511852bf5b7568ff4ae
+  React-RCTBlob: 23b0e4e8ff7180d2c3bb646260ae8ec7de8a58dd
+  React-RCTFabric: ee4f7b7fae2ab85e2383eeec526412969a203b20
+  React-RCTFBReactNativeSpec: 655725a7e242df0100848c162efe67dc92fa20fd
+  React-RCTImage: ef64f53e112ccb1537e26f48037ebcc8bc8b442f
+  React-RCTLinking: 0731051f482d5b00baadce4402c1c9ef0c9e8f32
+  React-RCTNetwork: 75eed6de0971c11a1a4c575c4cf8bf2c833d0a6b
+  React-RCTRuntime: 6945d25e23a1a06d123ad90f141044cb8d580f21
+  React-RCTSettings: 56be8807cd01f423063151a4c966aec865df2d1f
+  React-RCTText: c14124e077dd6d20b915b16e65fdf3ac17b8b697
+  React-RCTVibration: 59dc35c844b175dceb91a806567f264a11c08cbc
   React-rendererconsistency: e359ac59230336b24932d572d04c8769939cf84a
-  React-renderercss: f3dd8216e513c5924d99d054043fd250e75ea2c4
-  React-rendererdebug: cc2b17d84a5117a3ba1e6dc226e66ddbc6a493e2
-  React-RuntimeApple: d15a53889286a9c65b1b715a871688e893d44d15
-  React-RuntimeCore: 73aceb2d7f1e806dd0c210c8da5d0960c0f70018
-  React-runtimeexecutor: f31078bca73b9ef9cbd390cea48e14c654d5b371
-  React-RuntimeHermes: a2737ab7dc4597f8f1aed06c5ce5663a462c433e
-  React-runtimescheduler: 67effbc850dde580da517f099da21815ec9fff09
-  React-timing: 12a74d8aedb368d5cc4edc5e5a3182c53b7399b7
-  React-utils: 0b13d6374f37bf4ee67e94256056f478a6dc2425
-  ReactAppDependencyProvider: 47d16ef8e69fcd212cc47939c59c4fbed78ea45d
-  ReactCodegen: 28664236493f3cb37d877a76abece32bf5cf9da4
-  ReactCommon: 7f3b3d118cf8a8aac89d1e66439310d2abef32f5
-  ReactNativeEnrichedMarkdown: 42bf51b82f6c758ec26c6f8b1cc987f65b531358
+  React-renderercss: 61e25b59510412ae477c2e8193ee4fd9e1bce87b
+  React-rendererdebug: 4ab36c9d24464f608f4838815964cdbddb3547c0
+  React-RuntimeApple: 885f463222c3ed1b773575e338d9a03a596c5b1f
+  React-RuntimeCore: b0f91b9798cca365f475e1d16ade722597811f84
+  React-runtimeexecutor: 54ca02011257511ea5ccc108a9b82e3a0ffe6f5d
+  React-RuntimeHermes: 25a64b6bc08450119eae9deb21e1150181eee627
+  React-runtimescheduler: 42f8c6a600d4469d503daed2ada874350d4d89f5
+  React-timing: 917e7ed9b59607b7c766402964b8798cca3ae9df
+  React-utils: 76855ce2971935d8344af7d0d60c37c365ad7e60
+  ReactAppDependencyProvider: 81faffd1e23962bc11e006b2a8c975cc0cfce2f5
+  ReactCodegen: 7ab7a68e6cfbf489e5da68f272c9a8b4ee99c0b7
+  ReactCommon: 4702457a560d38a9b96a98a728100cae76820edc
+  ReactNativeEnrichedMarkdown: 5295a67096e1bf26edf9476cfedfa274703abe96
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 4e7825418aa0a50bdaa8dff6d3e5fa8a2994d308
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-enriched-markdown-monorepo",
+  "name": "enriched-markdown-monorepo",
   "version": "0.0.0",
   "private": true,
   "workspaces": [

--- a/packages/android-enriched-markdown/gradle/publish.gradle
+++ b/packages/android-enriched-markdown/gradle/publish.gradle
@@ -53,12 +53,12 @@ afterEvaluate {
         pom {
           name = mavenArtifactName
           description = mavenArtifactDescription
-          url = "https://github.com/software-mansion/react-native-enriched-markdown"
+          url = "https://github.com/software-mansion/enriched-markdown"
 
           licenses {
             license {
               name = "MIT License"
-              url = "https://github.com/software-mansion/react-native-enriched-markdown/blob/main/LICENSE"
+              url = "https://github.com/software-mansion/enriched-markdown/blob/main/LICENSE"
             }
           }
 
@@ -71,9 +71,9 @@ afterEvaluate {
           }
 
           scm {
-            connection = "scm:git:https://github.com/software-mansion/react-native-enriched-markdown.git"
-            developerConnection = "scm:git:https://github.com/software-mansion/react-native-enriched-markdown.git"
-            url = "https://github.com/software-mansion/react-native-enriched-markdown"
+            connection = "scm:git:https://github.com/software-mansion/enriched-markdown.git"
+            developerConnection = "scm:git:https://github.com/software-mansion/enriched-markdown.git"
+            url = "https://github.com/software-mansion/enriched-markdown"
           }
         }
       }

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
@@ -17,7 +17,7 @@ import kotlin.math.abs
  * Must never mutate the buffer's Selection spans — the platform Editor
  * manages them during long-press gestures, and removing or overwriting
  * them mid-gesture crashes on some OEM skins.
- * See: https://github.com/software-mansion/react-native-enriched-markdown/issues/580
+ * See: https://github.com/software-mansion/enriched-markdown/issues/580
  */
 class LinkLongPressMovementMethod : ArrowKeyMovementMethod() {
   private val handler = Handler(Looper.getMainLooper())

--- a/packages/core/EnrichedMarkdownCore.podspec
+++ b/packages/core/EnrichedMarkdownCore.podspec
@@ -8,10 +8,10 @@ Pod::Spec.new do |s|
   s.name         = "EnrichedMarkdownCore"
   s.version      = package["version"]
   s.summary      = package["description"]
-  s.homepage     = "https://github.com/software-mansion/react-native-enriched-markdown"
+  s.homepage     = "https://github.com/software-mansion/enriched-markdown"
   s.license      = { :type => "MIT" }
   s.authors      = "Software Mansion"
-  s.source       = { :git => "https://github.com/software-mansion/react-native-enriched-markdown.git" }
+  s.source       = { :git => "https://github.com/software-mansion/enriched-markdown.git" }
 
   s.platforms    = { :ios => min_ios_version_supported, :osx => "14.0" }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@enriched-markdown/core",
   "version": "0.0.0",
   "private": true,
-  "description": "Shared C++ core (md4c parser, AST) for react-native-enriched-markdown and future native ports",
+  "description": "Shared C++ core (md4c parser, AST) for enriched-markdown native and React Native libraries",
   "files": [
     "cpp",
     "EnrichedMarkdownCore.podspec",

--- a/packages/ios-enriched-markdown/README.md
+++ b/packages/ios-enriched-markdown/README.md
@@ -13,7 +13,7 @@ Add the package via [Swift Package Manager](https://www.swift.org/documentation/
 ```swift
 dependencies: [
   .package(
-    url: "https://github.com/software-mansion/react-native-enriched-markdown.git",
+    url: "https://github.com/software-mansion/enriched-markdown.git",
     branch: "main"
   ),
 ],

--- a/packages/ios-enriched-markdown/package.json
+++ b/packages/ios-enriched-markdown/package.json
@@ -2,7 +2,7 @@
   "name": "@enriched-markdown/ios",
   "version": "0.0.0",
   "private": true,
-  "description": "Standalone iOS native library for enriched-markdown",
+  "description": "iOS native code for enriched-markdown",
   "scripts": {
     "build": "cd ../.. && swift build",
     "test": "cd ../.. && swift test",

--- a/packages/react-native-enriched-markdown/README.md
+++ b/packages/react-native-enriched-markdown/README.md
@@ -1,0 +1,231 @@
+<img src="https://github.com/user-attachments/assets/83cb462c-17df-4809-8b8a-fa4abb258cb3" alt="react-native-enriched-markdown by Software Mansion" width="100%">
+<a href="https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-enriched-1&n=1"><img src="https://swm-delivery.com/www/images/zone-gh-react-native-enriched-1?n=1" /></a>
+<a href="https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-enriched-2&n=1"><img src="https://swm-delivery.com/www/images/zone-gh-react-native-enriched-2?n=1" /></a>
+<a href="https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-enriched-3&n=1"><img src="https://swm-delivery.com/www/images/zone-gh-react-native-enriched-3?n=1" /></a>
+
+# react-native-enriched-markdown
+
+`react-native-enriched-markdown` is a powerful React Native library that renders Markdown content as native text and provides a rich text input with Markdown output. It supports iOS, Android, macOS, and Web, and requires the New Architecture (Fabric) for native platforms.
+
+### EnrichedMarkdownText
+
+- ⚡ Fully native text rendering (no WebView)
+- 🌐 Web support via [react-native-web](https://necolas.github.io/react-native-web/) + [md4c](https://github.com/mity/md4c) compiled to WebAssembly
+- 🎯 High-performance Markdown parsing with [md4c](https://github.com/mity/md4c)
+- 📐 CommonMark standard compliant
+- 📊 GitHub Flavored Markdown (GFM)
+- 🧮 LaTeX math rendering (block `$$...$$` with `flavor="github"`, inline `$...$` in all flavors)
+- 🔀 [Markdown Streaming](../../docs/MARKDOWN_STREAMING.md) support (via [react-native-streamdown](https://github.com/software-mansion-labs/react-native-streamdown))
+- 🎨 Fully customizable styles for all elements
+- ✨ Text selection and copy support
+- 📌 Custom text selection context menu items
+- 🔗 Interactive link handling with [per-URL-pattern styling](../../docs/MENTIONS.md#link-variants-styling) (`linkVariants`)
+- 👤 Renders mentions as styled links (compatible with `EnrichedMarkdownTextInput` mention output)
+- 🙈 Spoiler text with animated particle overlay and tap-to-reveal
+- 🖼️ Native image interactions (iOS: Copy, Save to Camera Roll)
+- 🌐 Native platform features (Translate, Look Up, Search Web, Share)
+- 🗣️ Accessibility support (VoiceOver on iOS, TalkBack on Android, semantic HTML on web)
+- 🔄 Full RTL (right-to-left) support including text, lists, blockquotes, tables, and task lists
+
+### EnrichedMarkdownTextInput
+
+- ✏️ Rich text input with Markdown output
+- 🕹️ Imperative API for toggling styles and managing links
+- 📋 Native context menu with formatting submenu
+- 🔍 Real-time style state detection
+- 🔗 Auto-link detection with customizable regex
+- 🔄 Smart copy/paste with Markdown preservation
+- 🎨 Customizable bold, italic, and link colors
+- 👤 [Mentions](../../docs/MENTIONS.md) with configurable indicators, suggestion lifecycle events, and per-pattern link styling
+
+Since 2012 [Software Mansion](https://swmansion.com) is a software agency with experience in building web and mobile apps. We are Core React Native Contributors and experts in dealing with all kinds of React Native issues.
+We can help you build your next dream product –
+[Hire us](https://swmansion.com/contact/projects?utm_source=react-native-enriched-markdown&utm_medium=readme).
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Native assets (install-time download)](../../docs/NATIVE_ASSETS.md)
+- [EnrichedMarkdownText](#enrichedmarkdowntext-1)
+  - [Usage](../../docs/TEXT.md#usage)
+  - [Supported Markdown Elements](../../docs/TEXT.md#supported-markdown-elements)
+  - [Copy Options](../../docs/TEXT.md#copy-options)
+  - [Accessibility](../../docs/TEXT.md#accessibility)
+  - [RTL Support](../../docs/TEXT.md#rtl-support)
+  - [Customizing Styles](../../docs/TEXT.md#customizing-styles)
+  - [LaTeX Math](../../docs/LATEX_MATH.md)
+  - [Image Caching](../../docs/IMAGE_CACHING.md)
+  - [Markdown Streaming](../../docs/MARKDOWN_STREAMING.md)
+- [EnrichedMarkdownTextInput](#enrichedmarkdowntextinput-1)
+  - [Usage](../../docs/INPUT.md#usage)
+  - [Inline Styles](../../docs/INPUT.md#inline-styles)
+  - [Links](../../docs/INPUT.md#links)
+  - [Auto-Link Detection](../../docs/INPUT.md#auto-link-detection)
+  - [Mentions](../../docs/MENTIONS.md)
+  - [Style Detection](../../docs/INPUT.md#style-detection)
+  - [Other Events](../../docs/INPUT.md#other-events)
+  - [Customizing Styles](../../docs/INPUT.md#customizing-enrichedmarkdowntextinput--styles)
+- [API Reference](#api-reference)
+- [Testing with Jest](../../docs/TESTING.md)
+- [Web Support](../../docs/WEB.md)
+- [macOS Support](../../docs/MACOS.md)
+- [Compatibility Table](#compatibility-table)
+- [Contributing](#contributing)
+- [Future Plans](#future-plans)
+- [License](#license)
+
+## Prerequisites
+
+**Native (iOS / Android / macOS)**
+
+- Requires [the React Native New Architecture (Fabric)](https://reactnative.dev/architecture/landing-page)
+- See [Compatibility Table](#compatibility-table) for supported React Native versions
+- macOS support via [react-native-macos](https://github.com/microsoft/react-native-macos) `0.81+`
+
+**Web**
+
+- Requires [`react-native-web`](https://necolas.github.io/react-native-web/) and Metro (or another bundler with `.web.tsx` platform resolution)
+- No New Architecture requirement — the web renderer runs entirely in JavaScript via WebAssembly
+- Only `EnrichedMarkdownText` is supported on web (`EnrichedMarkdownTextInput` is native-only)
+- LaTeX math requires the optional [`katex`](https://katex.org/) peer dependency
+
+## Installation
+
+### Web
+
+No steps beyond having `react-native-web` configured. For LaTeX math, install the optional peer dependency:
+
+```sh
+npm install katex
+# or
+yarn add katex
+```
+
+See [Web Support](../../docs/WEB.md) for full setup details, supported features, and prop behaviour.
+
+### Bare React Native app (iOS / Android)
+
+#### 1. Install the library
+
+```sh
+yarn add react-native-enriched-markdown
+```
+
+> [!TIP]
+> To try the latest features before they land in a stable release, install the nightly build:
+>
+> ```sh
+> yarn add react-native-enriched-markdown@nightly
+> ```
+>
+> Nightly versions are published to npm automatically and may contain breaking changes.
+
+> [!NOTE]
+> On install, a `postinstall` script downloads the large native assets used by code highlighting
+> and iOS LaTeX math (kept out of the npm tarball to keep it ~1 MB). This needs network access to
+> `registry.npmjs.org` and `github.com`. If you install offline, with `--ignore-scripts`, or with
+> **pnpm** (which blocks dependency scripts by default), see
+> [Native assets](../../docs/NATIVE_ASSETS.md) for how to restore them. If you don't use a feature, skip
+> its download with an `"enriched-markdown": { "enableCodeHighlight": false, "enableMath": false }`
+> block in your app's `package.json` — see [Skipping the download](../../docs/NATIVE_ASSETS.md#skipping-the-download-opt-out).
+
+#### 2. Install iOS / macOS dependencies
+
+The library includes native code so you will need to re-build the native app.
+
+```sh
+# iOS
+cd ios && bundle install && bundle exec pod install
+
+# macOS (react-native-macos)
+cd macos && bundle install && bundle exec pod install
+```
+
+### Expo app
+
+#### 1. Install the library
+
+```sh
+npx expo install react-native-enriched-markdown
+```
+
+#### 2. Run prebuild
+
+The library includes native code so you will need to re-build the native app.
+
+```sh
+npx expo prebuild
+```
+
+> [!NOTE]
+> The library won't work in Expo Go as it needs native changes.
+
+> [!NOTE]
+> `npx expo install` runs the same `postinstall` asset download described under
+> [Native assets](../../docs/NATIVE_ASSETS.md); it needs network access and does not work with Yarn PnP.
+
+> [!IMPORTANT]
+> **iOS: Save to Camera Roll**
+>
+> If your Markdown content includes images and you want users to save them to their photo library, add the following to your `Info.plist`:
+>
+> ```xml
+> <key>NSPhotoLibraryAddUsageDescription</key>
+> <string>This app needs access to your photo library to save images.</string>
+> ```
+
+## EnrichedMarkdownText
+
+See [EnrichedMarkdownText](../../docs/TEXT.md) for detailed documentation on usage examples, GFM tables, task lists, link handling, supported elements, copy options, accessibility, RTL support, and customizing styles. Mentions created by `EnrichedMarkdownTextInput` render as styled links — use [`linkVariants`](../../docs/MENTIONS.md#link-variants-styling) to customize their appearance.
+
+## EnrichedMarkdownTextInput
+
+See [EnrichedMarkdownTextInput](../../docs/INPUT.md) for detailed documentation on usage examples, inline styles, links, style detection, events, and customizing styles.
+
+## API Reference
+
+See the [API Reference](../../docs/API_REFERENCE.md) for a detailed overview of all the props, methods, and events available.
+
+## Web Support
+
+See [Web Support](../../docs/WEB.md) for details on supported features, web-specific prop behaviour, and known limitations.
+
+## macOS Support
+
+`react-native-enriched-markdown` supports macOS via [react-native-macos](https://github.com/microsoft/react-native-macos). See [macOS Support](../../docs/MACOS.md) for details on macOS-specific features, known limitations, and the example app.
+
+## Future Plans
+
+We're actively working on expanding the capabilities of `react-native-enriched-markdown`. Here's what's on the roadmap:
+
+- `EnrichedMarkdownTextInput`: headings, lists, blockquotes, code blocks, inline images
+- `EnrichedMarkdownTextInput` web support
+- macOS: block math rendering, VoiceOver accessibility, tail fade-in animation
+- Web: spoiler text, streaming animation, configurable link `target`, copy options (Copy as Markdown, multi-format clipboard)
+
+## Compatibility Table
+
+|             | 0.82 | 0.83 | 0.84 | 0.85 | 0.86 | 0.87 |
+| ----------- | :--: | :--: | :--: | :--: | :--: | :--: |
+| **nightly** |  ⛔  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
+| **1.0.0**   |  ⛔  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
+| **0.7.0**   |  ⛔  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
+| **0.6.0**   |  ⛔  |  ✅  |  ✅  |  ✅  |  ⛔  |  ⛔  |
+| **0.5.0**   |  ⛔  |  ✅  |  ✅  |  ✅  |  ⛔  |  ⛔  |
+| **0.4.x**   |  ✅  |  ✅  |  ✅  |  ⛔  |  ⛔  |  ⛔  |
+| **0.3.0**   |  ✅  |  ✅  |  ✅  |  ⛔  |  ⛔  |  ⛔  |
+
+## Contributing
+
+See the [contributing guide](../../CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.
+
+## License
+
+`react-native-enriched-markdown` library is licensed under [The MIT License](../../LICENSE).
+
+---
+
+Built by [Software Mansion](https://swmansion.com/).
+
+[<img width="128" height="69" alt="Software Mansion Logo" src="https://github.com/user-attachments/assets/f0e18471-a7aa-4e80-86ac-87686a86fe56" />](https://swmansion.com/)

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported, :osx => '14.0' }
-  s.source       = { :git => "https://github.com/software-mansion/react-native-enriched-markdown.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/software-mansion/enriched-markdown.git", :tag => "#{s.version}" }
 
   if monorepo
     s.private_header_files = "ios/**/*.h"

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/text/view/LinkLongPressMovementMethod.kt
@@ -19,7 +19,7 @@ import kotlin.math.abs
  * Must never mutate the buffer's Selection spans — the platform Editor
  * manages them during long-press gestures, and removing or overwriting
  * them mid-gesture crashes on some OEM skins.
- * See: https://github.com/software-mansion/react-native-enriched-markdown/issues/580
+ * See: https://github.com/software-mansion/enriched-markdown/issues/580
  */
 class LinkLongPressMovementMethod : ArrowKeyMovementMethod() {
   private val handler = Handler(Looper.getMainLooper())

--- a/packages/react-native-enriched-markdown/package.json
+++ b/packages/react-native-enriched-markdown/package.json
@@ -67,13 +67,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/software-mansion/react-native-enriched-markdown.git",
+    "url": "git+https://github.com/software-mansion/enriched-markdown.git",
     "directory": "packages/react-native-enriched-markdown"
   },
   "author": "Gregory Moskaliuk <mosckalyuck@gmail.com> (https://github.com/hryhoriiK97)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/software-mansion/react-native-enriched-markdown/issues"
+    "url": "https://github.com/software-mansion/enriched-markdown/issues"
   },
   "homepage": "https://enriched.swmansion.com/markdown",
   "publishConfig": {

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -3,7 +3,7 @@
 // Usage: ./scripts/generate-changelog.mjs <from-tag> [to-ref] | pbcopy
 import { execFileSync } from 'node:child_process';
 
-const REPO = 'software-mansion/react-native-enriched-markdown';
+const REPO = 'software-mansion/enriched-markdown';
 const [OWNER, NAME] = REPO.split('/');
 
 const SECTIONS = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -10304,6 +10304,71 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"enriched-markdown-monorepo@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "enriched-markdown-monorepo@workspace:."
+  dependencies:
+    "@commitlint/config-conventional": "npm:^20.5.0"
+    "@eslint/compat": "npm:^2.0.3"
+    "@eslint/eslintrc": "npm:^3.3.5"
+    "@eslint/js": "npm:^10.0.1"
+    "@react-native-community/cli": "npm:20.1.0"
+    "@react-native/babel-preset": "npm:0.85.0"
+    "@react-native/eslint-config": "npm:0.85.0"
+    "@release-it/conventional-changelog": "npm:^10.0.6"
+    commitlint: "npm:^20.5.0"
+    eslint: "npm:^9.39.4"
+    eslint-config-prettier: "npm:^10.1.8"
+    eslint-plugin-ft-flow: "npm:^3.0.11"
+    eslint-plugin-prettier: "npm:^5.5.5"
+    lefthook: "npm:^2.1.4"
+    prettier: "npm:^3.8.1"
+    react-native-builder-bob: "npm:^0.41.0"
+    release-it: "npm:^19.2.4"
+    turbo: "npm:^2.8.21"
+    typescript: "npm:^6.0.2"
+  dependenciesMeta:
+    "@tree-sitter-grammars/tree-sitter-markdown":
+      built: false
+    "@tree-sitter-grammars/tree-sitter-yaml":
+      built: false
+    tree-sitter-bash:
+      built: false
+    tree-sitter-c:
+      built: false
+    tree-sitter-c-sharp:
+      built: false
+    tree-sitter-cli:
+      built: false
+    tree-sitter-cpp:
+      built: false
+    tree-sitter-css:
+      built: false
+    tree-sitter-go:
+      built: false
+    tree-sitter-html:
+      built: false
+    tree-sitter-java:
+      built: false
+    tree-sitter-javascript:
+      built: false
+    tree-sitter-json:
+      built: false
+    tree-sitter-php:
+      built: false
+    tree-sitter-python:
+      built: false
+    tree-sitter-ruby:
+      built: false
+    tree-sitter-rust:
+      built: false
+    tree-sitter-swift:
+      built: false
+    tree-sitter-typescript:
+      built: false
+  languageName: unknown
+  linkType: soft
+
 "entities@npm:^4.2.0, entities@npm:^4.4.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
@@ -16715,71 +16780,6 @@ __metadata:
     react-native-builder-bob: "npm:^0.41.0"
     react-native-enriched-markdown: "npm:*"
     react-native-macos: "npm:0.81.4"
-  languageName: unknown
-  linkType: soft
-
-"react-native-enriched-markdown-monorepo@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "react-native-enriched-markdown-monorepo@workspace:."
-  dependencies:
-    "@commitlint/config-conventional": "npm:^20.5.0"
-    "@eslint/compat": "npm:^2.0.3"
-    "@eslint/eslintrc": "npm:^3.3.5"
-    "@eslint/js": "npm:^10.0.1"
-    "@react-native-community/cli": "npm:20.1.0"
-    "@react-native/babel-preset": "npm:0.85.0"
-    "@react-native/eslint-config": "npm:0.85.0"
-    "@release-it/conventional-changelog": "npm:^10.0.6"
-    commitlint: "npm:^20.5.0"
-    eslint: "npm:^9.39.4"
-    eslint-config-prettier: "npm:^10.1.8"
-    eslint-plugin-ft-flow: "npm:^3.0.11"
-    eslint-plugin-prettier: "npm:^5.5.5"
-    lefthook: "npm:^2.1.4"
-    prettier: "npm:^3.8.1"
-    react-native-builder-bob: "npm:^0.41.0"
-    release-it: "npm:^19.2.4"
-    turbo: "npm:^2.8.21"
-    typescript: "npm:^6.0.2"
-  dependenciesMeta:
-    "@tree-sitter-grammars/tree-sitter-markdown":
-      built: false
-    "@tree-sitter-grammars/tree-sitter-yaml":
-      built: false
-    tree-sitter-bash:
-      built: false
-    tree-sitter-c:
-      built: false
-    tree-sitter-c-sharp:
-      built: false
-    tree-sitter-cli:
-      built: false
-    tree-sitter-cpp:
-      built: false
-    tree-sitter-css:
-      built: false
-    tree-sitter-go:
-      built: false
-    tree-sitter-html:
-      built: false
-    tree-sitter-java:
-      built: false
-    tree-sitter-javascript:
-      built: false
-    tree-sitter-json:
-      built: false
-    tree-sitter-php:
-      built: false
-    tree-sitter-python:
-      built: false
-    tree-sitter-ruby:
-      built: false
-    tree-sitter-rust:
-      built: false
-    tree-sitter-swift:
-      built: false
-    tree-sitter-typescript:
-      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What/Why?

Rename the GitHub repo from `react-native-enriched-markdown` to `enriched-markdown` to reflect the multi-platform scope of the monorepo (React Native, Android, iOS).

This PR updates all internal references to the new repo name:
- GitHub URLs across workflows, podspecs, POM metadata, issue templates, and code comments
- `github.repository` guards in publish workflows (npm + Maven)
- Root workspace name (`enriched-markdown-monorepo`)
- Package descriptions in `core` and `ios-enriched-markdown`
- Moves the React Native README to `packages/react-native-enriched-markdown/` and replaces the root with a hub-style monorepo overview

The npm package name (`react-native-enriched-markdown`) and directory paths are unchanged — no breaking changes for consumers.

### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

