### PR TITLE
feat(ios): bring the example Text screen to RN parity

### DIFF
--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Extensions/Color+Named.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Extensions/Color+Named.swift
@@ -36,6 +36,7 @@ extension Color {
     // MARK: - Markdown accents (Tailwind blue/violet)
 
     static var linkBlue: Color { Color(red: 37 / 255, green: 99 / 255, blue: 235 / 255) }
+    static var selectionPurple: Color { Color(red: 90 / 255, green: 82 / 255, blue: 250 / 255) }
     static var codeViolet: Color { Color(red: 124 / 255, green: 58 / 255, blue: 237 / 255) }
     static var codeVioletBackground: Color { Color(red: 245 / 255, green: 243 / 255, blue: 255 / 255) }
 }

--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Resources/sample_markdown.md
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Resources/sample_markdown.md
@@ -156,7 +156,7 @@ class TreeNetwork {
 
   connectTrees(tree1, tree2) {
     // Trees share nutrients through mycorrhizal networks
-    this.fungalConnections.set(`\${tree1.id}-\${tree2.id}`, {
+    this.fungalConnections.set(`${tree1.id}-${tree2.id}`, {
       nutrientFlow: 'bidirectional',
       signalTransmission: true
     });

--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Theme/ExampleMarkdownStyles.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Theme/ExampleMarkdownStyles.swift
@@ -117,6 +117,15 @@ let CustomMarkdownTheme = MarkdownTheme {
         .height(1)
         .marginTop(24)
         .marginBottom(24)
+
+    TaskList()
+        .checkedColor(Color.linkBlue)
+        .borderColor(Color.gray400)
+        .checkboxSize(18)
+        .checkboxBorderRadius(4)
+        .checkmarkColor(Color.white)
+        .checkedTextColor(Color.gray400)
+        .checkedStrikethrough(true)
 }
 
 /// Mirrors Android PlaygroundMarkdownStyle.

--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/AppShell.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/AppShell.swift
@@ -6,7 +6,7 @@ struct AppShell: View {
 
     @State private var path: [ExampleRoute] = []
     @State private var unavailableRouteName: String?
-    @State private var sampleMarkdown = ""
+    @State private var sampleMarkdown: String = Bundle.main.sampleMarkdown
 
     // MARK: - Views
 
@@ -20,11 +20,6 @@ struct AppShell: View {
                 }
         }
         .tint(Color.brandNavy)
-        .onAppear {
-            if sampleMarkdown.isEmpty {
-                sampleMarkdown = Bundle.main.sampleMarkdown
-            }
-        }
         .alert(
             unavailableRouteName.map { "\($0) is not available on iOS yet" } ?? "",
             isPresented: Binding(

--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Text/TextScreen.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Text/TextScreen.swift
@@ -6,20 +6,33 @@ struct TextScreen: View {
 
     let markdown: String
 
+    @State private var pressedLink: URL?
+    @State private var linkAlertVisible: Bool = false
+
     // MARK: - Views
 
     var body: some View {
         ScrollView {
-            EnrichedMarkdownText(markdown)
+            EnrichedMarkdownText(markdown, flags: Md4cFlags(superscript: true, subscript: true))
                 .markdownTheme(CustomMarkdownTheme)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 16)
                 .onLinkPress { url in
-                    UIApplication.shared.open(url)
+                    pressedLink = url
+                    linkAlertVisible = true
                 }
         }
         .background(Color.white)
+        .markdownSelectionColor(Color.selectionPurple)
+        .alert("Link Pressed!", isPresented: $linkAlertVisible, presenting: pressedLink) { url in
+            Button("Open in Browser") {
+                UIApplication.shared.open(url)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { url in
+            Text("You tapped on: \(url.absoluteString)")
+        }
     }
 }
 


### PR DESCRIPTION
### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

