### PR TITLE
fix(android): honor allowFontScaling in EnrichedMarkdownText measure

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -9,6 +9,7 @@ import android.os.Looper
 import android.text.Layout
 import android.util.AttributeSet
 import android.util.Log
+import android.util.TypedValue
 import android.view.MotionEvent
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.StateWrapper
@@ -190,6 +191,10 @@ class EnrichedMarkdownText
       }
     }
 
+    fun commitProps() {
+      updateMeasurementStoreFontScaling()
+    }
+
     private fun updateMeasurementStoreFontScaling() {
       MeasurementStore.updateFontScalingSettings(id, allowFontScaling, maxFontSizeMultiplier)
     }
@@ -257,6 +262,10 @@ class EnrichedMarkdownText
 
     private fun applyRenderedText(styledText: CharSequence) {
       val tailStart = previousTextLength
+
+      markdownStyle?.paragraphStyle?.fontSize?.let {
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, it)
+      }
 
       text = styledText
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -72,6 +72,11 @@ class EnrichedMarkdownTextManager :
     return view
   }
 
+  override fun onAfterUpdateTransaction(view: EnrichedMarkdownText) {
+    super.onAfterUpdateTransaction(view)
+    view.commitProps()
+  }
+
   override fun updateState(
     view: EnrichedMarkdownText,
     props: ReactStylesDiffMap?,

--- a/packages/react-native-enriched-markdown/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
+++ b/packages/react-native-enriched-markdown/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
@@ -12,6 +12,8 @@ inline folly::dynamic toDynamic(const EnrichedMarkdownTextProps &props) {
   serializedProps["markdown"] = props.markdown;
   serializedProps["markdownStyle"] = toDynamic(props.markdownStyle);
   serializedProps["md4cFlags"] = toDynamic(props.md4cFlags);
+  serializedProps["allowFontScaling"] = props.allowFontScaling;
+  serializedProps["maxFontSizeMultiplier"] = props.maxFontSizeMultiplier;
   serializedProps["allowTrailingMargin"] = props.allowTrailingMargin;
   serializedProps["streamingAnimation"] = props.streamingAnimation;
 
@@ -29,6 +31,8 @@ inline folly::dynamic toDynamic(const EnrichedMarkdownProps &props) {
   serializedProps["markdown"] = props.markdown;
   serializedProps["markdownStyle"] = toDynamic(props.markdownStyle);
   serializedProps["md4cFlags"] = toDynamic(props.md4cFlags);
+  serializedProps["allowFontScaling"] = props.allowFontScaling;
+  serializedProps["maxFontSizeMultiplier"] = props.maxFontSizeMultiplier;
   serializedProps["allowTrailingMargin"] = props.allowTrailingMargin;
   serializedProps["streamingAnimation"] = props.streamingAnimation;
 


### PR DESCRIPTION
### What/Why?

Yoga measure for `EnrichedMarkdownText` ignored `allowFontScaling` / `maxFontSizeMultiplier` because `toDynamic()` omitted them, so `MeasurementStore` defaulted to `allowFontScaling=true` while the view could render with `false` — oversized height / white gaps on Android with large system fonts.

Also mirrors `EnrichedMarkdown`:
- `commitProps()` + `onAfterUpdateTransaction` to re-register settings under the real view id
- Align view base paint with `paragraphStyle.fontSize` via `setTextSize(TypedValue.COMPLEX_UNIT_PX, …)`


<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

Made with [Cursor](https://cursor.com)