### PR TITLE
fix(android): expo windows developement build

### DIFF
--- a/packages/react-native-enriched-markdown/android/build.gradle
+++ b/packages/react-native-enriched-markdown/android/build.gradle
@@ -138,7 +138,7 @@ if (codeHighlightActive) {
   highlightConfigFile.text = """\
 set(ENRICHED_MARKDOWN_CODE_HIGHLIGHT ON)
 set(ENRICHED_MARKDOWN_HIGHLIGHT_LANGUAGES "${codeHighlightLanguages.join(';')}")
-set(ENRICHED_MARKDOWN_HIGHLIGHT_GENERATED_DIR "${generatedDir.canonicalPath}")
+set(ENRICHED_MARKDOWN_HIGHLIGHT_GENERATED_DIR "${generatedDir.canonicalPath.replace('\\', '/')}")
 """
 } else {
   highlightConfigFile.text = "set(ENRICHED_MARKDOWN_CODE_HIGHLIGHT OFF)\n"


### PR DESCRIPTION
### What/Why?
Fixes #666.

On Windows, `expo run:android` (and any Gradle Android build) failed while configuring the native build with:

```
CMake Error at .../react-native-enriched-markdown/android/build/generated/highlight/highlight-config.cmake:3 (set):
    Syntax error in cmake code at .../highlight-config.cmake:3
```

`android/build.gradle` generates `highlight-config.cmake` and writes the code-highlight registry directory into it via `generatedDir.canonicalPath`. On Windows that path uses backslashes (`C:\Users\...\generated`), and CMake treats `\U`, `\g`, etc. as escape sequences, so the `set(...)` on line 3 is a syntax error. The build only reaches this path when code highlighting is active (the default when grammars are vendored), which is why the regression appeared in 1.0.0/1.0.1 and downgrading to 0.7.4 (pre-highlight) worked around it.

The fix normalizes the path separators to forward slashes, which CMake accepts on every platform:

```groovy
  set(ENRICHED_MARKDOWN_HIGHLIGHT_GENERATED_DIR "${generatedDir.canonicalPath.replace('\\', '/')}")
```

One-line change; POSIX builds are unaffected (no backslashes to replace).

### Testing
Reproduced and verified on a Windows 11 machine with a minimal Expo SDK 57 app (blank template + react-native-enriched-markdown, code highlighting enabled):
- Before: npx expo run:android fails at configureCMakeDebug with the highlight-config.cmake:3 syntax error above.
- After: the generated highlight-config.cmake contains `set(ENRICHED_MARKDOWN_HIGHLIGHT_GENERATED_DIR "C:/dev/.../generated")` (forward slashes) and the app builds and installs successfully.
- Confirmed both by hand-patching node_modules and by installing a locally packed tarball containing the fix, to validate the shipped artifact.

macOS/Linux builds are unchanged (verified canonicalPath has no backslashes to replace, so the emitted config is identical to before).

