### PR TITLE
feat(ios): render GFM tables as live text attachments

### DIFF
--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Attachments/TableAttachment.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Attachments/TableAttachment.swift
@@ -1,0 +1,126 @@
+import UIKit
+import UniformTypeIdentifiers
+
+struct TableCellModel: Equatable {
+    let attributedText: NSAttributedString
+    let isHeader: Bool
+}
+
+struct TableModel: Equatable {
+    let rows: [[TableCellModel]]
+    let columnCount: Int
+}
+
+/// RN-parity defaults; theme plumbing comes with the production table work.
+struct TableAttachmentStyle {
+    static let `default` = TableAttachmentStyle()
+
+    var textColor = UIColor(red: 0.12, green: 0.16, blue: 0.22, alpha: 1)
+    var headerTextColor = UIColor(red: 0.07, green: 0.09, blue: 0.15, alpha: 1)
+    var headerBackground = UIColor(red: 0.95, green: 0.96, blue: 0.96, alpha: 1)
+    var rowEvenBackground = UIColor.white
+    var rowOddBackground = UIColor(red: 0.98, green: 0.98, blue: 0.99, alpha: 1)
+    var borderColor = UIColor(red: 0.90, green: 0.91, blue: 0.92, alpha: 1)
+    var borderWidth: CGFloat = 1
+    var cornerRadius: CGFloat = 6
+    var fontSize: CGFloat = 14
+    var cellPaddingHorizontal: CGFloat = 12
+    var cellPaddingVertical: CGFloat = 8
+    var marginBottom: CGFloat = 16
+
+    static let minColumnWidth: CGFloat = 60
+    static let maxColumnWidth: CGFloat = 300
+}
+
+/// Two-pass intrinsic column sizing ported from the React Native package.
+/// Totals include one border width because adjacent cell strokes overlap.
+struct TableAttachmentLayout: Equatable {
+    let columnWidths: [CGFloat]
+    let rowHeights: [CGFloat]
+    let totalWidth: CGFloat
+    let totalHeight: CGFloat
+
+    static func compute(model: TableModel, style: TableAttachmentStyle) -> TableAttachmentLayout {
+        let horizontalPadding = style.cellPaddingHorizontal * 2
+        let verticalPadding = style.cellPaddingVertical * 2
+        var columnWidths = [CGFloat](repeating: 0, count: model.columnCount)
+
+        for row in model.rows {
+            for (column, cell) in row.enumerated() {
+                let bounding = cell.attributedText.boundingRect(
+                    with: CGSize(width: Self.maxColumnWidth, height: .greatestFiniteMagnitude),
+                    options: [.usesLineFragmentOrigin, .usesFontLeading],
+                    context: nil
+                )
+                let width = min(
+                    max(ceil(bounding.width) + horizontalPadding, Self.minColumnWidth),
+                    Self.maxColumnWidth + horizontalPadding
+                )
+                columnWidths[column] = max(columnWidths[column], width)
+            }
+        }
+
+        var rowHeights: [CGFloat] = []
+        for row in model.rows {
+            var rowHeight: CGFloat = 0
+            for (column, cell) in row.enumerated() {
+                let availableWidth = columnWidths[column] - horizontalPadding
+                let bounding = cell.attributedText.boundingRect(
+                    with: CGSize(width: availableWidth, height: .greatestFiniteMagnitude),
+                    options: [.usesLineFragmentOrigin, .usesFontLeading],
+                    context: nil
+                )
+                rowHeight = max(rowHeight, ceil(bounding.height) + verticalPadding)
+            }
+            rowHeights.append(rowHeight)
+        }
+
+        return TableAttachmentLayout(
+            columnWidths: columnWidths,
+            rowHeights: rowHeights,
+            totalWidth: columnWidths.reduce(0, +) + style.borderWidth,
+            totalHeight: rowHeights.reduce(0, +) + style.borderWidth
+        )
+    }
+
+    private static var minColumnWidth: CGFloat { TableAttachmentStyle.minColumnWidth }
+    private static var maxColumnWidth: CGFloat { TableAttachmentStyle.maxColumnWidth }
+}
+
+/// A GFM table embedded as a full-width block attachment whose view
+/// provider hosts the live grid view.
+final class TableAttachment: NSTextAttachment {
+    /// Must be a resolvable UTI — NSTextAttachment silently drops any other
+    /// string, which breaks the provider-class lookup.
+    static let fileType: String = UTType(
+        filenameExtension: "enriched-markdown-table"
+    )?.identifier ?? "public.data"
+
+    /// UIKit installs the view only via this registration; overriding
+    /// `viewProvider(for:...)` on the attachment breaks it.
+    private static let providerRegistration: Void = {
+        NSTextAttachment.registerViewProviderClass(
+            TableAttachmentViewProvider.self,
+            forFileType: TableAttachment.fileType
+        )
+    }()
+
+    let model: TableModel
+    let layout: TableAttachmentLayout
+    let style: TableAttachmentStyle
+
+    init(model: TableModel, style: TableAttachmentStyle) {
+        self.model = model
+        self.style = style
+        self.layout = TableAttachmentLayout.compute(model: model, style: style)
+        _ = Self.providerRegistration
+        // fileType only persists with non-nil contents; the data is never read.
+        super.init(data: Data("table".utf8), ofType: Self.fileType)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Attachments/TableAttachmentView.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Attachments/TableAttachmentView.swift
@@ -1,0 +1,156 @@
+import UIKit
+
+/// TextKit 2 creates and destroys providers with viewport layout, so all
+/// state lives on the attachment.
+final class TableAttachmentViewProvider: NSTextAttachmentViewProvider {
+    override init(
+        textAttachment: NSTextAttachment,
+        parentView: UIView?,
+        textLayoutManager: NSTextLayoutManager?,
+        location: NSTextLocation
+    ) {
+        super.init(
+            textAttachment: textAttachment,
+            parentView: parentView,
+            textLayoutManager: textLayoutManager,
+            location: location
+        )
+        tracksTextAttachmentViewBounds = true
+    }
+
+    override func loadView() {
+        guard let attachment = textAttachment as? TableAttachment else {
+            view = UIView()
+            return
+        }
+        view = TableAttachmentView(
+            model: attachment.model,
+            layout: attachment.layout,
+            style: attachment.style
+        )
+    }
+
+    override func attachmentBounds(
+        for attributes: [NSAttributedString.Key: Any],
+        location: NSTextLocation,
+        textContainer: NSTextContainer?,
+        proposedLineFragment: CGRect,
+        position: CGPoint
+    ) -> CGRect {
+        guard let attachment = textAttachment as? TableAttachment else { return .zero }
+        return CGRect(x: 0, y: 0, width: proposedLineFragment.width, height: attachment.layout.totalHeight)
+    }
+}
+
+final class TableAttachmentView: UIView {
+    private let scrollView = UIScrollView()
+    private let gridView: TableGridView
+    private let layout: TableAttachmentLayout
+    private let style: TableAttachmentStyle
+
+    init(model: TableModel, layout: TableAttachmentLayout, style: TableAttachmentStyle) {
+        self.gridView = TableGridView(model: model, layout: layout, style: style)
+        self.layout = layout
+        self.style = style
+        super.init(frame: .zero)
+
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = true
+        scrollView.alwaysBounceVertical = false
+        addSubview(scrollView)
+
+        gridView.backgroundColor = .clear
+        gridView.layer.cornerRadius = style.cornerRadius
+        gridView.layer.masksToBounds = true
+        scrollView.addSubview(gridView)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        scrollView.frame = bounds
+        gridView.frame = CGRect(x: 0, y: 0, width: layout.totalWidth, height: layout.totalHeight)
+        scrollView.contentSize = gridView.frame.size
+        scrollView.isScrollEnabled = layout.totalWidth > bounds.width
+    }
+}
+
+/// Draws the whole grid in one pass; cell rects overlap by one border width
+/// so adjacent strokes coincide.
+final class TableGridView: UIView {
+    private let model: TableModel
+    private let layout: TableAttachmentLayout
+    private let style: TableAttachmentStyle
+
+    init(model: TableModel, layout: TableAttachmentLayout, style: TableAttachmentStyle) {
+        self.model = model
+        self.layout = layout
+        self.style = style
+        super.init(frame: .zero)
+        isOpaque = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard let context = UIGraphicsGetCurrentContext() else { return }
+
+        var yOffset: CGFloat = 0
+        var bodyRowIndex = 0
+        for (rowIndex, row) in model.rows.enumerated() {
+            let rowHeight = layout.rowHeights[rowIndex]
+            let isHeaderRow = row.first?.isHeader ?? false
+            let background = rowBackground(isHeader: isHeaderRow, bodyRowIndex: bodyRowIndex)
+            if !isHeaderRow {
+                bodyRowIndex += 1
+            }
+
+            var xOffset: CGFloat = 0
+            for column in 0..<model.columnCount {
+                let columnWidth = layout.columnWidths[column]
+                let cellRect = CGRect(
+                    x: xOffset,
+                    y: yOffset,
+                    width: columnWidth + style.borderWidth,
+                    height: rowHeight + style.borderWidth
+                )
+
+                context.setFillColor(background.cgColor)
+                context.fill(cellRect)
+                context.setStrokeColor(style.borderColor.cgColor)
+                context.setLineWidth(style.borderWidth)
+                context.stroke(cellRect)
+
+                if column < row.count {
+                    let textRect = CGRect(
+                        x: xOffset + style.cellPaddingHorizontal,
+                        y: yOffset + style.cellPaddingVertical,
+                        width: columnWidth - style.cellPaddingHorizontal * 2,
+                        height: rowHeight - style.cellPaddingVertical * 2
+                    )
+                    row[column].attributedText.draw(
+                        with: textRect,
+                        options: [.usesLineFragmentOrigin, .usesFontLeading],
+                        context: nil
+                    )
+                }
+                xOffset += columnWidth
+            }
+            yOffset += rowHeight
+        }
+    }
+
+    private func rowBackground(isHeader: Bool, bodyRowIndex: Int) -> UIColor {
+        if isHeader {
+            return style.headerBackground
+        }
+        return bodyRowIndex.isMultiple(of: 2) ? style.rowEvenBackground : style.rowOddBackground
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
@@ -89,6 +89,8 @@ final class RendererFactory {
             return ListRenderer(factory: self, config: config, isOrdered: true)
         case .listItem:
             return ListItemRenderer(factory: self, config: config)
+        case .table:
+            return TableRenderer(factory: self, config: config)
         default:
             return nil
         }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/TableRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/TableRenderer.swift
@@ -1,0 +1,98 @@
+import UIKit
+
+/// Renders a GFM table as a view-provider attachment; cell content goes
+/// through the regular renderer factory.
+final class TableRenderer: NodeRenderer {
+    private let factory: RendererFactory
+    private let config: MarkdownStyleConfig
+
+    init(factory: RendererFactory, config: MarkdownStyleConfig) {
+        self.factory = factory
+        self.config = config
+    }
+
+    func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
+        let style = TableAttachmentStyle.default
+        let model = buildModel(from: node, style: style)
+        guard !model.rows.isEmpty, model.columnCount > 0 else { return }
+
+        ParagraphStyleHelpers.ensureStartingOnNewLine(in: output)
+        let attachment = TableAttachment(model: model, style: style)
+        output.append(NSAttributedString(attachment: attachment))
+        output.append(NSAttributedString(string: "\n"))
+        ParagraphStyleHelpers.applyBlockSpacingAfter(to: output, marginBottom: style.marginBottom)
+    }
+
+    private func buildModel(from node: MarkdownASTNode, style: TableAttachmentStyle) -> TableModel {
+        var rows: [[TableCellModel]] = []
+        var columnCount = 0
+
+        for section in node.children where section.type == .tableHead || section.type == .tableBody {
+            let sectionIsHead = section.type == .tableHead
+            for rowNode in section.children where rowNode.type == .tableRow {
+                var cells: [TableCellModel] = []
+                for cellNode in rowNode.children
+                where cellNode.type == .tableHeaderCell || cellNode.type == .tableCell {
+                    let isHeader = sectionIsHead || cellNode.type == .tableHeaderCell
+                    cells.append(TableCellModel(
+                        attributedText: renderCell(cellNode, isHeader: isHeader, style: style),
+                        isHeader: isHeader
+                    ))
+                }
+                columnCount = max(columnCount, cells.count)
+                rows.append(cells)
+            }
+        }
+
+        return TableModel(rows: rows, columnCount: columnCount)
+    }
+
+    private func renderCell(
+        _ cellNode: MarkdownASTNode,
+        isHeader: Bool,
+        style: TableAttachmentStyle
+    ) -> NSAttributedString {
+        let cellOutput = NSMutableAttributedString()
+        let cellContext = RenderContext()
+        cellContext.setBlockStyle(
+            font: cellFont(isHeader: isHeader, style: style),
+            color: isHeader ? style.headerTextColor : style.textColor
+        )
+        factory.renderChildren(of: cellNode, into: cellOutput, context: cellContext)
+        trimTrailingNewlines(in: cellOutput)
+        applyAlignment(cellNode.attribute("align"), to: cellOutput)
+        return cellOutput
+    }
+
+    private func cellFont(isHeader: Bool, style: TableAttachmentStyle) -> UIFont {
+        let base = (config.paragraph.font ?? UIFont.preferredFont(forTextStyle: .body))
+            .withSize(style.fontSize)
+        guard isHeader else { return base }
+        guard let boldDescriptor = base.fontDescriptor.withSymbolicTraits(.traitBold) else {
+            return base
+        }
+        return UIFont(descriptor: boldDescriptor, size: style.fontSize)
+    }
+
+    private func applyAlignment(_ align: String?, to cellOutput: NSMutableAttributedString) {
+        let alignment: NSTextAlignment
+        switch align {
+        case "center": alignment = .center
+        case "right": alignment = .right
+        default: return
+        }
+
+        let range = NSRange(location: 0, length: cellOutput.length)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = alignment
+        cellOutput.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
+    }
+
+    private func trimTrailingNewlines(in cellOutput: NSMutableAttributedString) {
+        while cellOutput.length > 0,
+              let scalar = Unicode.Scalar((cellOutput.string as NSString).character(at: cellOutput.length - 1)),
+              CharacterSet.whitespacesAndNewlines.contains(scalar) {
+            cellOutput.deleteCharacters(in: NSRange(location: cellOutput.length - 1, length: 1))
+        }
+    }
+}

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/TableAttachmentTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/TableAttachmentTests.swift
@@ -1,0 +1,97 @@
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+@MainActor
+final class TableAttachmentTests: XCTestCase {
+    private var config: MarkdownStyleConfig!
+
+    override func setUp() {
+        super.setUp()
+        config = MarkdownStyleConfig.baseline()
+    }
+
+    func testTableRendersAsSingleAttachment() {
+        let rendered = MarkdownRenderer.render(
+            "before\n\n| A | B |\n|---|---|\n| one | two |\n\nafter",
+            config: config
+        )
+
+        var attachments: [TableAttachment] = []
+        rendered.enumerateAttribute(.attachment, in: NSRange(location: 0, length: rendered.length)) { value, _, _ in
+            if let table = value as? TableAttachment { attachments.append(table) }
+        }
+
+        XCTAssertEqual(attachments.count, 1)
+        let attachment = attachments[0]
+        XCTAssertEqual(attachment.model.columnCount, 2)
+        XCTAssertEqual(attachment.model.rows.count, 2)
+        XCTAssertTrue(attachment.model.rows[0].allSatisfy(\.isHeader))
+        XCTAssertFalse(attachment.model.rows[1].contains { $0.isHeader })
+        XCTAssertTrue(rendered.string.contains("before"))
+        XCTAssertTrue(rendered.string.contains("after"))
+    }
+
+    func testColumnWidthsAreClampedAndHeightsAccumulate() {
+        let longText = String(repeating: "wide content ", count: 30)
+        let rendered = MarkdownRenderer.render(
+            "| A | B |\n|---|---|\n| x | \(longText) |",
+            config: config
+        )
+        var attachment: TableAttachment?
+        rendered.enumerateAttribute(.attachment, in: NSRange(location: 0, length: rendered.length)) { value, _, _ in
+            if let table = value as? TableAttachment { attachment = table }
+        }
+        guard let attachment else { return XCTFail("no table attachment") }
+
+        let horizontalPadding = attachment.style.cellPaddingHorizontal * 2
+        // The long column wraps near the 300pt cap: its width lands at the
+        // last word boundary at or under the cap.
+        XCTAssertEqual(attachment.layout.columnWidths[0], TableAttachmentStyle.minColumnWidth)
+        XCTAssertLessThanOrEqual(
+            attachment.layout.columnWidths[1],
+            TableAttachmentStyle.maxColumnWidth + horizontalPadding
+        )
+        XCTAssertGreaterThan(attachment.layout.columnWidths[1], TableAttachmentStyle.maxColumnWidth * 0.8)
+        XCTAssertEqual(attachment.layout.rowHeights.count, 2)
+        XCTAssertGreaterThan(attachment.layout.rowHeights[1], attachment.layout.rowHeights[0])
+        XCTAssertEqual(
+            attachment.layout.totalHeight,
+            attachment.layout.rowHeights.reduce(0, +) + attachment.style.borderWidth
+        )
+    }
+
+    /// Breaks silently with an undeclared UTI, nil contents, or an
+    /// attachment-side viewProvider override.
+    func testProviderViewIsInstalledInTextView() {
+        let rendered = MarkdownRenderer.render(
+            "before\n\n| A | B |\n|---|---|\n| one | two |\n\nafter",
+            config: config
+        )
+
+        let textView = MarkdownTextView()
+        textView.styleConfig = config
+        textView.frame = CGRect(x: 0, y: 0, width: 380, height: 10)
+        textView.setMarkdownAttributedText(rendered)
+
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 380, height: 1000))
+        window.addSubview(textView)
+        window.makeKeyAndVisible()
+        let fitted = textView.sizeThatFits(CGSize(width: 380, height: CGFloat.greatestFiniteMagnitude))
+        textView.frame.size.height = fitted.height
+        textView.layoutIfNeeded()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.3))
+        textView.layoutIfNeeded()
+
+        XCTAssertNotNil(findTableView(in: textView))
+        window.isHidden = true
+    }
+
+    private func findTableView(in view: UIView) -> TableAttachmentView? {
+        if let table = view as? TableAttachmentView { return table }
+        for subview in view.subviews {
+            if let found = findTableView(in: subview) { return found }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Alternative to the segment pipeline: tables stay inside the single UITextView as full-width NSTextAttachment blocks whose registered NSTextAttachmentViewProvider hosts a live grid view (horizontal scroll view over a single-pass grid renderer). Cell content renders through the regular renderer factory, so inline styles work in cells; columns use the React Native package's two-pass intrinsic sizing with the 60/300pt clamps.

The provider wiring has three silently-failing requirements, each guarded by a comment and a regression test: the attachment's fileType must resolve to a real UTI (a dynamic UTType identifier here), it only persists when the attachment carries contents, and the view is only installed through registerViewProviderClass — an attachment-side viewProvider override breaks installation.

Spike scope: styling is fixed to RN defaults (no theme element yet), and link taps in cells, VoiceOver rows, the copy menu, and horizontal overflow bleed are not wired.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

