### PR TITLE
feat(ios): render GFM task lists

### DIFF
--- a/packages/enriched-markdown-ios/README.md
+++ b/packages/enriched-markdown-ios/README.md
@@ -141,10 +141,13 @@ The `MarkdownTheme` builder supports these elements:
 | `Link()` | Links |
 | `Strong()` | Bold text |
 | `Emphasis()` | Italic text |
+| `Strikethrough()` | Struck-through text |
+| `Underline()` | Underlined text (`Md4cFlags(underline: true)`) |
 | `Code()` | Inline code |
 | `CodeBlock()` | Fenced code blocks |
 | `Blockquote()` | Block quotes |
 | `List()` | Ordered and unordered lists |
+| `TaskList()` | Task-list checkboxes (`- [x]`) |
 | `BlockImage()` | Block images |
 | `InlineImage()` | Inline images |
 | `ThematicBreak()` | Horizontal rules |
@@ -159,6 +162,7 @@ Element-specific modifiers include:
 - **Code / CodeBlock / Blockquote:** `.background` / `.backgroundStyle`
 - **CodeBlock / Blockquote:** `.borderColor`, `.borderWidth`, `.padding` / `.gapWidth`, `.cornerRadius` / `.borderRadius`
 - **List:** `.bulletColor`, `.markerColor`, `.bulletSize`, `.markerMinWidth`, `.gapWidth`, `.marginLeft`
+- **TaskList:** `.checkedColor`, `.borderColor`, `.checkmarkColor`, `.checkboxSize`, `.checkboxBorderRadius`, `.checkedTextColor`, `.checkedStrikethrough`
 - **BlockImage:** `.height`, `.borderRadius`
 - **InlineImage:** `.size`
 - **ThematicBreak:** `.color` / `.foregroundStyle`, `.height`
@@ -326,7 +330,9 @@ Dynamic Type is supported throughout via text styles in the default theme.
 - Fenced code blocks
 - Block quotes
 - Ordered and unordered lists
+- Task lists (`- [x]` / `- [ ]`, display-only checkboxes)
 - Links and images (block and inline)
+- Autolinked bare URLs, `www.` links, and emails (`permissiveAutolinks`, on by default)
 - Thematic breaks (`---`)
 
 ## Development

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElementBuilder.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElementBuilder.swift
@@ -221,6 +221,10 @@ enum MarkdownAccessibilityElementBuilder {
         }
 
         let prefix = depth > 0 ? "nested " : ""
+        if let taskValue = text.attribute(MarkdownAttribute.taskListItem, at: position, effectiveRange: nil) {
+            let state = MarkdownAttributeValue.boolValue(from: taskValue) ? "checked" : "not checked"
+            return "\(prefix)task, \(state)"
+        }
         if type == ListType.ordered.rawValue {
             return "\(prefix)list item \(number)"
         }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator.swift
@@ -75,7 +75,14 @@ enum MarkdownHTMLGenerator {
         case heading(Int)
         case codeBlock
         case blockquote(depth: Int)
-        case list(depth: Int, ordered: Bool)
+        case list(ListParagraph)
+    }
+
+    private struct ListParagraph: Equatable {
+        let depth: Int
+        let ordered: Bool
+        /// Non-nil for the paragraph anchoring a task-list item.
+        let taskChecked: Bool?
     }
 
     private struct Paragraph {
@@ -126,7 +133,10 @@ enum MarkdownHTMLGenerator {
             let ordered = MarkdownAttributeValue.intValue(
                 from: attrs[MarkdownAttribute.listType]
             ) == ListType.ordered.rawValue
-            return .list(depth: depth, ordered: ordered)
+            let taskChecked = attrs[MarkdownAttribute.taskListItem].map {
+                MarkdownAttributeValue.boolValue(from: $0)
+            }
+            return .list(ListParagraph(depth: depth, ordered: ordered, taskChecked: taskChecked))
         }
         return .normal
     }
