### PR TITLE
fix(ios): redraw table images after async loading

### DIFF
--- a/packages/react-native-enriched-markdown/ios/attachments/ENRMImageAttachment.h
+++ b/packages/react-native-enriched-markdown/ios/attachments/ENRMImageAttachment.h
@@ -2,6 +2,7 @@
 #import "ENRMUIKit.h"
 
 @class StyleConfig;
+@class ENRMImageAttachment;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -12,6 +13,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol ENRMImageLayoutObserver
 - (void)imageAttachmentDidResolveLayout;
+@end
+
+/**
+ * Adopted by renderers that draw image attachments without a UITextView.
+ * Observers are held weakly and notified on the main thread when processed
+ * display content changes.
+ */
+@protocol ENRMImageDisplayObserver
+- (void)imageAttachmentDidUpdateDisplay:(ENRMImageAttachment *)attachment;
 @end
 
 /**
@@ -30,6 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSCache<NSString *, RCTUIImage *> *)originalImageCache;
 + (NSCache<NSString *, RCTUIImage *> *)processedImageCache;
+
+- (void)addDisplayObserver:(id<ENRMImageDisplayObserver>)observer;
+- (void)removeDisplayObserver:(id<ENRMImageDisplayObserver>)observer;
 
 @end
 

--- a/packages/react-native-enriched-markdown/ios/attachments/ENRMImageAttachment.m
+++ b/packages/react-native-enriched-markdown/ios/attachments/ENRMImageAttachment.m
@@ -36,6 +36,7 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
 @property (nonatomic, strong) RCTUIImage *loadedImage;
 @property (nonatomic, strong) RCTUIImage *placeholderImage;
 @property (nonatomic, copy) NSString *lastProcessedKey;
+@property (nonatomic, strong) NSHashTable<id<ENRMImageDisplayObserver>> *displayObservers;
 
 @end
 
@@ -102,6 +103,8 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
     _cachedAspectRatio = [config imageAspectRatio];
     _cachedResizeMode = [config imageResizeMode];
     _cachedBorderRadius = [config imageBorderRadius];
+    _displayObservers =
+        [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality];
 
     [self setupPlaceholder];
     [self startDownloadingImage];
@@ -335,6 +338,18 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
 
 - (void)refreshDisplay
 {
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), ^{ [self refreshDisplay]; });
+    return;
+  }
+
+  if (self.loadedImage) {
+    NSArray<id<ENRMImageDisplayObserver>> *observers = self.displayObservers.allObjects;
+    for (id<ENRMImageDisplayObserver> observer in observers) {
+      [observer imageAttachmentDidUpdateDisplay:self];
+    }
+  }
+
   UITextView *textView = [self fetchAssociatedTextView];
   if (!textView)
     return;
@@ -347,6 +362,42 @@ static NSMapTable<NSString *, ENRMImageAttachment *> *_attachmentRegistry;
       [self notifyImageLayoutObserver:textView];
     }
   }
+}
+
+- (void)addDisplayObserver:(id<ENRMImageDisplayObserver>)observer
+{
+  if (!NSThread.isMainThread) {
+    __weak typeof(self) weakSelf = self;
+    __weak id<ENRMImageDisplayObserver> weakObserver = observer;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      id<ENRMImageDisplayObserver> strongObserver = weakObserver;
+      if (strongSelf && strongObserver) {
+        [strongSelf.displayObservers addObject:strongObserver];
+      }
+    });
+    return;
+  }
+
+  [self.displayObservers addObject:observer];
+}
+
+- (void)removeDisplayObserver:(id<ENRMImageDisplayObserver>)observer
+{
+  if (!NSThread.isMainThread) {
+    __weak typeof(self) weakSelf = self;
+    __weak id<ENRMImageDisplayObserver> weakObserver = observer;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      id<ENRMImageDisplayObserver> strongObserver = weakObserver;
+      if (strongSelf && strongObserver) {
+        [strongSelf.displayObservers removeObject:strongObserver];
+      }
+    });
+    return;
+  }
+
+  [self.displayObservers removeObject:observer];
 }
 
 // With maxHeight/aspectRatio sizing the box height can settle after the image

--- a/packages/react-native-enriched-markdown/ios/views/ENRMTableIOSGridView.m
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMTableIOSGridView.m
@@ -1,12 +1,17 @@
 #import "ENRMTableIOSGridView.h"
+#import "ENRMImageAttachment.h"
 
 #if !TARGET_OS_OSX
 
 @implementation ENRMTableIOSRowData
 @end
 
+@interface ENRMTableIOSGridView () <ENRMImageDisplayObserver>
+@end
+
 @implementation ENRMTableIOSGridView {
   NSArray<ENRMTableIOSRowData *> *_tableRows;
+  NSArray<ENRMImageAttachment *> *_observedImageAttachments;
   NSArray<NSNumber *> *_columnWidths;
   NSArray<NSNumber *> *_rowHeights;
   UIColor *_borderColor;
@@ -36,6 +41,43 @@
 
 #pragma mark - Data
 
+- (NSArray<ENRMImageAttachment *> *)uniqueImageAttachmentsInRows:(NSArray<ENRMTableIOSRowData *> *)rows
+{
+  NSHashTable<ENRMImageAttachment *> *uniqueAttachments =
+      [NSHashTable hashTableWithOptions:NSPointerFunctionsStrongMemory | NSPointerFunctionsObjectPointerPersonality];
+
+  for (ENRMTableIOSRowData *row in rows) {
+    for (NSAttributedString *cellText in row.cellTexts) {
+      if (cellText.length == 0)
+        continue;
+
+      [cellText enumerateAttribute:NSAttachmentAttributeName
+                           inRange:NSMakeRange(0, cellText.length)
+                           options:0
+                        usingBlock:^(id value, NSRange range, BOOL *stop) {
+                          if ([value isKindOfClass:[ENRMImageAttachment class]]) {
+                            [uniqueAttachments addObject:(ENRMImageAttachment *)value];
+                          }
+                        }];
+    }
+  }
+
+  return uniqueAttachments.allObjects;
+}
+
+- (void)replaceObservedImageAttachments:(NSArray<ENRMImageAttachment *> *)attachments
+{
+  for (ENRMImageAttachment *attachment in _observedImageAttachments) {
+    [attachment removeDisplayObserver:self];
+  }
+
+  _observedImageAttachments = [attachments copy];
+
+  for (ENRMImageAttachment *attachment in _observedImageAttachments) {
+    [attachment addDisplayObserver:self];
+  }
+}
+
 - (void)updateWithRows:(NSArray<ENRMTableIOSRowData *> *)rows
              columnWidths:(NSArray<NSNumber *> *)columnWidths
                rowHeights:(NSArray<NSNumber *> *)rowHeights
@@ -45,6 +87,8 @@
       verticalCellPadding:(CGFloat)verticalCellPadding
              cornerRadius:(CGFloat)cornerRadius
 {
+  NSArray<ENRMImageAttachment *> *imageAttachments = [self uniqueImageAttachmentsInRows:rows];
+  [self replaceObservedImageAttachments:imageAttachments];
   _tableRows = [rows copy];
   _columnWidths = [columnWidths copy];
   _rowHeights = [rowHeights copy];
@@ -52,6 +96,18 @@
   _borderWidth = borderWidth;
   _horizontalCellPadding = horizontalCellPadding;
   _verticalCellPadding = verticalCellPadding;
+  [self setNeedsDisplay];
+}
+
+- (void)dealloc
+{
+  for (ENRMImageAttachment *attachment in _observedImageAttachments) {
+    [attachment removeDisplayObserver:self];
+  }
+}
+
+- (void)imageAttachmentDidUpdateDisplay:(ENRMImageAttachment *)attachment
+{
   [self setNeedsDisplay];
 }
 


### PR DESCRIPTION
Table-backed Markdown images on iOS now redraw when their asynchronous image content resolves, so grammar tables no longer remain blank after a cold load.

The renderer keeps its single `drawRect:` table path and existing text-view invalidation behavior. Table grids register as weak, pointer-identity display observers for their image attachments, redraw on completion, and replace/remove registrations as rows change or the grid is released. This was verified with focused observer behavior coverage and a cold-load native iOS check of the affected grammar table.

Generated with OpenAI Codex
