### PR TITLE
feat: support HTML line break tags

### DIFF
--- a/packages/android-enriched-markdown/parser/src/androidTest/java/com/swmansion/enriched/markdown/parser/ParserTest.kt
+++ b/packages/android-enriched-markdown/parser/src/androidTest/java/com/swmansion/enriched/markdown/parser/ParserTest.kt
@@ -131,6 +131,62 @@ class ParserTest {
   }
 
   @Test
+  fun parsesHtmlBreakTagsAsLineBreaks() {
+    for (tag in listOf("<br>", "<br/>", "<br />", "<BR>")) {
+      val ast = requireNotNull(parser.parseMarkdown("line one${tag}line two"))
+      val paragraph = ast.assertHasChildType(MarkdownASTNode.NodeType.Paragraph)
+
+      assertEquals(
+        "failed for $tag",
+        listOf(
+          MarkdownASTNode.NodeType.Text,
+          MarkdownASTNode.NodeType.LineBreak,
+          MarkdownASTNode.NodeType.Text,
+        ),
+        paragraph.children.map { it.type },
+      )
+      assertEquals("line one", paragraph.children.first().content)
+      assertEquals("line two", paragraph.children.last().content)
+    }
+  }
+
+  @Test
+  fun preservesOtherInlineHtmlAsText() {
+    val markdown = "before<span>inside</span><br class=\"ignored\">after"
+    val ast = requireNotNull(parser.parseMarkdown(markdown))
+    val paragraph = ast.assertHasChildType(MarkdownASTNode.NodeType.Paragraph)
+
+    assertEquals(listOf(MarkdownASTNode.NodeType.Text), paragraph.children.map { it.type })
+    assertEquals(markdown, paragraph.children.first().content)
+  }
+
+  @Test
+  fun preservesHtmlBreakInsideCodeSpan() {
+    val ast = requireNotNull(parser.parseMarkdown("`<br>`"))
+    val code = requireNotNull(ast.firstOfType(MarkdownASTNode.NodeType.Code))
+
+    assertEquals(listOf(MarkdownASTNode.NodeType.Text), code.children.map { it.type })
+    assertEquals("<br>", code.children.first().content)
+  }
+
+  @Test
+  fun parsesHtmlBreakInsideTableCell() {
+    val ast = requireNotNull(parser.parseMarkdown("| Header |\n| --- |\n| line one<br>line two |"))
+    val cell = requireNotNull(ast.firstOfType(MarkdownASTNode.NodeType.TableCell))
+
+    assertEquals(
+      listOf(
+        MarkdownASTNode.NodeType.Text,
+        MarkdownASTNode.NodeType.LineBreak,
+        MarkdownASTNode.NodeType.Text,
+      ),
+      cell.children.map { it.type },
+    )
+    assertEquals("line one", cell.children.first().content)
+    assertEquals("line two", cell.children.last().content)
+  }
+
+  @Test
   fun parsesDeeplyNestedBlockquotes() {
     val depth = 500
     val markdown = "> ".repeat(depth) + "deep"

--- a/packages/core/cpp/parser/MD4CParser.cpp
+++ b/packages/core/cpp/parser/MD4CParser.cpp
@@ -1,5 +1,6 @@
 #include "MD4CParser.hpp"
 #include "../md4c/md4c.h"
+#include <cctype>
 #include <cstring>
 #include <vector>
 
@@ -71,6 +72,36 @@ public:
     // Use string constructor directly - let SSO handle small strings efficiently
     // Empty return {} avoids allocating empty string object
     return std::string(attr->text, attr->size);
+  }
+
+  static bool isHtmlLineBreak(const MD_CHAR *text, MD_SIZE size) {
+    if (size < 4 || text[0] != '<') {
+      return false;
+    }
+
+    auto lowerAscii = [](MD_CHAR character) {
+      if (character >= 'A' && character <= 'Z') {
+        return static_cast<MD_CHAR>(character + ('a' - 'A'));
+      }
+      return character;
+    };
+
+    size_t offset = 1;
+    if (lowerAscii(text[offset++]) != 'b' || lowerAscii(text[offset++]) != 'r') {
+      return false;
+    }
+
+    while (offset < size && std::isspace(static_cast<unsigned char>(text[offset]))) {
+      offset++;
+    }
+    if (offset < size && text[offset] == '/') {
+      offset++;
+      while (offset < size && std::isspace(static_cast<unsigned char>(text[offset]))) {
+        offset++;
+      }
+    }
+
+    return offset + 1 == size && text[offset] == '>';
   }
 
   static int enterBlock(MD_BLOCKTYPE type, void *detail, void *userdata) {
@@ -364,6 +395,16 @@ public:
       return 0;
     }
 
