### PR TITLE
fix: key code-highlight registry per app for monorepo safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,9 +101,10 @@ web-build/
 packages/core/cpp/highlight/vendor/tree-sitter/
 packages/core/cpp/highlight/vendor/grammars/
 packages/core/cpp/highlight/vendor/generated/
-# Registry for a custom ENRICHED_MARKDOWN_CODE_HIGHLIGHT_LANGUAGES set (iOS); kept
-# out of the committed generated/ dir so a custom build never clobbers the default.
-packages/core/cpp/highlight/vendor/generated-custom/
+# Per-app registry for a custom code-highlight language set (iOS, generated-<app-slug>);
+# kept out of the committed generated/ dir so a custom build never clobbers the default,
+# and keyed per app so monorepo apps with different sets never clobber each other.
+packages/core/cpp/highlight/vendor/generated-*/
 
 # RaTeX (iOS LaTeX math): the prebuilt static XCFramework, RaTeX's four core Swift
 # sources, and the KaTeX fonts are restored from the pins in vendor/ratex-version.json

--- a/packages/core/cpp/highlight/code_highlight_podspec.rb
+++ b/packages/core/cpp/highlight/code_highlight_podspec.rb
@@ -33,20 +33,37 @@ module EnrichedMarkdownConfig
   # root. Per-app config therefore works; the download side (postinstall) is a
   # separate, install-time decision. ENV vars remain a deprecated fallback.
   #
-  # Memoized: both this file (code highlighting) and the main podspec (math) read it.
+  # A cheap accessor over the memoized package.json (see consumer_package_json), so both
+  # this file (code highlighting) and the main podspec (math) can read it without re-parsing.
   def self.consumer_config
-    return @consumer_config if defined?(@consumer_config)
-    @consumer_config = load_consumer_config
+    config = consumer_package_json['enriched-markdown']
+    config.is_a?(Hash) ? config : {}
   end
 
-  def self.load_consumer_config
+  # A filesystem-safe identifier for the app being built, derived from its package.json
+  # "name" (falling back to the app directory name). It keys the per-app generated
+  # code-highlight registry (generated-<slug>) so that, in a hoisted monorepo, two apps
+  # with different custom language sets each get their own registry instead of clobbering
+  # a single shared one.
+  def self.consumer_app_slug
+    name = consumer_package_json['name'].to_s
+    name = File.basename(File.dirname(Pod::Config.instance.installation_root.to_s)) if name.empty?
+    slug = name.gsub(%r{[^A-Za-z0-9._-]+}, '-').gsub(/\A-+|-+\z/, '')
+    slug.empty? ? 'app' : slug
+  end
+
+  def self.consumer_package_json
+    return @consumer_package_json if defined?(@consumer_package_json)
+    @consumer_package_json = load_consumer_package_json
+  end
+
+  def self.load_consumer_package_json
     path = File.join(Pod::Config.instance.installation_root.to_s, '..', 'package.json')
     return {} unless File.exist?(path)
-    config = JSON.parse(File.read(path))['enriched-markdown']
-    config.is_a?(Hash) ? config : {}
+    JSON.parse(File.read(path))
   rescue StandardError => e
-    Pod::UI.warn "[ReactNativeEnrichedMarkdown] could not read \"enriched-markdown\" config " \
-      "from the app package.json (#{e.message}); using defaults."
+    Pod::UI.warn "[ReactNativeEnrichedMarkdown] could not read the app package.json " \
+      "(#{e.message}); using defaults."
     {}
   end
 end
@@ -132,13 +149,13 @@ module EnrichedMarkdownCodeHighlight
     return disabled if langs.empty?
 
     vendor = File.join(podspec_dir, 'cpp/highlight/vendor')
-    # A custom language set regenerates its registry into a SEPARATE dir so it never
-    # clobbers the committed default-set registry in vendor/generated. That committed
-    # dir is the shared source of truth other default builds -- and the Android build
-    # -- rely on staying the default set; overwriting it in place with a custom set
-    # leaves the next default build linking a mismatched grammar list.
+    # A custom language set regenerates its registry into a per-app dir
+    # (generated-<app-slug>), never the committed default-set registry in vendor/generated.
+    # Keying by app (not by "generated-custom") means two apps in a hoisted monorepo with
+    # different custom sets each get their own registry instead of clobbering a single
+    # shared one -- which would leave the other app linking a mismatched grammar list.
     custom = langs.sort != defaults.sort