@@ -162,8 +172,8 @@ enum MarkdownHTMLGenerator {
             collectCodeBlockLine(inline, state: &state)
         case .blockquote(let depth):
             emitBlockquote(inline, depth: depth, into: &html, styles: styles, state: &state)
-        case .list(let depth, let ordered):
-            emitList(inline, depth: depth, ordered: ordered, into: &html, styles: styles, state: &state)
+        case .list(let list):
+            emitList(inline, list: list, into: &html, styles: styles, state: &state)
         case .heading(let level):
             emitHeading(inline, level: level, into: &html, styles: styles, state: &state)
         case .normal:
@@ -256,12 +266,13 @@ enum MarkdownHTMLGenerator {
 
     private static func emitList(
         _ content: String,
-        depth: Int,
-        ordered: Bool,
+        list: ListParagraph,
         into html: inout String,
         styles: CachedStyles,
         state: inout State
     ) {
+        let depth = list.depth
+        let ordered = list.ordered
         closeCodeBlockIfOpen(&html, state: &state, styles: styles)
         closeAllBlockquotes(&html, state: &state)
 
@@ -291,9 +302,16 @@ enum MarkdownHTMLGenerator {
             }
         }
 
+        // Task items hide the list marker and lead with a disabled checkbox,
+        // matching GitHub's task-list markup.
+        let taskListStyle = list.taskChecked != nil ? " list-style-type: none;" : ""
+        let checkboxPrefix = list.taskChecked.map { checked in
+            "<input type=\"checkbox\" disabled\(checked ? " checked" : "") "
+                + "style=\"margin: 0 0.4em 0.1em -1.3em; vertical-align: middle;\">"
+        } ?? ""
         html += "<li style=\"margin-bottom: \(styles.listMarginBottom)px; "
             + "color: \(styles.listColor); "
-            + "font-size: \(styles.listFontSize)px;\">\(content)</li>"
+            + "font-size: \(styles.listFontSize)px;\(taskListStyle)\">\(checkboxPrefix)\(content)</li>"
         state.previousWasBlockquote = false
     }
 

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RenderContext.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RenderContext.swift
@@ -32,6 +32,9 @@ enum MarkdownAttribute {
     static let listDepth = NSAttributedString.Key("EnrichedMarkdownListDepth")
     static let listType = NSAttributedString.Key("EnrichedMarkdownListType")
     static let listItemNumber = NSAttributedString.Key("EnrichedMarkdownListItemNumber")
+    /// Present on the first paragraph of a GFM task-list item; the value is
+    /// the checked state as a boolean.
+    static let taskListItem = NSAttributedString.Key("EnrichedMarkdownTaskListItem")
 }
 
 final class RenderContext {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
@@ -38,6 +38,9 @@ final class RendererFactory {
         if let renderer = createBlockRenderer(for: type) {
             return renderer
         }
+        #if DEBUG
+        print("[EnrichedMarkdown] No renderer for node type '\(type)'; rendering its children only.")
+        #endif
         return childrenOnlyRenderer
     }
 

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/BlockquoteRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/BlockquoteRenderer.swift
@@ -96,13 +96,7 @@ final class BlockquoteRenderer: NodeRenderer {
         depth: Int,
         levelSpacing: CGFloat
     ) {
-        let paragraphStyle = ParagraphStyleHelpers.getOrCreateParagraphStyle(in: output, at: range.location)
-        let totalIndent = CGFloat(depth + 1) * levelSpacing
-        paragraphStyle.firstLineHeadIndent = totalIndent
-        paragraphStyle.headIndent = totalIndent
-
         var attributes: [NSAttributedString.Key: Any] = [
-            .paragraphStyle: paragraphStyle,
             MarkdownAttribute.blockquoteDepth: depth
         ]
 
@@ -111,9 +105,41 @@ final class BlockquoteRenderer: NodeRenderer {
         }
 
         output.addAttributes(attributes, range: range)
+        applyIndentSkippingListItems(to: output, range: range, indent: CGFloat(depth + 1) * levelSpacing)
 
         if let lineHeight = config.blockquote.lineHeight {
             ParagraphStyleHelpers.applyBlockLineHeight(to: output, range: range, lineHeight: lineHeight)
+        }
+    }
+
+    /// List items position themselves inside blockquotes (their indent
+    /// already includes the quote offset, and it must not be overwritten or
+    /// their marker column collapses onto the quote border), so the quote
+    /// indent is applied per paragraph, skipping list-item paragraphs.
+    private func applyIndentSkippingListItems(
+        to output: NSMutableAttributedString,
+        range: NSRange,
+        indent: CGFloat
+    ) {
+        let string = output.string as NSString
+        var location = range.location
+        let end = NSMaxRange(range)
+
+        while location < end {
+            let paragraphRange = string.paragraphRange(for: NSRange(location: location, length: 0))
+            let applyRange = NSIntersectionRange(paragraphRange, range)
+            guard applyRange.length > 0 else { break }
+            location = NSMaxRange(applyRange)
+
+            if output.attribute(MarkdownAttribute.listDepth, at: applyRange.location, effectiveRange: nil) != nil {
+                continue
+            }
+
+            let style = ParagraphStyleHelpers.getOrCreateParagraphStyle(in: output, at: applyRange.location)
+            style.firstLineHeadIndent = indent
+            style.headIndent = indent
+            style.tailIndent = 0
+            output.addAttribute(.paragraphStyle, value: style, range: applyRange)
         }
     }
 
@@ -123,18 +149,11 @@ final class BlockquoteRenderer: NodeRenderer {
         levelSpacing: CGFloat
     ) {
         for info in nestedInfo {
-            let style = ParagraphStyleHelpers.getOrCreateParagraphStyle(in: output, at: info.range.location)
-            let indent = CGFloat(info.depth + 1) * levelSpacing
-            style.firstLineHeadIndent = indent
-            style.headIndent = indent
-            style.tailIndent = 0
-
-            output.addAttributes(
-                [
-                    .paragraphStyle: style,
-                    MarkdownAttribute.blockquoteDepth: info.depth
-                ],
-                range: info.range
+            output.addAttributes([MarkdownAttribute.blockquoteDepth: info.depth], range: info.range)
+            applyIndentSkippingListItems(
+                to: output,
+                range: info.range,
+                indent: CGFloat(info.depth + 1) * levelSpacing
             )
         }
     }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/ListItemRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/ListItemRenderer.swift
@@ -14,6 +14,8 @@ final class ListItemRenderer: NodeRenderer {
         let currentPosition = context.listItemNumber
         let currentDepth = context.listDepth
         let nestingLevel = currentDepth - 1
+        let isTask = node.attribute("isTask") == "true"
+        let isChecked = isTask && node.attribute("taskChecked") == "true"
 
         let startLocation = output.length
         factory.renderChildren(of: node, into: output, context: context)
@@ -22,10 +24,13 @@ final class ListItemRenderer: NodeRenderer {
         let itemRange = NSRange(location: startLocation, length: output.length - startLocation)
         guard itemRange.length > 0 else { return }
 
-        let baseMarkerWidth = effectiveMarkerWidth(for: context.listType)
+        let baseMarkerWidth = isTask
+            ? effectiveTaskMarkerWidth(for: context.listType)
+            : effectiveMarkerWidth(for: context.listType)
         let gapWidth = max(config.list.gapWidth ?? 12, 4)
         let marginLeft = config.list.marginLeft ?? 24
-        let totalIndent = baseMarkerWidth + gapWidth + (CGFloat(nestingLevel) * marginLeft)
+        let blockquoteIndent = CGFloat(context.blockquoteDepth) * blockquoteLevelSpacing()
+        let totalIndent = blockquoteIndent + baseMarkerWidth + gapWidth + (CGFloat(nestingLevel) * marginLeft)
         let lineHeight = config.list.lineHeight ?? 0
 
         let metadata: [NSAttributedString.Key: Any] = [
@@ -42,6 +47,15 @@ final class ListItemRenderer: NodeRenderer {
             totalIndent: totalIndent,
             lineHeight: lineHeight
         )
+
+        if isTask {
+            applyTaskItemStyling(
+                to: output,
+                itemRange: itemRange,
+                nestingLevel: nestingLevel,
+                isChecked: isChecked
+            )
+        }
     }
 
     private func effectiveMarkerWidth(for listType: ListType) -> CGFloat {
@@ -51,6 +65,87 @@ final class ListItemRenderer: NodeRenderer {
             return max(minWidth, 20)
         case .unordered:
             return max(minWidth, config.list.bulletSize ?? 6)
+        }
+    }
+
+    /// The checkbox column is at least as wide as the list type's normal
+    /// marker column, so task items align with their non-task siblings.
+    private func effectiveTaskMarkerWidth(for listType: ListType) -> CGFloat {
+        max(effectiveMarkerWidth(for: listType), config.taskList.checkboxSize ?? 14)
+    }
+
+    private func blockquoteLevelSpacing() -> CGFloat {
+        (config.blockquote.borderWidth ?? 3) + (config.blockquote.gapWidth ?? 16)
+    }
+
+    /// Marks the item's own paragraphs (not nested children) with the task
+    /// attribute — the first one anchors the checkbox — and applies the
+    /// checked-item text decoration when configured.
+    private func applyTaskItemStyling(
+        to output: NSMutableAttributedString,
+        itemRange: NSRange,
+        nestingLevel: Int,
+        isChecked: Bool
+    ) {
+        let checkedTextColor = isChecked ? config.taskList.checkedTextColor : nil
+        let checkedStrikethrough = isChecked && (config.taskList.checkedStrikethrough ?? false)
+
+        let string = output.string as NSString
+        var location = itemRange.location
+        let end = NSMaxRange(itemRange)
+        var markedCheckboxAnchor = false
+
+        while location < end {
+            let paragraphRange = string.paragraphRange(for: NSRange(location: location, length: 0))
+            let applyRange = NSIntersectionRange(paragraphRange, itemRange)
+            guard applyRange.length > 0 else { break }
+            location = NSMaxRange(applyRange)
+
+            if shouldSkipListStyling(in: output, range: applyRange, nestingLevel: nestingLevel) {
+                continue
+            }
+
+            if !markedCheckboxAnchor {
+                markedCheckboxAnchor = true
+                output.addAttribute(
+                    MarkdownAttribute.taskListItem,
+                    value: NSNumber(value: isChecked),
+                    range: applyRange
+                )
+            }
+
+            guard checkedTextColor != nil || checkedStrikethrough else {
+                break
+            }
+            applyCheckedDecoration(
+                to: output,
+                range: applyRange,
+                textColor: checkedTextColor,
+                strikethrough: checkedStrikethrough
+            )
+        }
+    }
+
+    private func applyCheckedDecoration(
+        to output: NSMutableAttributedString,
+        range: NSRange,
+        textColor: UIColor?,
+        strikethrough: Bool
+    ) {
+        let strikethroughColor = textColor ?? config.list.foregroundColor ?? UIColor.label
+        output.enumerateAttributes(in: range, options: []) { attrs, runRange, _ in
+            guard attrs[.attachment] == nil else { return }
+            if strikethrough {
+                output.addAttribute(
+                    .strikethroughStyle,
+                    value: NSUnderlineStyle.single.rawValue,
+                    range: runRange
+                )
+                output.addAttribute(.strikethroughColor, value: strikethroughColor, range: runRange)
+            }
+            if let textColor, !RenderContext.shouldPreserveColors(attrs) {
+                output.addAttribute(.foregroundColor, value: textColor, range: runRange)
+            }
         }
     }
 

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/DefaultMarkdownTheme.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/DefaultMarkdownTheme.swift
@@ -97,6 +97,13 @@ enum DefaultMarkdownTheme {
                 .gapWidth(12)
                 .marginLeft(24)
                 .marginBottom(16)
+
+            TaskList()
+                .checkedColor(Semantic.tint)
+                .borderColor(Semantic.secondary)
+                .checkmarkColor(.white)
+                .checkboxSize(14)
+                .checkboxBorderRadius(3)
         }
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/TaskList.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/TaskList.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+public struct TaskList: MarkdownThemeContent {
+    public var checkedColorSpec: ThemeColorSpec?
+    public var borderColorSpec: ThemeColorSpec?
+    public var checkmarkColorSpec: ThemeColorSpec?
+    public var checkedTextColorSpec: ThemeColorSpec?
+    public var checkboxSize: CGFloat?
+    public var checkboxBorderRadius: CGFloat?
+    public var checkedStrikethrough: Bool?
+
+    public init() {}
+
+    public func checkedColor(_ color: Color) -> Self {
+        var copy = self
+        copy.checkedColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func checkedColor(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.checkedColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func borderColor(_ color: Color) -> Self {
+        var copy = self
+        copy.borderColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func borderColor(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.borderColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func checkmarkColor(_ color: Color) -> Self {
+        var copy = self
+        copy.checkmarkColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func checkmarkColor(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.checkmarkColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func checkedTextColor(_ color: Color) -> Self {
+        var copy = self
+        copy.checkedTextColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func checkedTextColor(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.checkedTextColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func checkboxSize(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.checkboxSize = value
+        return copy
+    }
+
+    public func checkboxBorderRadius(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.checkboxBorderRadius = value
+        return copy
+    }
+
+    public func checkedStrikethrough(_ enabled: Bool = true) -> Self {
+        var copy = self
+        copy.checkedStrikethrough = enabled
+        return copy
+    }
+
+    public func apply(to config: inout MarkdownStyleConfig, traitCollection: UITraitCollection) {
+        if let checkedColorSpec {
+            config.taskList.checkedColor = checkedColorSpec.resolve(traitCollection: traitCollection)
+        }
+        if let borderColorSpec {
+            config.taskList.borderColor = borderColorSpec.resolve(traitCollection: traitCollection)
+        }
+        if let checkmarkColorSpec {
+            config.taskList.checkmarkColor = checkmarkColorSpec.resolve(traitCollection: traitCollection)
+        }
+        if let checkedTextColorSpec {
+            config.taskList.checkedTextColor = checkedTextColorSpec.resolve(traitCollection: traitCollection)
+        }
+        if let checkboxSize { config.taskList.checkboxSize = checkboxSize }
+        if let checkboxBorderRadius { config.taskList.checkboxBorderRadius = checkboxBorderRadius }
+        if let checkedStrikethrough { config.taskList.checkedStrikethrough = checkedStrikethrough }
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
@@ -256,6 +256,44 @@ public struct ListStyle: Equatable, Sendable {
     }
 }
 
+public struct TaskListStyle: Equatable, Sendable {
+    public var checkedColor: UIColor?
+    public var borderColor: UIColor?
+    public var checkboxSize: CGFloat?
+    public var checkboxBorderRadius: CGFloat?
+    public var checkmarkColor: UIColor?
+    public var checkedTextColor: UIColor?
+    public var checkedStrikethrough: Bool?
+
+    public init(
+        checkedColor: UIColor? = nil,
+        borderColor: UIColor? = nil,
+        checkboxSize: CGFloat? = nil,
+        checkboxBorderRadius: CGFloat? = nil,
+        checkmarkColor: UIColor? = nil,
+        checkedTextColor: UIColor? = nil,
+        checkedStrikethrough: Bool? = nil
+    ) {
+        self.checkedColor = checkedColor
+        self.borderColor = borderColor
+        self.checkboxSize = checkboxSize
+        self.checkboxBorderRadius = checkboxBorderRadius
+        self.checkmarkColor = checkmarkColor
+        self.checkedTextColor = checkedTextColor
+        self.checkedStrikethrough = checkedStrikethrough
+    }
+
+    public mutating func merge(_ other: TaskListStyle) {
+        checkedColor = other.checkedColor ?? checkedColor
+        borderColor = other.borderColor ?? borderColor
+        checkboxSize = other.checkboxSize ?? checkboxSize
+        checkboxBorderRadius = other.checkboxBorderRadius ?? checkboxBorderRadius
+        checkmarkColor = other.checkmarkColor ?? checkmarkColor
+        checkedTextColor = other.checkedTextColor ?? checkedTextColor
+        checkedStrikethrough = other.checkedStrikethrough ?? checkedStrikethrough
+    }
+}
+
 public struct MarkdownStyleConfig: Equatable, Sendable {
     public var paragraph: ElementStyle
     public var heading1: ElementStyle
@@ -276,6 +314,7 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
     public var codeBlock: CodeBlockStyle
     public var blockquote: BlockquoteStyle
     public var list: ListStyle
+    public var taskList: TaskListStyle
 
     public init(
         paragraph: ElementStyle = ElementStyle(),
@@ -296,7 +335,8 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         thematicBreak: ThematicBreakStyle = ThematicBreakStyle(),
         codeBlock: CodeBlockStyle = CodeBlockStyle(),
         blockquote: BlockquoteStyle = BlockquoteStyle(),
-        list: ListStyle = ListStyle()
+        list: ListStyle = ListStyle(),
+        taskList: TaskListStyle = TaskListStyle()
     ) {
         self.paragraph = paragraph
         self.heading1 = heading1
@@ -317,6 +357,7 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         self.codeBlock = codeBlock
         self.blockquote = blockquote
         self.list = list
+        self.taskList = taskList
     }
 
     public mutating func merge(_ other: MarkdownStyleConfig) {
@@ -339,6 +380,7 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         codeBlock.merge(other.codeBlock)
         blockquote.merge(other.blockquote)
         list.merge(other.list)
+        taskList.merge(other.taskList)
     }
 
     public func headingStyle(for level: Int) -> ElementStyle {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/Layout/BlockDecorationConfig.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/Layout/BlockDecorationConfig.swift
@@ -18,10 +18,17 @@ struct BlockDecorationConfig {
     var listMarkerColor: UIColor = UIColor(red: 0.42, green: 0.45, blue: 0.50, alpha: 1)
     var listMarkerFont: UIFont = .systemFont(ofSize: 16, weight: .medium)
 
+    var taskCheckboxSize: CGFloat = 14
+    var taskCheckboxBorderRadius: CGFloat = 3
+    var taskCheckedColor: UIColor = UIColor(red: 0.0, green: 0.48, blue: 1.0, alpha: 1)
+    var taskBorderColor: UIColor = UIColor(red: 0.62, green: 0.62, blue: 0.62, alpha: 1)
+    var taskCheckmarkColor: UIColor = .white
+
     init(styleConfig: MarkdownStyleConfig) {
         applyCodeBlockStyle(from: styleConfig.codeBlock)
         applyBlockquoteStyle(from: styleConfig.blockquote)
         applyListStyle(from: styleConfig.list)
+        applyTaskListStyle(from: styleConfig.taskList)
     }
 
     private mutating func applyCodeBlockStyle(from style: CodeBlockStyle) {
@@ -72,6 +79,24 @@ struct BlockDecorationConfig {
         }
         if let font = style.font {
             listMarkerFont = font
+        }
+    }
+
+    private mutating func applyTaskListStyle(from style: TaskListStyle) {
+        if let size = style.checkboxSize {
+            taskCheckboxSize = size
+        }
+        if let radius = style.checkboxBorderRadius {
+            taskCheckboxBorderRadius = radius
+        }
+        if let color = style.checkedColor {
+            taskCheckedColor = color
+        }
+        if let color = style.borderColor {
+            taskBorderColor = color
+        }
+        if let color = style.checkmarkColor {
+            taskCheckmarkColor = color
         }
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/Layout/ListMarkerDrawer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/Layout/ListMarkerDrawer.swift
@@ -42,7 +42,22 @@ enum ListMarkerDrawer {
                 )
             )
 
-            if MarkdownAttributeValue.intValue(from: attrs[MarkdownAttribute.listType]) == ListType.unordered.rawValue {
+            if let taskValue = attrs[MarkdownAttribute.taskListItem] {
+                let font = (attrs[.font] as? UIFont) ?? UIFont.systemFont(ofSize: 16)
+                let rect = checkboxRect(
+                    markerX: layoutInfo.markerX,
+                    baselineY: layoutInfo.visualBaselineY,
+                    font: font,
+                    isRTL: isRTL,
+                    config: config
+                )
+                drawCheckbox(
+                    in: rect,
+                    isChecked: MarkdownAttributeValue.boolValue(from: taskValue),
+                    config: config,
+                    context: drawContext.context
+                )
+            } else if MarkdownAttributeValue.intValue(from: attrs[MarkdownAttribute.listType]) == ListType.unordered.rawValue {
                 let depth = MarkdownAttributeValue.intValue(from: attrs[MarkdownAttribute.listDepth]) ?? 0
                 let font = (attrs[.font] as? UIFont) ?? UIFont.systemFont(ofSize: 16)
                 let bulletY = bulletCenterY(visualBaselineY: layoutInfo.visualBaselineY, font: font)
@@ -169,6 +184,65 @@ enum ListMarkerDrawer {
             at: CGPoint(x: drawX, y: baselineY - config.listMarkerFont.ascender),
             withAttributes: attributes
         )
+    }
+
+    /// Checkbox trailing edge sits at the marker boundary (like ordered
+    /// markers), vertically centered on the cap height so the box brackets
+    /// the first line's text.
+    private static func checkboxRect(
+        markerX: CGFloat,
+        baselineY: CGFloat,
+        font: UIFont,
+        isRTL: Bool,
+        config: BlockDecorationConfig
+    ) -> CGRect {
+        let size = config.taskCheckboxSize
+        let originX = isRTL ? markerX : markerX - size
+        let centerY = baselineY - font.capHeight / 2
+        return CGRect(x: originX, y: centerY - size / 2, width: size, height: size)
+    }
+
+    /// Geometry mirrors the React Native package's ListMarkerDrawer so both
+    /// renderers produce the same checkbox at the same style values.
+    private static func drawCheckbox(
+        in rect: CGRect,
+        isChecked: Bool,
+        config: BlockDecorationConfig,
+        context: CGContext
+    ) {
+        let size = rect.width
+        let cornerRadius = min(config.taskCheckboxBorderRadius, size / 2)
+
+        context.saveGState()
+        defer { context.restoreGState() }
+
+        if isChecked {
+            let path = UIBezierPath(roundedRect: rect, cornerRadius: cornerRadius)
+            context.setFillColor(config.taskCheckedColor.cgColor)
+            context.addPath(path.cgPath)
+            context.fillPath()
+
+            let inset = size * 0.22
+            let midOffset = size * 0.05
+            let checkmark = CGMutablePath()
+            checkmark.move(to: CGPoint(x: rect.minX + inset, y: rect.midY))
+            checkmark.addLine(to: CGPoint(x: rect.midX - midOffset, y: rect.maxY - inset))
+            checkmark.addLine(to: CGPoint(x: rect.maxX - inset, y: rect.minY + inset))
+            context.setStrokeColor(config.taskCheckmarkColor.cgColor)
+            context.setLineWidth(max(1.5, size * 0.12))
+            context.setLineCap(.round)
+            context.setLineJoin(.round)
+            context.addPath(checkmark)
+            context.strokePath()
+        } else {
+            let lineWidth = max(1.0, size * 0.09)
+            let insetRect = rect.insetBy(dx: lineWidth / 2, dy: lineWidth / 2)
+            let path = UIBezierPath(roundedRect: insetRect, cornerRadius: cornerRadius)
+            context.setStrokeColor(config.taskBorderColor.cgColor)
+            context.setLineWidth(lineWidth)
+            context.addPath(path.cgPath)
+            context.strokePath()
+        }
     }
 
     private static func paragraphIsRTL(_ style: NSParagraphStyle?) -> Bool {

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/AccessibilityElementBuilderTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/AccessibilityElementBuilderTests.swift
@@ -91,6 +91,21 @@ final class AccessibilityElementBuilderTests: XCTestCase {
         XCTAssertEqual(result[1].listAnnouncement, "nested bullet point")
     }
 
+    func testTaskListItemsAnnounceCheckedState() {
+        let result = specs(for: "- [x] done\n- [ ] todo")
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].listAnnouncement, "task, checked")
+        XCTAssertEqual(result[1].listAnnouncement, "task, not checked")
+    }
+
+    func testNestedTaskItemsAnnounceNesting() {
+        let result = specs(for: "- outer\n  - [ ] inner task")
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[1].listAnnouncement, "nested task, not checked")
+    }
+
     func testLinkInsideListItemCarriesListContext() {
         let result = specs(for: "- see [docs](https://d.example) here")
 

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/HTMLGeneratorTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/HTMLGeneratorTests.swift
@@ -155,6 +155,23 @@ final class HTMLGeneratorTests: XCTestCase {
         XCTAssertTrue(result.contains("</ol>"))
     }
 
+    func testTaskListItemsEmitDisabledCheckboxes() {
+        let result = html(for: "- [x] done\n- [ ] todo")
+
+        XCTAssertTrue(result.contains("<input type=\"checkbox\" disabled checked "))
+        XCTAssertTrue(result.contains("<input type=\"checkbox\" disabled style"))
+        XCTAssertTrue(result.contains("list-style-type: none;"))
+        XCTAssertTrue(result.contains("done</li>"))
+        XCTAssertTrue(result.contains("todo</li>"))
+    }
+
+    func testRegularListItemsEmitNoCheckbox() {
+        let result = html(for: "- plain")
+
+        XCTAssertFalse(result.contains("checkbox"))
+        XCTAssertFalse(result.contains("list-style-type: none"))
+    }
+
     func testNestedListsOpenSecondContainer() {
         let result = html(for: "- outer\n  - inner")
 

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/TaskListRenderingTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/TaskListRenderingTests.swift
@@ -1,0 +1,223 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+final class TaskListRenderingTests: XCTestCase {
+    private var config: MarkdownStyleConfig!
+
+    override func setUp() {
+        super.setUp()
+        config = MarkdownStyleConfig.baseline()
+    }
+
+    // MARK: - Parsing
+
+    func testParserEmitsTaskAttributesOnListItems() {
+        let ast = Parser.shared.parseMarkdown("- [x] done\n- [ ] todo")
+
+        let items = ast.all(ofType: .listItem)
+        XCTAssertEqual(items.count, 2)
+        XCTAssertEqual(items[0].attribute("isTask"), "true")
+        XCTAssertEqual(items[0].attribute("taskChecked"), "true")
+        XCTAssertEqual(items[1].attribute("isTask"), "true")
+        XCTAssertEqual(items[1].attribute("taskChecked"), "false")
+    }
+
+    func testParserLeavesRegularItemsUnmarked() {
+        let ast = Parser.shared.parseMarkdown("- plain item")
+
+        let item = ast.first(ofType: .listItem)
+        XCTAssertNil(item?.attribute("isTask"))
+    }
+
+    // MARK: - Rendered attributes
+
+    func testTaskItemsCarryCheckedStateAttribute() {
+        let result = MarkdownRenderer.render("- [x] done\n- [ ] todo", config: config)
+        let string = result.string as NSString
+
+        let doneLocation = string.range(of: "done").location
+        let todoLocation = string.range(of: "todo").location
+        XCTAssertTrue(MarkdownAttributeValue.boolValue(
+            from: result.attribute(MarkdownAttribute.taskListItem, at: doneLocation, effectiveRange: nil)
+        ))
+        let todoValue = result.attribute(MarkdownAttribute.taskListItem, at: todoLocation, effectiveRange: nil)
+        XCTAssertNotNil(todoValue)
+        XCTAssertFalse(MarkdownAttributeValue.boolValue(from: todoValue))
+    }
+
+    func testRegularItemsHaveNoTaskAttribute() {
+        let result = MarkdownRenderer.render("- plain item", config: config)
+        let location = (result.string as NSString).range(of: "plain").location
+
+        XCTAssertNil(result.attribute(MarkdownAttribute.taskListItem, at: location, effectiveRange: nil))
+    }
+
+    // MARK: - Indent
+
+    func testTaskItemIndentReservesCheckboxWidth() {
+        let result = MarkdownRenderer.render("- [ ] task\n- bullet", config: config)
+        let string = result.string as NSString
+
+        let taskStyle = result.attribute(
+            .paragraphStyle,
+            at: string.range(of: "task").location,
+            effectiveRange: nil
+        ) as? NSParagraphStyle
+        let bulletStyle = result.attribute(
+            .paragraphStyle,
+            at: string.range(of: "bullet").location,
+            effectiveRange: nil
+        ) as? NSParagraphStyle
+
+        // Default theme: checkboxSize 14 + gap 12 vs bulletSize 6 + gap 12.
+        XCTAssertEqual(taskStyle?.headIndent, 26)
+        XCTAssertEqual(bulletStyle?.headIndent, 18)
+    }
+
+    func testOrderedTaskItemsAlignWithSiblingNumbers() {
+        let result = MarkdownRenderer.render("1. [x] done step\n2. plain step", config: config)
+
+        // The checkbox column widens to the ordered marker column, so task
+        // and plain items in the same ordered list share one text indent.
+        XCTAssertEqual(paragraphStyle(in: result, at: "done")?.headIndent, 32)
+        XCTAssertEqual(paragraphStyle(in: result, at: "plain")?.headIndent, 32)
+    }
+
+    func testListItemsInsideBlockquoteKeepMarkerColumn() {
+        let result = MarkdownRenderer.render("> intro\n> - [ ] quoted task\n> - plain quoted", config: config)
+
+        // Default theme quote offset: borderWidth 3 + gapWidth 16 = 19.
+        XCTAssertEqual(paragraphStyle(in: result, at: "intro")?.headIndent, 19)
+        XCTAssertEqual(paragraphStyle(in: result, at: "quoted task")?.headIndent, 19 + 26)
+        XCTAssertEqual(paragraphStyle(in: result, at: "plain quoted")?.headIndent, 19 + 18)
+
+        // The quote border/background must still span the list items.
+        let string = result.string as NSString
+        let taskLocation = string.range(of: "quoted task").location
+        XCTAssertNotNil(result.attribute(MarkdownAttribute.blockquoteDepth, at: taskLocation, effectiveRange: nil))
+        XCTAssertNotNil(result.attribute(MarkdownAttribute.taskListItem, at: taskLocation, effectiveRange: nil))
+    }
+
+    private func paragraphStyle(in result: NSAttributedString, at substring: String) -> NSParagraphStyle? {
+        let range = (result.string as NSString).range(of: substring)
+        guard range.location != NSNotFound else { return nil }
+        return result.attribute(.paragraphStyle, at: range.location, effectiveRange: nil) as? NSParagraphStyle
+    }
+
+    // MARK: - Checked decoration
+
+    func testCheckedItemAppliesTextColorAndStrikethrough() {
+        config.taskList.checkedTextColor = .red
+        config.taskList.checkedStrikethrough = true
+        let result = MarkdownRenderer.render("- [x] done\n- [ ] todo", config: config)
+        let string = result.string as NSString
+
+        let doneLocation = string.range(of: "done").location
+        XCTAssertEqual(
+            result.attribute(.foregroundColor, at: doneLocation, effectiveRange: nil) as? UIColor,
+            .red
+        )
+        XCTAssertEqual(
+            MarkdownAttributeValue.intValue(
+                from: result.attribute(.strikethroughStyle, at: doneLocation, effectiveRange: nil)
+            ),
+            NSUnderlineStyle.single.rawValue
+        )
+        XCTAssertEqual(
+            result.attribute(.strikethroughColor, at: doneLocation, effectiveRange: nil) as? UIColor,
+            .red
+        )
+
+        let todoLocation = string.range(of: "todo").location
+        XCTAssertNotEqual(
+            result.attribute(.foregroundColor, at: todoLocation, effectiveRange: nil) as? UIColor,
+            .red
+        )
+        XCTAssertNil(result.attribute(.strikethroughStyle, at: todoLocation, effectiveRange: nil))
+    }
+
+    func testUncheckedItemGetsNoDecorationWithoutConfig() {
+        let result = MarkdownRenderer.render("- [x] done", config: config)
+        let location = (result.string as NSString).range(of: "done").location
+
+        XCTAssertNil(result.attribute(.strikethroughStyle, at: location, effectiveRange: nil))
+    }
+
+    func testCheckedDecorationSkipsNestedItems() {
+        config.taskList.checkedTextColor = .red
+        let result = MarkdownRenderer.render("- [x] parent\n  - child", config: config)
+        let string = result.string as NSString
+
+        XCTAssertEqual(
+            result.attribute(
+                .foregroundColor,
+                at: string.range(of: "parent").location,
+                effectiveRange: nil
+            ) as? UIColor,
+            .red
+        )
+        XCTAssertNotEqual(
+            result.attribute(
+                .foregroundColor,
+                at: string.range(of: "child").location,
+                effectiveRange: nil
+            ) as? UIColor,
+            .red
+        )
+    }
+
+    func testCheckedDecorationPreservesLinkColor() {
+        config.taskList.checkedTextColor = .red
+        let linkColor = config.link.foregroundColor
+        let result = MarkdownRenderer.render("- [x] see [docs](https://example.com)", config: config)
+        let location = (result.string as NSString).range(of: "docs").location
+
+        XCTAssertEqual(
+            result.attribute(.foregroundColor, at: location, effectiveRange: nil) as? UIColor,
+            linkColor
+        )
+    }
+
+    // MARK: - Theme element
+
+    func testTaskListThemeElementAppliesToConfig() {
+        var applied = MarkdownStyleConfig()
+        TaskList()
+            .checkedColor(Color(UIColor.systemGreen))
+            .borderColor(Color(UIColor.systemGray))
+            .checkmarkColor(Color(UIColor.black))
+            .checkedTextColor(Color(UIColor.systemGray2))
+            .checkboxSize(20)
+            .checkboxBorderRadius(5)
+            .checkedStrikethrough()
+            .apply(to: &applied, traitCollection: .current)
+
+        XCTAssertNotNil(applied.taskList.checkedColor)
+        XCTAssertNotNil(applied.taskList.borderColor)
+        XCTAssertNotNil(applied.taskList.checkmarkColor)
+        XCTAssertNotNil(applied.taskList.checkedTextColor)
+        XCTAssertEqual(applied.taskList.checkboxSize, 20)
+        XCTAssertEqual(applied.taskList.checkboxBorderRadius, 5)
+        XCTAssertEqual(applied.taskList.checkedStrikethrough, true)
+    }
+
+    func testDefaultThemeConfiguresCheckbox() {
+        XCTAssertEqual(config.taskList.checkboxSize, 14)
+        XCTAssertEqual(config.taskList.checkboxBorderRadius, 3)
+        XCTAssertNotNil(config.taskList.checkedColor)
+        XCTAssertNotNil(config.taskList.borderColor)
+        XCTAssertNotNil(config.taskList.checkmarkColor)
+        XCTAssertNil(config.taskList.checkedTextColor)
+    }
+
+    func testTaskListStyleMergePrefersOverlay() {
+        var base = TaskListStyle(checkedColor: .blue, checkboxSize: 14)
+        base.merge(TaskListStyle(checkboxSize: 20, checkedStrikethrough: true))
+
+        XCTAssertEqual(base.checkedColor, .blue)
+        XCTAssertEqual(base.checkboxSize, 20)
+        XCTAssertEqual(base.checkedStrikethrough, true)
+    }
+}


### PR DESCRIPTION
Task-list items (- [x] / - [ ]) now draw themed checkboxes in the decoration layer, matching the React Native package's geometry and TaskListStyle keys (checkedColor, borderColor, checkboxSize, checkboxBorderRadius, checkmarkColor, checkedTextColor, checkedStrikethrough). Checked items can optionally recolor and strike through their text; copy-as-HTML emits disabled checkbox inputs and VoiceOver announces the checked state.

The checkbox column widens to the list type's marker column so task items align with numbered siblings, and list items inside blockquotes now compose the quote offset into their own indent instead of having BlockquoteRenderer overwrite their paragraph styles (previously the marker column collapsed onto the quote border for any quoted list).

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

