### PR TITLE
fix: stop overwriting package README during npm publish

### DIFF
--- a/scripts/prepare-npm-publish.sh
+++ b/scripts/prepare-npm-publish.sh
@@ -52,7 +52,6 @@ case "$mode" in
     cp "$REPO_ROOT/vendor/vendor-grammars.mjs" vendor-grammars.mjs
     cp "$REPO_ROOT/vendor/vendor-ratex.mjs" vendor-ratex.mjs
 
-    cp "$REPO_ROOT/README.md" README.md
     cp "$REPO_ROOT/LICENSE" LICENSE
     cp -R "$REPO_ROOT/docs" docs
     ;;
@@ -61,7 +60,7 @@ case "$mode" in
     rm -rf cpp
     ln -s ../core/cpp cpp
 
-    rm -f README.md LICENSE ratex-version.json vendor-grammars.mjs vendor-ratex.mjs
+    rm -f LICENSE ratex-version.json vendor-grammars.mjs vendor-ratex.mjs
     rm -rf docs
     ;;
   *)


### PR DESCRIPTION
### What/Why?
The prepack script was copying the root README into the package directory, which would overwrite the package's own README with the hub-style monorepo overview. Now that the React Native package has its own permanent README, remove the copy in prepack and the cleanup in postpack.

### Testing
<!-- How to test changed code? What testing has been done? -->

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