-    generated_rel = custom ? 'cpp/highlight/vendor/generated-custom' : 'cpp/highlight/vendor/generated'
+    generated_rel = custom ? "cpp/highlight/vendor/generated-#{EnrichedMarkdownConfig.consumer_app_slug}" : 'cpp/highlight/vendor/generated'
     generated = File.join(podspec_dir, generated_rel)
     ensure_registry(podspec_dir, vendor, generated, langs, custom)
 

--- a/packages/react-native-enriched-markdown/android/build.gradle
+++ b/packages/react-native-enriched-markdown/android/build.gradle
@@ -30,13 +30,26 @@ def getExtOrIntegerDefault(name) {
 // Per-app config therefore works; the download side (postinstall) is a separate,
 // install-time decision. Gradle properties remain a deprecated fallback.
 def consumerConfig = [:]
+def consumerAppName = null
 def consumerPackageJson = new File(rootProject.projectDir, "../package.json")
 if (consumerPackageJson.exists()) {
     def parsed = new groovy.json.JsonSlurper().parse(consumerPackageJson)
-    if (parsed instanceof Map && parsed["enriched-markdown"] instanceof Map) {
-        consumerConfig = parsed["enriched-markdown"]
+    if (parsed instanceof Map) {
+        if (parsed["enriched-markdown"] instanceof Map) {
+            consumerConfig = parsed["enriched-markdown"]
+        }
+        consumerAppName = parsed["name"]
     }
 }
+
+// Filesystem-safe per-app slug: package.json "name", else the app directory name -- the
+// same source and fallback the iOS podspec uses (installation root's parent), so both
+// platforms derive an identical slug for the same app. It keys the per-app generated
+// code-highlight registry (generated-<slug>) below so the artifact layout matches iOS and
+// two monorepo apps with different custom language sets never share one dir.
+def consumerAppSlug = (consumerAppName ?: rootProject.projectDir.parentFile?.name ?: "app").toString()
+    .replaceAll('[^A-Za-z0-9._-]+', '-').replaceAll('^-+|-+$', '')
+if (!consumerAppSlug) consumerAppSlug = "app"
 
 // Math: package.json > gradle property (deprecated) > default true. Android math is a
 // Maven dependency (no downloaded asset), so the flag simply includes or excludes it --
@@ -195,8 +208,12 @@ if (codeHighlightActive) {
     // Common case: the committed default-set registry ships in-tree, no codegen.
     generatedDir = committedGenerated
   } else {
-    // Custom language set: regenerate the registry from the vendored .scm files.
-    generatedDir = new File(highlightConfigDir, "generated")
+    // Custom language set: regenerate the registry from the vendored .scm files into a
+    // per-app dir (generated-<slug>), mirroring iOS. Android rewrites this on every
+    // gradle configure so it never had iOS's persistent clash, but keying per app keeps
+    // the two platforms' artifact layout identical. (highlight-config.cmake itself stays
+    // at the CMakeLists-fixed shared path and is rewritten each configure.)
+    generatedDir = new File(highlightConfigDir, "generated-${consumerAppSlug}")
     generatedDir.mkdirs()
     def genScript = [
       new File(projectDir, "../../../vendor/gen-registry.mjs"),


### PR DESCRIPTION
### What/Why?
Stacked on #673, which made the app's `package.json` the source of truth for native config. This resolves the "known limitation" flagged there.

In a hoisted monorepo, two apps using **different custom `codeHighlightLanguages`** did set shared one generated tree-sitter registry (`generated-custom`) in the hoisted `node_modules`. The later `pod install` overwrote it, so the other app compiled a registry referencing a grammar it doesn't build — an undefined `tree_sitter_<lang>` link error, until re-podded.

This keys the generated registry by app: a custom set now compiles into a per-app `generated-<app-slug>` dir (slug derived from the app's `package.json` `name`) instead of one shared `generated-custom`. The apps get independent registries that coexist. 

### Testing

Verified in a real npm-workspaces monorepo (hoisted `node_modules`; AppA = `["javascript"]`, AppB = `["javascript", "python"]`):

- Both registries coexist after podding each app: `generated-AppA` + `generated-AppB` (previously a single shared
`generated-custom`).
- Each app's pod is pinned to its own registry - AppA → `generated-AppA`, AppB → `generated-AppB`.
- Registry contents correct: AppA registers `javascript`, AppB registers `javascript` + `python`.
- The original clash is gone: after AppB pods, AppA's Pods project has **0** `python` references, so it no longer links a grammar it doesn't compile.
- Android (single-app harness): writes `generated-<app>`, and the generated `highlight-config.cmake` points `ENRICHED_MARKDOWN_HIGHLIGHT_GENERATED_DIR` at it.
