### PR TITLE
chore(ios): raise the native package minimum to iOS 16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "EnrichedMarkdown",
-    platforms: [.iOS(.v15), .macOS(.v14)],
+    platforms: [.iOS(.v16)],
     products: [
         .library(name: "EnrichedMarkdown", targets: ["EnrichedMarkdown"]),
     ],

--- a/packages/ios-enriched-markdown/README.md
+++ b/packages/ios-enriched-markdown/README.md
@@ -40,7 +40,7 @@ For local development, add a path dependency instead (as in [`apps/ios-example`]
 .package(path: "../react-native-enriched-markdown")
 ```
 
-Requirements: **iOS 15+**, SwiftUI.
+Requirements: **iOS 16+**, SwiftUI.
 
 ## Quick start
 
@@ -257,7 +257,7 @@ extension View {
 }
 ```
 
-Configures the custom items added to the text-selection edit menu (iOS 16+; earlier versions keep the stock menu):
+Configures the custom items added to the text-selection edit menu:
 
 - **Copy as Markdown** puts the selection on the clipboard as markdown. A selection covering the whole document returns the original source verbatim; partial selections are reconstructed from the rendered text.
 - **Copy Image URL** / **Copy N Image URLs** appears when the selection contains images with http(s) URLs.
@@ -308,7 +308,7 @@ All decodes are downsampled to the screen's pixel width, so large images never d
 
 ## Accessibility
 
-VoiceOver walks the rendered markdown as individual elements rather than one text blob (iOS 16+):
+VoiceOver walks the rendered markdown as individual elements rather than one text blob:
 
 - Headings announce "heading, level N"
 - Links are activatable elements that invoke `.onLinkPress`
@@ -316,18 +316,6 @@ VoiceOver walks the rendered markdown as individual elements rather than one tex
 - List items announce their position ("bullet point", "list item N", with a "nested" prefix)
 
 Dynamic Type is supported throughout via text styles in the default theme.
-
-## iOS version notes
-
-The package supports iOS 15+, but some features require iOS 16:
-
-| Feature | Minimum iOS |
-|---------|-------------|
-| Text rendering, themes, links, selection, images | 15 |
-| Copy with HTML flavor, `.onLinkLongPress`, `.markdownSelectable`, `.markdownSelectionColor`, `.markdownImageRequestHeaders` | 15 |
-| Block decorations (code-block backgrounds, blockquote bars, list markers) | 16 |
-| Custom selection-menu items (`.markdownSelectionMenu`) | 16 |
-| VoiceOver element tree | 16 |
 
 ## Supported Markdown
 

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElement.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElement.swift
@@ -3,7 +3,6 @@ import UIKit
 /// VoiceOver element for one segment of the rendered markdown. The frame is
 /// resolved lazily from TextKit 2 layout on every query, so scrolling and
 /// Dynamic Type changes never leave stale bounds.
-@available(iOS 16.0, *)
 class MarkdownAccessibilityElement: UIAccessibilityElement {
     private(set) weak var textView: MarkdownTextView?
     let range: NSRange
@@ -38,7 +37,6 @@ class MarkdownAccessibilityElement: UIAccessibilityElement {
     }
 }
 
-@available(iOS 16.0, *)
 final class MarkdownLinkAccessibilityElement: MarkdownAccessibilityElement {
     let url: URL
 

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Environment+SelectionMenu.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Environment+SelectionMenu.swift
@@ -30,8 +30,7 @@ public extension EnvironmentValues {
 
 public extension View {
     /// Configures the custom edit-menu items ("Copy as Markdown",
-    /// "Copy Image URL") shown when text is selected. Requires iOS 16;
-    /// earlier versions keep the stock menu.
+    /// "Copy Image URL") shown when text is selected.
     func markdownSelectionMenu(_ config: MarkdownSelectionMenuConfig) -> some View {
         environment(\.markdownSelectionMenu, config)
     }

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Layout/MarkdownViewportDecorator.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/Layout/MarkdownViewportDecorator.swift
@@ -5,7 +5,6 @@ enum MarkdownDecorationPass {
     case foreground
 }
 
-@available(iOS 16.0, *)
 final class MarkdownViewportDecorator {
     private weak var backgroundView: MarkdownDecorationView?
     private weak var foregroundView: MarkdownDecorationView?
@@ -108,7 +107,6 @@ final class MarkdownViewportDecorator {
     }
 }
 
-@available(iOS 16.0, *)
 final class MarkdownDecorationView: UIView {
     weak var textView: UITextView?
     var viewportDecorator: MarkdownViewportDecorator?

--- a/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/ios-enriched-markdown/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -38,7 +38,6 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
         uiView.delegate = nil
     }
 
-    @available(iOS 16.0, *)
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: MarkdownTextView, context: Context) -> CGSize? {
         let width = proposal.width ?? UIScreen.main.bounds.width
         let size = uiView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
@@ -70,7 +69,7 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
             return handleLinkPress(url)
         }
 
-        // iOS 15–16 (and 17+ fallback when the UITextItem methods are
+        // iOS 16 (and 17+ fallback when the UITextItem methods are
         // unavailable): tap arrives as .invokeDefaultAction, long-press as
         // .presentActions or .preview.
         func textView(
@@ -113,7 +112,6 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
             return handleLinkLongPress(url) ? nil : UITextItem.MenuConfiguration(menu: defaultMenu)
         }
 
-        @available(iOS 16.0, *)
         func textView(
             _ textView: UITextView,
             editMenuForTextIn range: NSRange,
@@ -145,7 +143,6 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
             return UIMenu(children: Self.splice(actions, into: suggestedActions))
         }
 
-        @available(iOS 16.0, *)
         static func makeAction(for spec: MenuItemSpec) -> UIAction {
             UIAction(
                 title: spec.title,
@@ -156,7 +153,6 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
             }
         }
 
-        @available(iOS 16.0, *)
         static func makeSelectAllAction(for textView: UITextView) -> UIAction {
             UIAction(
                 title: "Select All",
@@ -172,7 +168,6 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
             textView.selectedRange = NSRange(location: 0, length: textView.attributedText?.length ?? 0)
         }
 
-        @available(iOS 16.0, *)
         static func containsSelectAll(_ elements: [UIMenuElement]) -> Bool {
             elements.contains { element in
                 if let command = element as? UICommand, command.action == #selector(UIResponder.selectAll(_:)) {
@@ -190,7 +185,6 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
         /// which is the only way to grow a selection from the long-press menu
         /// of a non-editable text view). Falls back to prepending when the
         /// submenu is absent.
-        @available(iOS 16.0, *)
         static func splice(_ actions: [UIMenuElement], into suggestedActions: [UIMenuElement]) -> [UIMenuElement] {
             var result: [UIMenuElement] = []
             var foundStandardEdit = false
@@ -214,9 +208,7 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
 final class MarkdownTextView: UITextView {
     var styleConfig: MarkdownStyleConfig = .baseline() {
         didSet {
-            if #available(iOS 16.0, *) {
-                updateDecorationStyleConfig()
-            }
+            updateDecorationStyleConfig()
         }
     }
 
@@ -225,8 +217,7 @@ final class MarkdownTextView: UITextView {
     var onLinkPress: ((URL) -> Void)?
 
     /// VoiceOver elements built from the attributed string; frames resolve
-    /// lazily against TextKit 2 layout. Empty (default UITextView behavior)
-    /// below iOS 16, where the decoration/text-layout stack is unavailable.
+    /// lazily against TextKit 2 layout.
     private var markdownAccessibilityElements: [UIAccessibilityElement] = []
 
     override var accessibilityElements: [Any]? {
@@ -288,9 +279,7 @@ final class MarkdownTextView: UITextView {
         linkTextAttributes = [:]
         setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
-        if #available(iOS 16.0, *) {
-            setupDecoration()
-        }
+        setupDecoration()
     }
 
     /// Injectable so tests avoid UIPasteboard.general, which a headless test
@@ -330,13 +319,10 @@ final class MarkdownTextView: UITextView {
         guard !(self.attributedText?.isEqual(to: attributedText) ?? false) else { return }
         self.attributedText = attributedText
         invalidateIntrinsicContentSize()
-        if #available(iOS 16.0, *) {
-            setDecorationNeedsDisplay()
-            rebuildAccessibilityElements()
-        }
+        setDecorationNeedsDisplay()
+        rebuildAccessibilityElements()
     }
 
-    @available(iOS 16.0, *)
     private func rebuildAccessibilityElements() {
         let specs = MarkdownAccessibilityElementBuilder.specs(for: attributedText ?? NSAttributedString())
         markdownAccessibilityElements = specs.map { spec in
@@ -349,7 +335,6 @@ final class MarkdownTextView: UITextView {
 
     /// Screen-coordinate frame for a character range, unioned over its
     /// TextKit 2 layout fragments.
-    @available(iOS 16.0, *)
     func accessibilityScreenFrame(for range: NSRange) -> CGRect {
         guard let textLayoutManager,
               let contentManager = textLayoutManager.textContentManager,
@@ -372,14 +357,11 @@ final class MarkdownTextView: UITextView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        if #available(iOS 16.0, *) {
-            layoutDecorationView()
-            setDecorationNeedsDisplay()
-        }
+        layoutDecorationView()
+        setDecorationNeedsDisplay()
     }
 }
 
-@available(iOS 16.0, *)
 private extension MarkdownTextView {
     private static var backgroundDecorationViewKey: UInt8 = 0
     private static var foregroundDecorationViewKey: UInt8 = 0

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/AccessibilityElementBuilderTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/AccessibilityElementBuilderTests.swift
@@ -114,7 +114,6 @@ final class AccessibilityElementBuilderTests: XCTestCase {
     }
 }
 
-@available(iOS 16.0, *)
 final class MarkdownTextViewAccessibilityTests: XCTestCase {
     private var config: MarkdownStyleConfig!
 

--- a/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/SelectionMenuItemsTests.swift
+++ b/packages/ios-enriched-markdown/Tests/EnrichedMarkdownTests/SelectionMenuItemsTests.swift
@@ -162,9 +162,7 @@ final class SelectionMenuItemsTests: XCTestCase {
 
     // MARK: - Menu splicing
 
-    func testSpliceInsertsAfterStandardEditMenu() throws {
-        guard #available(iOS 16.0, *) else { throw XCTSkip("Requires iOS 16") }
-
+    func testSpliceInsertsAfterStandardEditMenu() {
         let standardEdit = UIMenu(title: "", identifier: .standardEdit, children: [])
         let lookUp = UIMenu(title: "", identifier: .lookup, children: [])
         let custom = UIAction(title: "Copy as Markdown") { _ in }
@@ -182,9 +180,7 @@ final class SelectionMenuItemsTests: XCTestCase {
 
     // MARK: - Select All fallback
 
-    func testContainsSelectAllDetectsCommandNestedInStandardEditMenu() throws {
-        guard #available(iOS 16.0, *) else { throw XCTSkip("Requires iOS 16") }
-
+    func testContainsSelectAllDetectsCommandNestedInStandardEditMenu() {
         let selectAll = UICommand(title: "Select All", action: #selector(UIResponder.selectAll(_:)))
         let copy = UICommand(title: "Copy", action: #selector(UIResponder.copy(_:)))
         let standardEdit = UIMenu(title: "", identifier: .standardEdit, children: [copy, selectAll])
@@ -195,9 +191,7 @@ final class SelectionMenuItemsTests: XCTestCase {
         ]))
     }
 
-    func testMakeSelectAllActionAttributes() throws {
-        guard #available(iOS 16.0, *) else { throw XCTSkip("Requires iOS 16") }
-
+    func testMakeSelectAllActionAttributes() {
         let action = MarkdownTextViewRepresentable.Coordinator.makeSelectAllAction(for: UITextView())
 
         XCTAssertEqual(action.title, "Select All")
@@ -214,9 +208,7 @@ final class SelectionMenuItemsTests: XCTestCase {
         XCTAssertEqual(textView.selectedRange, NSRange(location: 0, length: textView.attributedText.length))
     }
 
-    func testSplicePrependsWhenStandardEditMenuAbsent() throws {
-        guard #available(iOS 16.0, *) else { throw XCTSkip("Requires iOS 16") }
-
+    func testSplicePrependsWhenStandardEditMenuAbsent() {
         let lookUp = UIMenu(title: "", identifier: .lookup, children: [])
         let custom = UIAction(title: "Copy as Markdown") { _ in }
 


### PR DESCRIPTION
Drop the iOS 15 fallback paths: availability gates around the decoration stack, custom selection menu, and VoiceOver element tree, plus the README version-notes table. Also remove the macOS platform claim from the SPM manifest; the EnrichedMarkdown target imports UIKit and never built for macOS (RN macOS support via CocoaPods is unaffected).

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

