### PR TITLE
fix(android): clean up text render executor

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -359,6 +359,15 @@ class EnrichedMarkdownText
       checkboxTouchHelper.isEnabled = enabled
     }
 
+    fun cleanup() {
+      currentRenderId++
+      executor.shutdownNow()
+      mainHandler.removeCallbacksAndMessages(null)
+      pendingStyledText = null
+      fadeAnimator?.cancelAll()
+      fadeAnimator = null
+    }
+
     override fun onAttachedToWindow() {
       super.onAttachedToWindow()
       pendingStyledText?.let {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -88,6 +88,7 @@ class EnrichedMarkdownTextManager :
 
   override fun onDropViewInstance(view: EnrichedMarkdownText) {
     super.onDropViewInstance(view)
+    view.cleanup()
     MeasurementStore.clearFontScalingSettings(view.id)
     MeasurementStore.clearBreakStrategy(view.id)
     view.layoutManager.releaseMeasurementStore()


### PR DESCRIPTION
## Summary

Each `EnrichedMarkdownText` created a background executor that stayed alive after React Native dropped the view. This change shuts it down and clears pending render work and animations.
