### PR TITLE
feat(ios): render documents as stacked segments

### DIFF
--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/AsyncRenderCoordinator.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/AsyncRenderCoordinator.swift
@@ -11,9 +11,9 @@ final class AsyncRenderCoordinator {
         queue = DispatchQueue(label: queueLabel)
     }
 
-    func scheduleRender(
-        _ render: @escaping () -> NSAttributedString?,
-        apply: @escaping (NSAttributedString) -> Void
+    func scheduleRender<Result>(
+        _ render: @escaping () -> Result?,
+        apply: @escaping (Result) -> Void
     ) {
         if blockAsyncRender {
             return

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/MarkdownSegmentRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/MarkdownSegmentRenderer.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+/// One vertically stacked piece of a rendered document. Today every document
+/// renders as a single text segment; table support will interleave natively
+/// rendered table segments between text segments.
+struct RenderedMarkdownSegment: Identifiable, Equatable {
+    enum Content: Equatable {
+        case text(NSAttributedString)
+    }
+
+    /// Position within the rendered document. Segments are only consumed as
+    /// a whole array from one render pass, so positional identity is stable.
+    let id: Int
+    let content: Content
+}
+
+enum MarkdownSegmentRenderer {
+    /// The placeholder for blank input: a single empty text segment, so the
+    /// view tree (and its sizing) matches what an empty attributed string
+    /// produced before segmentation existed.
+    static let empty: [RenderedMarkdownSegment] = [
+        RenderedMarkdownSegment(id: 0, content: .text(NSAttributedString()))
+    ]
+
+    static func renderSegments(
+        _ markdown: String,
+        config: MarkdownStyleConfig,
+        flags: Md4cFlags = .commonMark,
+        imageRequestHeaders: [String: String] = [:]
+    ) -> [RenderedMarkdownSegment] {
+        let text = MarkdownRenderer.render(
+            markdown,
+            config: config,
+            flags: flags,
+            imageRequestHeaders: imageRequestHeaders
+        )
+        return [RenderedMarkdownSegment(id: 0, content: .text(text))]
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -30,16 +30,17 @@ public struct EnrichedMarkdownText: View {
     }
 
     public var body: some View {
-        MarkdownTextViewRepresentable(
-            attributedText: renderStore.attributedText,
-            sourceMarkdown: renderStore.sourceMarkdown,
-            styleConfig: styleConfig,
-            onLinkPress: onLinkPress,
-            onLinkLongPress: onLinkLongPress,
-            selectionMenuConfig: selectionMenuConfig,
-            isSelectionEnabled: isSelectionEnabled,
-            selectionColor: selectionColor
-        )
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(renderStore.segments) { segment in
+                segmentView(for: segment)
+            }
+        }
+        // On the stack, not per segment: as the outermost layout modifier it
+        // receives the parent's real width proposal and forwards it to every
+        // segment, so heights are measured at the width the segments are
+        // actually laid out with. Per-segment fixedSize let an ideal-size
+        // probe at a different width supply the final height (25pt of
+        // phantom bottom space in containers like ScrollView + padding).
         .fixedSize(horizontal: false, vertical: true)
         .onAppear {
             renderStore.schedule(
@@ -86,6 +87,23 @@ public struct EnrichedMarkdownText: View {
         }
         .onDisappear {
             renderStore.invalidate()
+        }
+    }
+
+    @ViewBuilder
+    private func segmentView(for segment: RenderedMarkdownSegment) -> some View {
+        switch segment.content {
+        case .text(let attributedText):
+            MarkdownTextViewRepresentable(
+                attributedText: attributedText,
+                sourceMarkdown: renderStore.sourceMarkdown,
+                styleConfig: styleConfig,
+                onLinkPress: onLinkPress,
+                onLinkLongPress: onLinkLongPress,
+                selectionMenuConfig: selectionMenuConfig,
+                isSelectionEnabled: isSelectionEnabled,
+                selectionColor: selectionColor
+            )
         }
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownRenderStore.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownRenderStore.swift
@@ -3,8 +3,8 @@ import UIKit
 
 @MainActor
 final class MarkdownRenderStore: ObservableObject {
-    @Published private(set) var attributedText = NSAttributedString()
-    // Published together with `attributedText` so consumers never pair a new
+    @Published private(set) var segments = MarkdownSegmentRenderer.empty
+    // Published together with `segments` so consumers never pair a new
     // markdown string with a stale render result.
     @Published private(set) var sourceMarkdown: String?
 
@@ -17,20 +17,20 @@ final class MarkdownRenderStore: ObservableObject {
         imageRequestHeaders: [String: String] = [:]
     ) {
         if isBlank(markdown) {
-            attributedText = NSAttributedString()
+            segments = MarkdownSegmentRenderer.empty
             sourceMarkdown = nil
             return
         }
 
         coordinator.scheduleRender {
-            MarkdownRenderer.render(
+            MarkdownSegmentRenderer.renderSegments(
                 markdown,
                 config: config,
                 flags: flags,
                 imageRequestHeaders: imageRequestHeaders
             )
         } apply: { [weak self] result in
-            self?.attributedText = result
+            self?.segments = result
             self?.sourceMarkdown = markdown
         }
     }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -40,6 +40,15 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
 
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: MarkdownTextView, context: Context) -> CGSize? {
         let width = proposal.width ?? UIScreen.main.bounds.width
+        // TextKit 2 measures trailing spacer fragments against the current
+        // container layout, so a view whose layout hasn't settled at the
+        // target width over-reports height. Give the view its target width
+        // and flush layout before measuring so the answer is the same no
+        // matter when in the layout cycle SwiftUI asks.
+        if uiView.bounds.width != width {
+            uiView.frame.size.width = width
+        }
+        uiView.layoutIfNeeded()
         let size = uiView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
         return CGSize(width: width, height: size.height)
     }

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/AsyncRenderCoordinatorTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/AsyncRenderCoordinatorTests.swift
@@ -78,7 +78,7 @@ final class AsyncRenderCoordinatorTests: XCTestCase {
         let applyExpectation = expectation(description: "apply")
         applyExpectation.isInverted = true
 
-        coordinator.scheduleRender({
+        coordinator.scheduleRender({ () -> NSAttributedString? in
             nil
         }, apply: { _ in
             applyExpectation.fulfill()

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/EnrichedMarkdownTextLayoutTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/EnrichedMarkdownTextLayoutTests.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+/// Hosts `EnrichedMarkdownText` the way apps embed it (scroll view, flexible
+/// frame, padding) and checks that the text view's final frame matches its
+/// settled content height — the segment pipeline and the representable's
+/// measurement must not add or drop vertical space.
+@MainActor
+final class EnrichedMarkdownTextLayoutTests: XCTestCase {
+    func testHostedTextViewFrameMatchesSettledContentHeight() {
+        let markdown = "# Groceries\n\n- [x] milk with **bold** text\n- [ ] eggs\n- plain\n\n1. one\n2. two"
+        let root = ScrollView {
+            EnrichedMarkdownText(markdown)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(14)
+        }
+
+        let host = UIHostingController(rootView: root)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 380, height: 1200))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+
+        var textView: MarkdownTextView?
+        for _ in 0..<60 {
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            host.view.layoutIfNeeded()
+            textView = findTextView(in: host.view)
+            if let textView, textView.attributedText?.length ?? 0 > 0 {
+                break
+            }
+        }
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.2))
+        host.view.layoutIfNeeded()
+        window.isHidden = true
+
+        guard let textView else { return XCTFail("markdown text view never appeared") }
+        textView.layoutIfNeeded()
+        let settled = textView.sizeThatFits(
+            CGSize(width: textView.frame.width, height: .greatestFiniteMagnitude)
+        ).height
+
+        XCTAssertGreaterThan(settled, 50)
+        XCTAssertEqual(textView.frame.height, settled, accuracy: 1.0)
+    }
+
+    private func findTextView(in view: UIView) -> MarkdownTextView? {
+        if let textView = view as? MarkdownTextView { return textView }
+        for subview in view.subviews {
+            if let found = findTextView(in: subview) { return found }
+        }
+        return nil
+    }
+}

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/MarkdownSegmentRendererTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/MarkdownSegmentRendererTests.swift
@@ -1,0 +1,88 @@
+import Combine
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+final class MarkdownSegmentRendererTests: XCTestCase {
+    private var config: MarkdownStyleConfig!
+
+    override func setUp() {
+        super.setUp()
+        config = MarkdownStyleConfig.baseline()
+    }
+
+    func testDocumentRendersAsSingleTextSegment() {
+        let segments = MarkdownSegmentRenderer.renderSegments(
+            "# Title\n\nSome **bold** text\n\n- [x] a task",
+            config: config
+        )
+
+        XCTAssertEqual(segments.count, 1)
+        guard case .text(let text) = segments[0].content else {
+            return XCTFail("expected a text segment")
+        }
+        XCTAssertTrue(text.string.contains("Title"))
+        XCTAssertTrue(text.string.contains("a task"))
+    }
+
+    /// Segmentation must not change rendering: the single segment's content
+    /// is exactly what the direct renderer produces for the same input.
+    func testTextSegmentMatchesDirectRender() {
+        let markdown = "# Hello\n\n> quote\n\n- one\n- [ ] two"
+        let segments = MarkdownSegmentRenderer.renderSegments(markdown, config: config)
+        let direct = MarkdownRenderer.render(markdown, config: config)
+
+        guard case .text(let text) = segments[0].content else {
+            return XCTFail("expected a text segment")
+        }
+        XCTAssertTrue(text.isEqual(to: direct))
+    }
+
+    func testEmptyPlaceholderIsSingleEmptyTextSegment() {
+        XCTAssertEqual(MarkdownSegmentRenderer.empty.count, 1)
+        guard case .text(let text) = MarkdownSegmentRenderer.empty[0].content else {
+            return XCTFail("expected a text segment")
+        }
+        XCTAssertEqual(text.length, 0)
+    }
+}
+
+@MainActor
+final class MarkdownRenderStoreTests: XCTestCase {
+    func testInitialStateIsEmptyPlaceholder() {
+        let store = MarkdownRenderStore()
+
+        XCTAssertEqual(store.segments, MarkdownSegmentRenderer.empty)
+        XCTAssertNil(store.sourceMarkdown)
+    }
+
+    func testBlankMarkdownResetsSynchronously() {
+        let store = MarkdownRenderStore()
+
+        store.schedule(markdown: "   ", config: .baseline())
+
+        XCTAssertEqual(store.segments, MarkdownSegmentRenderer.empty)
+        XCTAssertNil(store.sourceMarkdown)
+    }
+
+    func testScheduleAppliesRenderedSegmentsWithSource() {
+        let store = MarkdownRenderStore()
+        let applied = expectation(description: "segments applied")
+
+        let cancellable = store.$segments.dropFirst().sink { segments in
+            XCTAssertEqual(segments.count, 1)
+            if case .text(let text) = segments[0].content {
+                XCTAssertTrue(text.string.contains("Hello"))
+            } else {
+                XCTFail("expected a text segment")
+            }
+            applied.fulfill()
+        }
+
+        store.schedule(markdown: "# Hello", config: .baseline())
+
+        wait(for: [applied], timeout: 2)
+        cancellable.cancel()
+        XCTAssertEqual(store.sourceMarkdown, "# Hello")
+    }
+}


### PR DESCRIPTION
Rendering now produces a list of vertically stacked segments instead of one attributed string: MarkdownSegmentRenderer emits the segment array (a single text segment today), MarkdownRenderStore publishes it, and EnrichedMarkdownText lays segments out in a VStack. This is the groundwork for rendering GFM tables as native views between text segments; current documents always produce exactly one text segment, so rendering is unchanged. The public MarkdownRenderer API is untouched.

Also fixes a latent measurement bug the new layout surfaced: MarkdownTextViewRepresentable.sizeThatFits answered with ~26pt of extra trailing-spacer height whenever TextKit 2 had not yet settled at the target width, and the stack changed query timing so the inflated first answer became the final frame. The view now receives its target width and flushes layout before measuring, making the answer independent of when SwiftUI asks. A regression test hosts the view in a ScrollView-plus-padding context and pins the text view frame to its settled content height.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