+    if (type == MD_TEXT_HTML) {
+      if (isHtmlLineBreak(text, size)) {
+        impl->addInlineNode(std::make_shared<MarkdownASTNode>(NodeType::LineBreak));
+      } else {
+        // Inline HTML remains visible as literal text. Only <br> is interpreted.
+        impl->currentText.append(text, size);
+      }
+      return 0;
+    }
+
     // Handle text content (normal text, code text, LaTeX math, etc.)
     if (type == MD_TEXT_NORMAL || type == MD_TEXT_CODE || type == MD_TEXT_LATEXMATH) {
       impl->currentText.append(text, size);
@@ -589,7 +630,7 @@ std::shared_ptr<MarkdownASTNode> MD4CParser::parse(const std::string &markdown, 
   impl_->reset(estimatedDepth);
   impl_->inputText = markdown.c_str();
 
-  unsigned flags = MD_FLAG_NOHTML | MD_FLAG_STRIKETHROUGH | MD_FLAG_TABLES | MD_FLAG_TASKLISTS | MD_FLAG_SPOILERS;
+  unsigned flags = MD_FLAG_NOHTMLBLOCKS | MD_FLAG_STRIKETHROUGH | MD_FLAG_TABLES | MD_FLAG_TASKLISTS | MD_FLAG_SPOILERS;
   if (md4cFlags.permissiveAutolinks) {
     flags |= MD_FLAG_PERMISSIVEAUTOLINKS;
   }

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/ParserTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/ParserTests.swift
@@ -127,6 +127,47 @@ final class ParserTests: XCTestCase {
         XCTAssertNil(paragraph?.child(ofType: .softBreak))
     }
 
+    func testParsesHtmlBreakTagsAsLineBreaks() {
+        for tag in ["<br>", "<br/>", "<br />", "<BR>"] {
+            let ast = parser.parseMarkdown("line one\(tag)line two")
+            let paragraph = ast.child(ofType: .paragraph)
+
+            XCTAssertEqual(
+                paragraph?.children.map(\.type),
+                [.text, .lineBreak, .text],
+                "failed for \(tag)"
+            )
+            XCTAssertEqual(paragraph?.children.first?.content, "line one")
+            XCTAssertEqual(paragraph?.children.last?.content, "line two")
+        }
+    }
+
+    func testPreservesOtherInlineHtmlAsText() {
+        let markdown = "before<span>inside</span><br class=\"ignored\">after"
+        let ast = parser.parseMarkdown(markdown)
+        let paragraph = ast.child(ofType: .paragraph)
+
+        XCTAssertEqual(paragraph?.children.map(\.type), [.text])
+        XCTAssertEqual(paragraph?.children.first?.content, markdown)
+    }
+
+    func testPreservesHtmlBreakInsideCodeSpan() {
+        let ast = parser.parseMarkdown("`<br>`")
+        let code = ast.first(ofType: .code)
+
+        XCTAssertEqual(code?.children.map(\.type), [.text])
+        XCTAssertEqual(code?.children.first?.content, "<br>")
+    }
+
+    func testParsesHtmlBreakInsideTableCell() {
+        let ast = parser.parseMarkdown("| Header |\n| --- |\n| line one<br>line two |")
+        let cell = ast.first(ofType: .tableCell)
+
+        XCTAssertEqual(cell?.children.map(\.type), [.text, .lineBreak, .text])
+        XCTAssertEqual(cell?.children.first?.content, "line one")
+        XCTAssertEqual(cell?.children.last?.content, "line two")
+    }
+
     func testParsesDeeplyNestedBlockquotes() {
         let depth = 500
         let markdown = String(repeating: "> ", count: depth) + "deep"


### PR DESCRIPTION
### What/Why?

Support attribute-free HTML line break tags (`<br>`, `<br/>`, `<br />`, including case variants) in the shared Markdown parser.

The parser previously disabled all HTML tokenization, so these tags were emitted as literal text. This change keeps HTML blocks disabled, enables inline HTML tokenization, maps only supported `br` tokens to the existing `LineBreak` AST node, and appends every other inline HTML token as literal text. Tags with attributes and tags inside code spans remain literal.

This also covers `br` inside GFM table cells.

Closes #52.

### Testing

- RED/GREEN standalone C++ parser harness, including paragraph, table, unsupported HTML, and code-span cases
- Full iOS `EnrichedMarkdown` XCTest suite on iPhone 17 Pro simulator
- Android parser native build for armv7, arm64, x86, and x86_64
- Android instrumentation-test APK compilation
- Android unit tests and ktlint
- C++ clang-format check
- `yarn lint`
- `yarn typecheck`
- `yarn test` — 6/6 tests
- `yarn prepare`

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)