### PR TITLE
chore: add appearance support for root README hero image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-<img src="https://github.com/user-attachments/assets/83cb462c-17df-4809-8b8a-fa4abb258cb3" alt="Enriched Markdown by Software Mansion" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/38c4b0b7-4e2c-453a-bdd5-38d37dd6da46">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/b4ac86b1-ad98-4faa-9349-9f69510c6152">
+  <img alt="Enriched Markdown by Software Mansion" src="https://github.com/user-attachments/assets/38c4b0b7-4e2c-453a-bdd5-38d37dd6da46">
+</picture>
 
 A multi-platform SDK for rendering Markdown as native text and editing rich text with Markdown output. Ships as a React Native library with iOS, Android, macOS, and Web support, plus standalone native SDKs for iOS (Swift) and Android (Kotlin).
 


### PR DESCRIPTION
### What/Why?

Use the HTML `<picture>` element with `prefers-color-scheme` media queries to serve theme-appropriate hero images on GitHub. Dark mode users see the dark variant, light mode users see the light variant, and npm/other renderers fall back to the dark image.


Made with [Cursor](https://cursor.com)