### PR TITLE
feat(ios): make GFM tables themeable and interactive

### DIFF
--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElement.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElement.swift
@@ -6,10 +6,17 @@ import UIKit
 class MarkdownAccessibilityElement: UIAccessibilityElement {
     private(set) weak var textView: MarkdownTextView?
     let range: NSRange
+    /// For table rows: vertical slice of the attachment frame.
+    private let rowSlice: (offset: CGFloat, height: CGFloat)?
 
     init(textView: MarkdownTextView, spec: MarkdownAccessibilityElementSpec) {
         self.textView = textView
         self.range = spec.range
+        if case .tableRow(let offset, let height, _) = spec.kind {
+            self.rowSlice = (offset, height)
+        } else {
+            self.rowSlice = nil
+        }
         super.init(accessibilityContainer: textView)
 
         accessibilityLabel = spec.label
@@ -28,11 +35,22 @@ class MarkdownAccessibilityElement: UIAccessibilityElement {
             accessibilityTraits = .link
         case .image:
             accessibilityTraits = .image
+        case .tableRow(_, _, let isHeader):
+            accessibilityTraits = isHeader ? [.staticText, .header] : .staticText
         }
     }
 
     override var accessibilityFrame: CGRect {
-        get { textView?.accessibilityScreenFrame(for: range) ?? .zero }
+        get {
+            guard var frame = textView?.accessibilityScreenFrame(for: range), frame != .zero else {
+                return .zero
+            }
+            if let rowSlice {
+                frame.origin.y += rowSlice.offset
+                frame.size.height = rowSlice.height
+            }
+            return frame
+        }
         set { super.accessibilityFrame = newValue }
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElementBuilder.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElementBuilder.swift
@@ -9,6 +9,7 @@ struct MarkdownAccessibilityElementSpec: Equatable {
         case heading(level: Int)
         case link(URL)
         case image
+        case tableRow(offset: CGFloat, height: CGFloat, isHeader: Bool)
     }
 
     let kind: Kind
@@ -58,6 +59,7 @@ enum MarkdownAccessibilityElementBuilder {
         let range: NSRange
         let kind: MarkdownAccessibilityElementSpec.Kind
         let imageLabel: String?
+        var table: TableAttachment?
     }
 
     private static func appendSpecs(
@@ -114,9 +116,12 @@ enum MarkdownAccessibilityElementBuilder {
             runs.append(SemanticRun(range: runRange, kind: .link(url), imageLabel: nil))
         }
         text.enumerateAttribute(.attachment, in: range) { value, runRange, _ in
-            guard let attachment = value as? MarkdownImageAttachment else { return }
-            let label = attachment.accessibilityLabel.flatMap { $0.isEmpty ? nil : $0 } ?? "Image"
-            runs.append(SemanticRun(range: runRange, kind: .image, imageLabel: label))
+            if let attachment = value as? MarkdownImageAttachment {
+                let label = attachment.accessibilityLabel.flatMap { $0.isEmpty ? nil : $0 } ?? "Image"
+                runs.append(SemanticRun(range: runRange, kind: .image, imageLabel: label))
+            } else if let table = value as? TableAttachment {
+                runs.append(SemanticRun(range: runRange, kind: .text, imageLabel: nil, table: table))
+            }
         }
 
         return runs.sorted { $0.range.location < $1.range.location }
@@ -127,6 +132,11 @@ enum MarkdownAccessibilityElementBuilder {
         in text: NSAttributedString,
         to specs: inout [MarkdownAccessibilityElementSpec]
     ) {
+        if let table = run.table {
+            appendTableRowSpecs(for: table, range: run.range, to: &specs)
+            return
+        }
+
         let label: String
         let announcement: String?
 
@@ -143,7 +153,7 @@ enum MarkdownAccessibilityElementBuilder {
             label = (text.string as NSString).substring(with: visible)
             // Links announce their list context even mid-item.
             announcement = listAnnouncement(in: text, at: run.range.location, requireStart: false)
-        case .text:
+        case .text, .tableRow:
             return
         }
 
@@ -153,6 +163,28 @@ enum MarkdownAccessibilityElementBuilder {
             range: trimmedRange(of: run.range, in: text) ?? run.range,
             listAnnouncement: announcement
         ))
+    }
+
+    /// One element per table row, RN-style: "Row {n}: {cells}", the header
+    /// row carrying the header trait. Frames are the attachment's frame
+    /// sliced by the precomputed row offsets.
+    private static func appendTableRowSpecs(
+        for table: TableAttachment,
+        range: NSRange,
+        to specs: inout [MarkdownAccessibilityElementSpec]
+    ) {
+        var offset: CGFloat = 0
+        for (index, row) in table.model.rows.enumerated() {
+            let height = table.layout.rowHeights[index]
+            let content = row.map(\.plainText).joined(separator: ", ")
+            specs.append(MarkdownAccessibilityElementSpec(
+                kind: .tableRow(offset: offset, height: height, isHeader: row.first?.isHeader ?? false),
+                label: "Row \(index + 1): \(content)",
+                range: range,
+                listAnnouncement: nil
+            ))
+            offset += height
+        }
     }
 
     private static func appendTextSpec(

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Attachments/TableAttachment.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Attachments/TableAttachment.swift
@@ -3,33 +3,76 @@ import UniformTypeIdentifiers
 
 struct TableCellModel: Equatable {
     let attributedText: NSAttributedString
+    let plainText: String
+    /// Cell content with inline markdown markers restored (bold, code,
+    /// links, …), for Copy as Markdown.
+    let markdownText: String
     let isHeader: Bool
 }
 
 struct TableModel: Equatable {
     let rows: [[TableCellModel]]
     let columnCount: Int
+    /// Raw `align` attribute per column ("left"/"center"/"right"/nil),
+    /// taken from the header row; used to rebuild markdown separators.
+    let columnAlignments: [String?]
 }
 
-/// RN-parity defaults; theme plumbing comes with the production table work.
-struct TableAttachmentStyle {
+/// Style values resolved from `MarkdownStyleConfig.table`, with RN-parity
+/// fallbacks for unset keys.
+struct TableAttachmentStyle: Equatable {
     static let `default` = TableAttachmentStyle()
 
-    var textColor = UIColor(red: 0.12, green: 0.16, blue: 0.22, alpha: 1)
-    var headerTextColor = UIColor(red: 0.07, green: 0.09, blue: 0.15, alpha: 1)
-    var headerBackground = UIColor(red: 0.95, green: 0.96, blue: 0.96, alpha: 1)
-    var rowEvenBackground = UIColor.white
-    var rowOddBackground = UIColor(red: 0.98, green: 0.98, blue: 0.99, alpha: 1)
-    var borderColor = UIColor(red: 0.90, green: 0.91, blue: 0.92, alpha: 1)
+    var font: UIFont?
+    var fontSize: CGFloat = 14
+    var lineHeight: CGFloat = 20
+    var textColor = UIColor.label
+    var headerTextColor = UIColor.label
+    var headerBackground = UIColor.tertiarySystemFill
+    var rowEvenBackground = UIColor.clear
+    var rowOddBackground = UIColor.quaternarySystemFill
+    var borderColor = UIColor.separator
     var borderWidth: CGFloat = 1
     var cornerRadius: CGFloat = 6
-    var fontSize: CGFloat = 14
     var cellPaddingHorizontal: CGFloat = 12
     var cellPaddingVertical: CGFloat = 8
+    var marginTop: CGFloat = 0
     var marginBottom: CGFloat = 16
+    var align: TableAlignment = .leading
 
     static let minColumnWidth: CGFloat = 60
     static let maxColumnWidth: CGFloat = 300
+
+    init() {}
+
+    init(config: MarkdownStyleConfig) {
+        applyColors(from: config.table)
+        applyMetrics(from: config.table)
+    }
+
+    private mutating func applyColors(from table: TableStyle) {
+        if let value = table.foregroundColor { textColor = value }
+        if let value = table.headerTextColor { headerTextColor = value }
+        if let value = table.headerBackgroundColor { headerBackground = value }
+        if let value = table.rowEvenBackgroundColor { rowEvenBackground = value }
+        if let value = table.rowOddBackgroundColor { rowOddBackground = value }
+        if let value = table.borderColor { borderColor = value }
+    }
+
+    private mutating func applyMetrics(from table: TableStyle) {
+        if let value = table.font {
+            font = value
+            fontSize = value.pointSize
+        }
+        if let value = table.lineHeight { lineHeight = value }
+        if let value = table.borderWidth { borderWidth = value }
+        if let value = table.borderRadius { cornerRadius = value }
+        if let value = table.cellPaddingHorizontal { cellPaddingHorizontal = value }
+        if let value = table.cellPaddingVertical { cellPaddingVertical = value }
+        if let value = table.marginTop { marginTop = value }
+        if let value = table.marginBottom { marginBottom = value }
+        if let value = table.align { align = value }
+    }
 }
 
 /// Two-pass intrinsic column sizing ported from the React Native package.
@@ -109,6 +152,10 @@ final class TableAttachment: NSTextAttachment {
     let layout: TableAttachmentLayout
     let style: TableAttachmentStyle
 
+    /// TextKit 2 recreates the provider view whenever the table re-enters
+    /// the viewport; the horizontal scroll position survives here.
+    var preservedContentOffset: CGPoint = .zero
+
     init(model: TableModel, style: TableAttachmentStyle) {
         self.model = model
         self.style = style
@@ -123,4 +170,41 @@ final class TableAttachment: NSTextAttachment {
         fatalError("init(coder:) has not been implemented")
     }
 
+    /// Tab-separated plain text for the pasteboard and accessibility.
+    func plainText() -> String {
+        model.rows
+            .map { row in row.map(\.plainText).joined(separator: "\t") }
+            .joined(separator: "\n")
+    }
+
+    /// Rebuilds the pipe table, with a separator row derived from the
+    /// column alignments.
+    func markdownText() -> String {
+        var lines: [String] = []
+        for (index, row) in model.rows.enumerated() {
+            let cells = (0..<model.columnCount).map { column in
+                column < row.count ? row[column].markdownText.replacingOccurrences(of: "|", with: "\\|") : ""
+            }
+            lines.append("| " + cells.joined(separator: " | ") + " |")
+
+            if index == 0 {
+                let separators = (0..<model.columnCount).map { column -> String in
+                    switch model.columnAlignments[safe: column] ?? nil {
+                    case "center": return ":---:"
+                    case "right": return "---:"
+                    case "left": return ":---"
+                    default: return "---"
+                    }
+                }
+                lines.append("| " + separators.joined(separator: " | ") + " |")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Attachments/TableAttachmentView.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Attachments/TableAttachmentView.swift
@@ -23,11 +23,7 @@ final class TableAttachmentViewProvider: NSTextAttachmentViewProvider {
             view = UIView()
             return
         }
-        view = TableAttachmentView(
-            model: attachment.model,
-            layout: attachment.layout,
-            style: attachment.style
-        )
+        view = TableAttachmentView(attachment: attachment)
     }
 
     override func attachmentBounds(
@@ -42,27 +38,36 @@ final class TableAttachmentViewProvider: NSTextAttachmentViewProvider {
     }
 }
 
-final class TableAttachmentView: UIView {
+final class TableAttachmentView: UIView, UIScrollViewDelegate, UIContextMenuInteractionDelegate {
     private let scrollView = UIScrollView()
     private let gridView: TableGridView
-    private let layout: TableAttachmentLayout
-    private let style: TableAttachmentStyle
+    private let attachment: TableAttachment
+    private var didRestoreOffset = false
 
-    init(model: TableModel, layout: TableAttachmentLayout, style: TableAttachmentStyle) {
-        self.gridView = TableGridView(model: model, layout: layout, style: style)
-        self.layout = layout
-        self.style = style
+    init(attachment: TableAttachment) {
+        self.attachment = attachment
+        self.gridView = TableGridView(
+            model: attachment.model,
+            layout: attachment.layout,
+            style: attachment.style
+        )
         super.init(frame: .zero)
 
         scrollView.showsVerticalScrollIndicator = false
         scrollView.showsHorizontalScrollIndicator = true
         scrollView.alwaysBounceVertical = false
+        scrollView.delegate = self
         addSubview(scrollView)
 
         gridView.backgroundColor = .clear
-        gridView.layer.cornerRadius = style.cornerRadius
+        gridView.layer.cornerRadius = attachment.style.cornerRadius
         gridView.layer.masksToBounds = true
         scrollView.addSubview(gridView)
+
+        gridView.addGestureRecognizer(
+            UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+        )
+        gridView.addInteraction(UIContextMenuInteraction(delegate: self))
     }
 
     @available(*, unavailable)
@@ -72,10 +77,90 @@ final class TableAttachmentView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+        let layout = attachment.layout
         scrollView.frame = bounds
-        gridView.frame = CGRect(x: 0, y: 0, width: layout.totalWidth, height: layout.totalHeight)
-        scrollView.contentSize = gridView.frame.size
-        scrollView.isScrollEnabled = layout.totalWidth > bounds.width
+
+        let fits = layout.totalWidth <= bounds.width
+        let alignOffset: CGFloat
+        if fits {
+            switch attachment.style.align {
+            case .leading: alignOffset = 0
+            case .center: alignOffset = (bounds.width - layout.totalWidth) / 2
+            case .trailing: alignOffset = bounds.width - layout.totalWidth
+            }
+        } else {
+            alignOffset = 0
+        }
+
+        gridView.frame = CGRect(
+            x: alignOffset,
+            y: 0,
+            width: layout.totalWidth,
+            height: layout.totalHeight
+        )
+        scrollView.contentSize = CGSize(
+            width: max(layout.totalWidth, bounds.width),
+            height: layout.totalHeight
+        )
+        scrollView.isScrollEnabled = !fits
+
+        if !didRestoreOffset, bounds.width > 0 {
+            didRestoreOffset = true
+            if !fits {
+                let maxOffset = layout.totalWidth - bounds.width
+                let restored = min(max(attachment.preservedContentOffset.x, 0), maxOffset)
+                scrollView.contentOffset = CGPoint(x: restored, y: 0)
+            }
+        }
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard didRestoreOffset else { return }
+        attachment.preservedContentOffset = scrollView.contentOffset
+    }
+
+    // MARK: - Link taps
+
+    @objc private func handleTap(_ recognizer: UITapGestureRecognizer) {
+        guard let url = gridView.linkURL(at: recognizer.location(in: gridView)) else { return }
+        if let onLinkPress = hostTextView()?.onLinkPress {
+            onLinkPress(url)
+        } else {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    private func hostTextView() -> MarkdownTextView? {
+        var view: UIView? = superview
+        while let current = view {
+            if let textView = current as? MarkdownTextView { return textView }
+            view = current.superview
+        }
+        return nil
+    }
+
+    // MARK: - Copy menu
+
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        configurationForMenuAtLocation location: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        let attachment = self.attachment
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
+            let copy = UIAction(
+                title: "Copy",
+                image: UIImage(systemName: "doc.on.doc")
+            ) { _ in
+                UIPasteboard.general.string = attachment.plainText()
+            }
+            let copyMarkdown = UIAction(
+                title: "Copy as Markdown",
+                image: UIImage(systemName: "doc.text")
+            ) { _ in
+                UIPasteboard.general.string = attachment.markdownText()
+            }
+            return UIMenu(children: [copy, copyMarkdown])
+        }
     }
 }
 
@@ -129,14 +214,8 @@ final class TableGridView: UIView {
                 context.stroke(cellRect)
 
                 if column < row.count {
-                    let textRect = CGRect(
-                        x: xOffset + style.cellPaddingHorizontal,
-                        y: yOffset + style.cellPaddingVertical,
-                        width: columnWidth - style.cellPaddingHorizontal * 2,
-                        height: rowHeight - style.cellPaddingVertical * 2
-                    )
                     row[column].attributedText.draw(
-                        with: textRect,
+                        with: textRect(column: column, xOffset: xOffset, yOffset: yOffset, rowHeight: rowHeight),
                         options: [.usesLineFragmentOrigin, .usesFontLeading],
                         context: nil
                     )
@@ -145,6 +224,77 @@ final class TableGridView: UIView {
             }
             yOffset += rowHeight
         }
+    }
+
+    /// Resolves a tap on the grid to a `.link` attribute in the tapped
+    /// cell, via a throwaway TextKit stack matching the drawing geometry.
+    func linkURL(at point: CGPoint) -> URL? {
+        guard let cell = cell(at: point) else { return nil }
+        let local = CGPoint(x: point.x - cell.textRect.minX, y: point.y - cell.textRect.minY)
+        guard local.x >= 0, local.y >= 0,
+              local.x <= cell.textRect.width, local.y <= cell.textRect.height else {
+            return nil
+        }
+
+        let storage = NSTextStorage(attributedString: cell.text)
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: cell.textRect.size)
+        container.lineFragmentPadding = 0
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+
+        let glyphIndex = layoutManager.glyphIndex(for: local, in: container)
+        guard glyphIndex < layoutManager.numberOfGlyphs else { return nil }
+        let glyphRect = layoutManager.boundingRect(
+            forGlyphRange: NSRange(location: glyphIndex, length: 1),
+            in: container
+        )
+        guard glyphRect.insetBy(dx: -4, dy: -4).contains(local) else { return nil }
+
+        let characterIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+        guard characterIndex < cell.text.length else { return nil }
+        let value = cell.text.attribute(.link, at: characterIndex, effectiveRange: nil)
+        if let url = value as? URL { return url }
+        if let string = value as? String { return URL(string: string) }
+        return nil
+    }
+
+    private func cell(at point: CGPoint) -> (text: NSAttributedString, textRect: CGRect)? {
+        var yOffset: CGFloat = 0
+        for (rowIndex, row) in model.rows.enumerated() {
+            let rowHeight = layout.rowHeights[rowIndex]
+            if point.y >= yOffset, point.y < yOffset + rowHeight {
+                var xOffset: CGFloat = 0
+                for column in 0..<model.columnCount {
+                    let columnWidth = layout.columnWidths[column]
+                    if point.x >= xOffset, point.x < xOffset + columnWidth {
+                        guard column < row.count else { return nil }
+                        return (
+                            row[column].attributedText,
+                            textRect(column: column, xOffset: xOffset, yOffset: yOffset, rowHeight: rowHeight)
+                        )
+                    }
+                    xOffset += columnWidth
+                }
+                return nil
+            }
+            yOffset += rowHeight
+        }
+        return nil
+    }
+
+    private func textRect(
+        column: Int,
+        xOffset: CGFloat,
+        yOffset: CGFloat,
+        rowHeight: CGFloat
+    ) -> CGRect {
+        CGRect(
+            x: xOffset + style.cellPaddingHorizontal,
+            y: yOffset + style.cellPaddingVertical,
+            width: layout.columnWidths[column] - style.cellPaddingHorizontal * 2,
+            height: rowHeight - style.cellPaddingVertical * 2
+        )
     }
 
     private func rowBackground(isHeader: Bool, bodyRowIndex: Int) -> UIColor {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownExtractor.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownExtractor.swift
@@ -45,6 +45,19 @@ enum MarkdownExtractor {
         return result.isEmpty ? nil : result
     }
 
+    /// Inline markdown for a single-paragraph attributed string (table
+    /// cells): reapplies the inline markers the renderers stripped, without
+    /// any block handling.
+    static func inlineMarkdown(for text: NSAttributedString) -> String {
+        var result = ""
+        text.enumerateAttributes(in: NSRange(location: 0, length: text.length), options: []) { attrs, range, _ in
+            let run = (text.string as NSString).substring(with: range)
+                .replacingOccurrences(of: "\u{2028}", with: " ")
+            result += applyInlineFormatting(run, traits: InlineTraits(attrs: attrs))
+        }
+        return result
+    }
+
     /// http(s) URLs of image attachments within `range`, in document order.
     static func imageURLs(in attributedText: NSAttributedString, range: NSRange) -> [String] {
         guard let clamped = clampedRange(range, in: attributedText) else { return [] }
@@ -86,6 +99,11 @@ private extension MarkdownExtractor {
 
         if attrs[.attachment] is ThematicBreakAttachment {
             appendThematicBreak(to: &result, state: &state)
+            return
+        }
+
+        if let table = attrs[.attachment] as? TableAttachment {
+            appendTable(table, to: &result, state: &state)
             return
         }
 
@@ -134,6 +152,19 @@ private extension MarkdownExtractor {
     static func appendThematicBreak(to result: inout String, state: inout ExtractionState) {
         ensureBlankLine(&result)
         result += "---\n"
+        state.needsBlankLine = true
+        state.blockquoteDepth = -1
+        state.listDepth = -1
+    }
+
+    static func appendTable(
+        _ table: TableAttachment,
+        to result: inout String,
+        state: inout ExtractionState
+    ) {
+        flushHeading(&result, state: &state)
+        ensureBlankLine(&result)
+        result += table.markdownText() + "\n"
         state.needsBlankLine = true
         state.blockquoteDepth = -1
         state.listDepth = -1
@@ -324,14 +355,25 @@ private extension MarkdownExtractor {
         )
     }
 
-    /// A selection is "full" when it starts at the beginning and any excluded
-    /// tail is whitespace-only (themes append 1–2 trailing margin spacers that
-    /// Select All may skip).
+    /// A selection is "full" when everything it excludes — leading or
+    /// trailing — is invisible (margin spacers, zero-width marker anchors),
+    /// so drag-selecting the whole document qualifies even though it starts
+    /// after the leading spacer.
     static func isFullSelection(_ range: NSRange, in attributedText: NSAttributedString) -> Bool {
-        guard range.location == 0 else { return false }
-        let tail = (attributedText.string as NSString).substring(from: NSMaxRange(range))
-        return tail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let string = attributedText.string as NSString
+        let head = string.substring(to: range.location)
+        let tail = string.substring(from: NSMaxRange(range))
+        return head.components(separatedBy: invisibleCharacters).joined().isEmpty
+            && tail.components(separatedBy: invisibleCharacters).joined().isEmpty
     }
+
+    /// Whitespace plus the zero-width space and line separator the renderers
+    /// use for marker anchors and hard breaks.
+    private static let invisibleCharacters: CharacterSet = {
+        var set = CharacterSet.whitespacesAndNewlines
+        set.insert(charactersIn: "\u{200B}\u{2028}")
+        return set
+    }()
 
     static func ensureBlankLine(_ result: inout String) {
         guard !result.isEmpty, !result.hasSuffix("\n\n") else { return }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator+Table.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator+Table.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+extension MarkdownHTMLGenerator {
+    static func appendTable(_ table: TableAttachment, into html: inout String) {
+        html += "<table style=\"border-collapse: collapse;\">"
+        for row in table.model.rows {
+            html += "<tr>"
+            for cell in row {
+                let tag = cell.isHeader ? "th" : "td"
+                html += "<\(tag) style=\"border: 1px solid #d0d0d0; "
+                    + "padding: 4px 8px; text-align: left;\">"
+                    + escapeHTML(cell.plainText)
+                    + "</\(tag)>"
+            }
+            html += "</tr>"
+        }
+        html += "</table>"
+    }
+
+    static func escapeHTML(_ text: String) -> String {
+        guard text.contains(where: { "&<>\"'".contains($0) }) else { return text }
+        return text
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator.swift
@@ -372,6 +372,11 @@ enum MarkdownHTMLGenerator {
                 appendImage(attachment, into: &html, styles: styles)
                 return
             }
+
+            if let table = attrs[.attachment] as? TableAttachment {
+                appendTable(table, into: &html)
+                return
+            }
             if attrs[.attachment] != nil || content == "\u{FFFC}" {
                 return
             }
@@ -587,13 +592,4 @@ enum MarkdownHTMLGenerator {
         return String(format: "#%02X%02X%02X", redByte, greenByte, blueByte)
     }
 
-    private static func escapeHTML(_ text: String) -> String {
-        guard text.contains(where: { "&<>\"'".contains($0) }) else { return text }
-        return text
-            .replacingOccurrences(of: "&", with: "&amp;")
-            .replacingOccurrences(of: "<", with: "&lt;")
-            .replacingOccurrences(of: ">", with: "&gt;")
-            .replacingOccurrences(of: "\"", with: "&quot;")
-            .replacingOccurrences(of: "'", with: "&#39;")
-    }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/TableRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/TableRenderer.swift
@@ -12,11 +12,18 @@ final class TableRenderer: NodeRenderer {
     }
 
     func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
-        let style = TableAttachmentStyle.default
+        let style = TableAttachmentStyle(config: config)
         let model = buildModel(from: node, style: style)
         guard !model.rows.isEmpty, model.columnCount > 0 else { return }
 
         ParagraphStyleHelpers.ensureStartingOnNewLine(in: output)
+        if style.marginTop > 0 {
+            _ = ParagraphStyleHelpers.applyBlockSpacingBefore(
+                to: output,
+                at: output.length,
+                marginTop: style.marginTop
+            )
+        }
         let attachment = TableAttachment(model: model, style: style)
         output.append(NSAttributedString(attachment: attachment))
         output.append(NSAttributedString(string: "\n"))
@@ -26,6 +33,7 @@ final class TableRenderer: NodeRenderer {
     private func buildModel(from node: MarkdownASTNode, style: TableAttachmentStyle) -> TableModel {
         var rows: [[TableCellModel]] = []
         var columnCount = 0
+        var columnAlignments: [String?] = []
 
         for section in node.children where section.type == .tableHead || section.type == .tableBody {
             let sectionIsHead = section.type == .tableHead
@@ -34,17 +42,26 @@ final class TableRenderer: NodeRenderer {
                 for cellNode in rowNode.children
                 where cellNode.type == .tableHeaderCell || cellNode.type == .tableCell {
                     let isHeader = sectionIsHead || cellNode.type == .tableHeaderCell
+                    let rendered = renderCell(cellNode, isHeader: isHeader, style: style)
                     cells.append(TableCellModel(
-                        attributedText: renderCell(cellNode, isHeader: isHeader, style: style),
+                        attributedText: rendered,
+                        plainText: rendered.string,
+                        markdownText: MarkdownExtractor.inlineMarkdown(for: rendered),
                         isHeader: isHeader
                     ))
+                    if sectionIsHead, columnAlignments.count < cells.count {
+                        columnAlignments.append(cellNode.attribute("align"))
+                    }
                 }
                 columnCount = max(columnCount, cells.count)
                 rows.append(cells)
             }
         }
 
-        return TableModel(rows: rows, columnCount: columnCount)
+        while columnAlignments.count < columnCount {
+            columnAlignments.append(nil)
+        }
+        return TableModel(rows: rows, columnCount: columnCount, columnAlignments: columnAlignments)
     }
 
     private func renderCell(
@@ -59,36 +76,45 @@ final class TableRenderer: NodeRenderer {
             color: isHeader ? style.headerTextColor : style.textColor
         )
         factory.renderChildren(of: cellNode, into: cellOutput, context: cellContext)
-        trimTrailingNewlines(in: cellOutput)
-        applyAlignment(cellNode.attribute("align"), to: cellOutput)
+        trimTrailingWhitespace(in: cellOutput)
+        applyParagraphStyle(align: cellNode.attribute("align"), style: style, to: cellOutput)
         return cellOutput
     }
 
     private func cellFont(isHeader: Bool, style: TableAttachmentStyle) -> UIFont {
-        let base = (config.paragraph.font ?? UIFont.preferredFont(forTextStyle: .body))
-            .withSize(style.fontSize)
+        let base = style.font
+            ?? (config.paragraph.font ?? UIFont.preferredFont(forTextStyle: .body)).withSize(style.fontSize)
         guard isHeader else { return base }
         guard let boldDescriptor = base.fontDescriptor.withSymbolicTraits(.traitBold) else {
             return base
         }
-        return UIFont(descriptor: boldDescriptor, size: style.fontSize)
+        return UIFont(descriptor: boldDescriptor, size: base.pointSize)
     }
 
-    private func applyAlignment(_ align: String?, to cellOutput: NSMutableAttributedString) {
-        let alignment: NSTextAlignment
-        switch align {
-        case "center": alignment = .center
-        case "right": alignment = .right
-        default: return
-        }
-
-        let range = NSRange(location: 0, length: cellOutput.length)
+    private func applyParagraphStyle(
+        align: String?,
+        style: TableAttachmentStyle,
+        to cellOutput: NSMutableAttributedString
+    ) {
+        guard cellOutput.length > 0 else { return }
         let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.alignment = alignment
-        cellOutput.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
+        if style.lineHeight > 0 {
+            paragraphStyle.minimumLineHeight = style.lineHeight
+            paragraphStyle.maximumLineHeight = style.lineHeight
+        }
+        switch align {
+        case "center": paragraphStyle.alignment = .center
+        case "right": paragraphStyle.alignment = .right
+        default: break
+        }
+        cellOutput.addAttribute(
+            .paragraphStyle,
+            value: paragraphStyle,
+            range: NSRange(location: 0, length: cellOutput.length)
+        )
     }
 
-    private func trimTrailingNewlines(in cellOutput: NSMutableAttributedString) {
+    private func trimTrailingWhitespace(in cellOutput: NSMutableAttributedString) {
         while cellOutput.length > 0,
               let scalar = Unicode.Scalar((cellOutput.string as NSString).character(at: cellOutput.length - 1)),
               CharacterSet.whitespacesAndNewlines.contains(scalar) {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/DefaultMarkdownTheme.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/DefaultMarkdownTheme.swift
@@ -104,6 +104,19 @@ enum DefaultMarkdownTheme {
                 .checkmarkColor(.white)
                 .checkboxSize(14)
                 .checkboxBorderRadius(3)
+
+            Table()
+                .lineHeight(20)
+                .foregroundStyle(Semantic.primary)
+                .headerTextColor(Semantic.primary)
+                .headerBackground(Color(UIColor.tertiarySystemFill))
+                .rowOddBackground(Color(UIColor.quaternarySystemFill))
+                .borderColor(Color(UIColor.separator))
+                .borderWidth(1)
+                .cornerRadius(6)
+                .cellPaddingHorizontal(12)
+                .cellPaddingVertical(8)
+                .marginBottom(16)
         }
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/Table.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/Table.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+public struct Table: MarkdownThemeElement {
+    public var fontSpec: ThemeFontSpec?
+    public var fontWeight: Font.Weight?
+    public var fontDesign: Font.Design?
+    public var foregroundColorSpec: ThemeColorSpec?
+    public var headerTextColorSpec: ThemeColorSpec?
+    public var headerBackgroundColorSpec: ThemeColorSpec?
+    public var rowEvenBackgroundColorSpec: ThemeColorSpec?
+    public var rowOddBackgroundColorSpec: ThemeColorSpec?
+    public var borderColorSpec: ThemeColorSpec?
+    public var marginTop: CGFloat?
+    public var marginBottom: CGFloat?
+    public var lineHeight: CGFloat?
+    public var textAlignment: TextAlignment?
+    public var borderWidth: CGFloat?
+    public var borderRadius: CGFloat?
+    public var cellPaddingHorizontal: CGFloat?
+    public var cellPaddingVertical: CGFloat?
+    public var align: TableAlignment?
+
+    public init() {}
+
+    public func headerTextColor(_ color: Color) -> Self {
+        var copy = self
+        copy.headerTextColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func headerTextColor(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.headerTextColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func headerBackground(_ color: Color) -> Self {
+        var copy = self
+        copy.headerBackgroundColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func headerBackground(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.headerBackgroundColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func rowEvenBackground(_ color: Color) -> Self {
+        var copy = self
+        copy.rowEvenBackgroundColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func rowEvenBackground(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.rowEvenBackgroundColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func rowOddBackground(_ color: Color) -> Self {
+        var copy = self
+        copy.rowOddBackgroundColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func rowOddBackground(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.rowOddBackgroundColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func borderColor(_ color: Color) -> Self {
+        var copy = self
+        copy.borderColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func borderColor(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.borderColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func borderWidth(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.borderWidth = value
+        return copy
+    }
+
+    public func cornerRadius(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.borderRadius = value
+        return copy
+    }
+
+    public func borderRadius(_ value: CGFloat) -> Self {
+        cornerRadius(value)
+    }
+
+    public func cellPaddingHorizontal(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.cellPaddingHorizontal = value
+        return copy
+    }
+
+    public func cellPaddingVertical(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.cellPaddingVertical = value
+        return copy
+    }
+
+    public func align(_ value: TableAlignment) -> Self {
+        var copy = self
+        copy.align = value
+        return copy
+    }
+
+    public func apply(to config: inout MarkdownStyleConfig, traitCollection: UITraitCollection) {
+        applyColors(to: &config, traitCollection: traitCollection)
+        applyMetrics(to: &config, traitCollection: traitCollection)
+    }
+
+    private func applyColors(to config: inout MarkdownStyleConfig, traitCollection: UITraitCollection) {
+        if let foregroundColorSpec {
+            config.table.foregroundColor = foregroundColorSpec.resolve(traitCollection: traitCollection)
+        }
+        if let headerTextColorSpec {
+            config.table.headerTextColor = headerTextColorSpec.resolve(traitCollection: traitCollection)
+        }
+        if let headerBackgroundColorSpec {
+            config.table.headerBackgroundColor = headerBackgroundColorSpec.resolve(traitCollection: traitCollection)
+        }
+        if let rowEvenBackgroundColorSpec {
+            config.table.rowEvenBackgroundColor = rowEvenBackgroundColorSpec.resolve(traitCollection: traitCollection)
+        }
+        if let rowOddBackgroundColorSpec {
+            config.table.rowOddBackgroundColor = rowOddBackgroundColorSpec.resolve(traitCollection: traitCollection)
+        }
+        if let borderColorSpec {
+            config.table.borderColor = borderColorSpec.resolve(traitCollection: traitCollection)
+        }
+    }
+
+    private func applyMetrics(to config: inout MarkdownStyleConfig, traitCollection: UITraitCollection) {
+        if fontSpec != nil || fontWeight != nil || fontDesign != nil {
+            config.table.font = ThemeResolver.applyFont(
+                spec: fontSpec,
+                weight: fontWeight,
+                design: fontDesign,
+                to: config.table.font,
+                traitCollection: traitCollection
+            )
+        }
+        if let marginTop { config.table.marginTop = marginTop }
+        if let marginBottom { config.table.marginBottom = marginBottom }
+        if let lineHeight { config.table.lineHeight = lineHeight }
+        if let borderWidth { config.table.borderWidth = borderWidth }
+        if let borderRadius { config.table.borderRadius = borderRadius }
+        if let cellPaddingHorizontal { config.table.cellPaddingHorizontal = cellPaddingHorizontal }
+        if let cellPaddingVertical { config.table.cellPaddingVertical = cellPaddingVertical }
+        if let align { config.table.align = align }
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
@@ -294,6 +294,82 @@ public struct TaskListStyle: Equatable, Sendable {
     }
 }
 
+public enum TableAlignment: String, Equatable, Sendable {
+    case leading
+    case center
+    case trailing
+}
+
+public struct TableStyle: Equatable, Sendable {
+    public var font: UIFont?
+    public var foregroundColor: UIColor?
+    public var lineHeight: CGFloat?
+    public var headerTextColor: UIColor?
+    public var headerBackgroundColor: UIColor?
+    public var rowEvenBackgroundColor: UIColor?
+    public var rowOddBackgroundColor: UIColor?
+    public var borderColor: UIColor?
+    public var borderWidth: CGFloat?
+    public var borderRadius: CGFloat?
+    public var cellPaddingHorizontal: CGFloat?
+    public var cellPaddingVertical: CGFloat?
+    public var marginTop: CGFloat?
+    public var marginBottom: CGFloat?
+    public var align: TableAlignment?
+
+    public init(
+        font: UIFont? = nil,
+        foregroundColor: UIColor? = nil,
+        lineHeight: CGFloat? = nil,
+        headerTextColor: UIColor? = nil,
+        headerBackgroundColor: UIColor? = nil,
+        rowEvenBackgroundColor: UIColor? = nil,
+        rowOddBackgroundColor: UIColor? = nil,
+        borderColor: UIColor? = nil,
+        borderWidth: CGFloat? = nil,
+        borderRadius: CGFloat? = nil,
+        cellPaddingHorizontal: CGFloat? = nil,
+        cellPaddingVertical: CGFloat? = nil,
+        marginTop: CGFloat? = nil,
+        marginBottom: CGFloat? = nil,
+        align: TableAlignment? = nil
+    ) {
+        self.font = font
+        self.foregroundColor = foregroundColor
+        self.lineHeight = lineHeight
+        self.headerTextColor = headerTextColor
+        self.headerBackgroundColor = headerBackgroundColor
+        self.rowEvenBackgroundColor = rowEvenBackgroundColor
+        self.rowOddBackgroundColor = rowOddBackgroundColor
+        self.borderColor = borderColor
+        self.borderWidth = borderWidth
+        self.borderRadius = borderRadius
+        self.cellPaddingHorizontal = cellPaddingHorizontal
+        self.cellPaddingVertical = cellPaddingVertical
+        self.marginTop = marginTop
+        self.marginBottom = marginBottom
+        self.align = align
+    }
+
+    public mutating func merge(_ other: TableStyle) {
+        font = other.font ?? font
+        foregroundColor = other.foregroundColor ?? foregroundColor
+        lineHeight = other.lineHeight ?? lineHeight
+        headerTextColor = other.headerTextColor ?? headerTextColor
+        headerBackgroundColor = other.headerBackgroundColor ?? headerBackgroundColor
+        rowEvenBackgroundColor = other.rowEvenBackgroundColor ?? rowEvenBackgroundColor
+        rowOddBackgroundColor = other.rowOddBackgroundColor ?? rowOddBackgroundColor
+        borderColor = other.borderColor ?? borderColor
+        borderWidth = other.borderWidth ?? borderWidth
+        borderRadius = other.borderRadius ?? borderRadius
+        cellPaddingHorizontal = other.cellPaddingHorizontal ?? cellPaddingHorizontal
+        cellPaddingVertical = other.cellPaddingVertical ?? cellPaddingVertical
+        marginTop = other.marginTop ?? marginTop
+        marginBottom = other.marginBottom ?? marginBottom
+        align = other.align ?? align
+    }
+}
+
 public struct MarkdownStyleConfig: Equatable, Sendable {
     public var paragraph: ElementStyle
     public var heading1: ElementStyle
@@ -315,6 +391,7 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
     public var blockquote: BlockquoteStyle
     public var list: ListStyle
     public var taskList: TaskListStyle
+    public var table: TableStyle
 
     public init(
         paragraph: ElementStyle = ElementStyle(),
@@ -336,7 +413,8 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         codeBlock: CodeBlockStyle = CodeBlockStyle(),
         blockquote: BlockquoteStyle = BlockquoteStyle(),
         list: ListStyle = ListStyle(),
-        taskList: TaskListStyle = TaskListStyle()
+        taskList: TaskListStyle = TaskListStyle(),
+        table: TableStyle = TableStyle()
     ) {
         self.paragraph = paragraph
         self.heading1 = heading1
@@ -358,6 +436,7 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         self.blockquote = blockquote
         self.list = list
         self.taskList = taskList
+        self.table = table
     }
 
     public mutating func merge(_ other: MarkdownStyleConfig) {
@@ -381,6 +460,7 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         blockquote.merge(other.blockquote)
         list.merge(other.list)
         taskList.merge(other.taskList)
+        table.merge(other.table)
     }
 
     public func headingStyle(for level: Int) -> ElementStyle {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -303,7 +303,7 @@ final class MarkdownTextView: UITextView {
             location: selectedRange.location,
             length: min(selectedRange.length, attributedText.length - selectedRange.location)
         )
-        let plain = (attributedText.string as NSString).substring(with: clamped)
+        let plain = Self.plainText(of: attributedText, in: clamped)
         let html = MarkdownHTMLGenerator.generateHTML(
             from: attributedText,
             in: clamped,
@@ -313,6 +313,20 @@ final class MarkdownTextView: UITextView {
             "public.utf8-plain-text": plain,
             "public.html": html
         ]]
+    }
+
+    /// Plain text for the pasteboard, with table attachment characters
+    /// replaced by the table's tab-separated content.
+    static func plainText(of attributedText: NSAttributedString, in range: NSRange) -> String {
+        var plain = ""
+        attributedText.enumerateAttribute(.attachment, in: range) { value, runRange, _ in
+            if let table = value as? TableAttachment {
+                plain += table.plainText()
+            } else {
+                plain += (attributedText.string as NSString).substring(with: runRange)
+            }
+        }
+        return plain
     }
 
     func setMarkdownAttributedText(_ attributedText: NSAttributedString) {

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/HTMLGeneratorTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/HTMLGeneratorTests.swift
@@ -155,6 +155,16 @@ final class HTMLGeneratorTests: XCTestCase {
         XCTAssertTrue(result.contains("</ol>"))
     }
 
+    func testTableEmitsSemanticTableMarkup() {
+        let result = html(for: "| A | B |\n|---|---|\n| one | two |")
+
+        XCTAssertTrue(result.contains("<table"))
+        XCTAssertTrue(result.contains("<th"))
+        XCTAssertTrue(result.contains(">A</th>"))
+        XCTAssertTrue(result.contains(">one</td>"))
+        XCTAssertFalse(result.contains("\u{FFFC}"))
+    }
+
     func testTaskListItemsEmitDisabledCheckboxes() {
         let result = html(for: "- [x] done\n- [ ] todo")
 

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/MarkdownExtractorTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/MarkdownExtractorTests.swift
@@ -42,6 +42,86 @@ final class MarkdownExtractorTests: XCTestCase {
         )
     }
 
+    // MARK: - Tables
+
+    func testTableOnlySelectionRebuildsPipeTable() {
+        let rendered = render("| A | B |\n|:--|--:|\n| one | two |")
+        let range = (rendered.string as NSString).range(of: "\u{FFFC}")
+        XCTAssertNotEqual(range.location, NSNotFound)
+
+        let markdown = MarkdownExtractor.extractMarkdown(from: rendered, in: range)
+
+        XCTAssertEqual(markdown, "| A | B |\n| :--- | ---: |\n| one | two |\n")
+    }
+
+    func testSelectionSpanningTableKeepsSurroundingText() {
+        let rendered = render("before\n\n| A | B |\n|---|---|\n| one | two |\n\nafter")
+        let markdown = MarkdownExtractor.extractMarkdown(
+            from: rendered,
+            in: NSRange(location: 0, length: rendered.length)
+        )
+
+        XCTAssertNotNil(markdown)
+        XCTAssertTrue(markdown?.contains("before") == true)
+        XCTAssertTrue(markdown?.contains("| A | B |") == true)
+        XCTAssertTrue(markdown?.contains("| one | two |") == true)
+        XCTAssertTrue(markdown?.contains("after") == true)
+        XCTAssertFalse(markdown?.contains("\u{FFFC}") == true)
+    }
+
+    /// Drag-selecting "everything" can start after a leading margin spacer;
+    /// the excluded head is invisible, so the original source comes back
+    /// verbatim (exact separator dashes included).
+    func testSelectionAfterLeadingSpacerReturnsSourceVerbatim() {
+        var spacedConfig = MarkdownStyleConfig.baseline()
+        spacedConfig.paragraph.marginTop = 12
+        let source = "intro\n\n| A | B |\n|:--------|------:|\n| one | two |\n\nafter"
+        let rendered = MarkdownRenderer.render(source, config: spacedConfig)
+
+        let introLocation = (rendered.string as NSString).range(of: "intro").location
+        XCTAssertGreaterThan(introLocation, 0, "expected a leading margin spacer")
+
+        let markdown = MarkdownExtractor.markdown(
+            for: NSRange(location: introLocation, length: rendered.length - introLocation),
+            in: rendered,
+            sourceMarkdown: source
+        )
+
+        XCTAssertEqual(markdown, source)
+    }
+
+    /// A selection that excludes real text must not take the verbatim
+    /// shortcut.
+    func testPartialSelectionDoesNotReturnFullSource() {
+        let source = "first paragraph\n\nsecond paragraph"
+        let rendered = render(source)
+        let firstRange = (rendered.string as NSString).range(of: "first paragraph")
+
+        let markdown = MarkdownExtractor.markdown(
+            for: firstRange,
+            in: rendered,
+            sourceMarkdown: source
+        )
+
+        XCTAssertEqual(markdown, "first paragraph")
+    }
+
+    func testSelectionMenuOffersCopyMarkdownForTableSelection() {
+        let rendered = render("| A | B |\n|---|---|\n| one | two |")
+        let range = (rendered.string as NSString).range(of: "\u{FFFC}")
+
+        let specs = SelectionMenuItems.build(
+            config: MarkdownSelectionMenuConfig(),
+            selectedRange: range,
+            attributedText: rendered,
+            sourceMarkdown: nil
+        )
+
+        let copyMarkdown = specs.first { $0.kind == .copyMarkdown }
+        XCTAssertNotNil(copyMarkdown)
+        XCTAssertTrue(copyMarkdown?.pasteboardString.contains("| one | two |") == true)
+    }
+
     // MARK: - Invalid input
 
     func testReturnsNilForEmptyRange() {

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/TableThemingTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/TableThemingTests.swift
@@ -1,0 +1,258 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+@MainActor
+final class TableThemingTests: XCTestCase {
+    private let tableMarkdown = "| Name | Score | Notes |\n|:-----|:-----:|------:|\n"
+        + "| alpha | ten | [docs](https://example.com) |\n| bravo | twelve | plain |"
+
+    private func attachment(
+        for markdown: String,
+        config: MarkdownStyleConfig = .baseline()
+    ) -> TableAttachment? {
+        let rendered = MarkdownRenderer.render(markdown, config: config)
+        var found: TableAttachment?
+        rendered.enumerateAttribute(.attachment, in: NSRange(location: 0, length: rendered.length)) { value, _, _ in
+            if let table = value as? TableAttachment { found = table }
+        }
+        return found
+    }
+
+    // MARK: - Theme element
+
+    func testTableThemeElementAppliesToConfig() {
+        var config = MarkdownStyleConfig()
+        Table()
+            .fontSize(15)
+            .lineHeight(22)
+            .foregroundStyle(Color(UIColor.systemRed))
+            .headerTextColor(Color(UIColor.systemBlue))
+            .headerBackground(Color(UIColor.systemGreen))
+            .rowEvenBackground(Color(UIColor.systemYellow))
+            .rowOddBackground(Color(UIColor.systemOrange))
+            .borderColor(Color(UIColor.systemPurple))
+            .borderWidth(2)
+            .cornerRadius(9)
+            .cellPaddingHorizontal(20)
+            .cellPaddingVertical(10)
+            .marginTop(4)
+            .marginBottom(24)
+            .align(.center)
+            .apply(to: &config, traitCollection: .current)
+
+        XCTAssertEqual(config.table.font?.pointSize, 15)
+        XCTAssertEqual(config.table.lineHeight, 22)
+        XCTAssertNotNil(config.table.foregroundColor)
+        XCTAssertNotNil(config.table.headerTextColor)
+        XCTAssertNotNil(config.table.headerBackgroundColor)
+        XCTAssertNotNil(config.table.rowEvenBackgroundColor)
+        XCTAssertNotNil(config.table.rowOddBackgroundColor)
+        XCTAssertNotNil(config.table.borderColor)
+        XCTAssertEqual(config.table.borderWidth, 2)
+        XCTAssertEqual(config.table.borderRadius, 9)
+        XCTAssertEqual(config.table.cellPaddingHorizontal, 20)
+        XCTAssertEqual(config.table.cellPaddingVertical, 10)
+        XCTAssertEqual(config.table.marginTop, 4)
+        XCTAssertEqual(config.table.marginBottom, 24)
+        XCTAssertEqual(config.table.align, .center)
+    }
+
+    func testDefaultThemeTableColorsAdaptToDarkMode() {
+        let light = MarkdownStyleConfig.resolve(
+            layers: [.default],
+            traitCollection: UITraitCollection(userInterfaceStyle: .light)
+        )
+        let dark = MarkdownStyleConfig.resolve(
+            layers: [.default],
+            traitCollection: UITraitCollection(userInterfaceStyle: .dark)
+        )
+
+        XCTAssertNotEqual(light.table.headerBackgroundColor, dark.table.headerBackgroundColor)
+        XCTAssertNotEqual(light.table.borderColor, dark.table.borderColor)
+        XCTAssertNotEqual(light.table.foregroundColor, dark.table.foregroundColor)
+    }
+
+    func testConfigDrivesAttachmentStyle() {
+        var config = MarkdownStyleConfig.baseline()
+        config.table.cellPaddingHorizontal = 20
+        config.table.borderWidth = 3
+        config.table.align = .trailing
+
+        let table = attachment(for: tableMarkdown, config: config)
+
+        XCTAssertEqual(table?.style.cellPaddingHorizontal, 20)
+        XCTAssertEqual(table?.style.borderWidth, 3)
+        XCTAssertEqual(table?.style.align, .trailing)
+    }
+
+    // MARK: - Cell styling
+
+    func testCellAlignmentAndLineHeightApplied() {
+        guard let table = attachment(for: tableMarkdown) else { return XCTFail("no table") }
+
+        // Column 1 is center-aligned, column 2 right-aligned; every cell
+        // carries the default 20pt line height.
+        let centerCell = table.model.rows[1][1].attributedText
+        let rightCell = table.model.rows[1][2].attributedText
+        let centerStyle = centerCell.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        let rightStyle = rightCell.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+
+        XCTAssertEqual(centerStyle?.alignment, .center)
+        XCTAssertEqual(rightStyle?.alignment, .right)
+        XCTAssertEqual(centerStyle?.minimumLineHeight, 20)
+        XCTAssertEqual(centerStyle?.maximumLineHeight, 20)
+    }
+
+    func testHeaderCellsUseBoldFont() {
+        guard let table = attachment(for: tableMarkdown) else { return XCTFail("no table") }
+
+        let headerFont = table.model.rows[0][0].attributedText
+            .attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        let bodyFont = table.model.rows[1][0].attributedText
+            .attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+
+        XCTAssertEqual(headerFont?.fontDescriptor.symbolicTraits.contains(.traitBold), true)
+        XCTAssertEqual(bodyFont?.fontDescriptor.symbolicTraits.contains(.traitBold), false)
+    }
+
+    // MARK: - Copy
+
+    func testPlainTextJoinsCellsWithTabsAndNewlines() {
+        guard let table = attachment(for: tableMarkdown) else { return XCTFail("no table") }
+
+        let plain = table.plainText()
+        XCTAssertTrue(plain.contains("Name\tScore\tNotes"))
+        XCTAssertTrue(plain.contains("bravo\ttwelve\tplain"))
+        XCTAssertEqual(plain.components(separatedBy: "\n").count, 3)
+    }
+
+    func testMarkdownTextRebuildsPipeTableWithAlignments() {
+        guard let table = attachment(for: tableMarkdown) else { return XCTFail("no table") }
+
+        let markdown = table.markdownText()
+        let lines = markdown.components(separatedBy: "\n")
+        XCTAssertEqual(lines.count, 4)
+        XCTAssertEqual(lines[0], "| Name | Score | Notes |")
+        XCTAssertEqual(lines[1], "| :--- | :---: | ---: |")
+        // Inline markdown inside cells is restored, not flattened.
+        XCTAssertEqual(lines[2], "| alpha | ten | [docs](https://example.com) |")
+    }
+
+    func testMarkdownTextRestoresInlineFormatting() {
+        guard let table = attachment(
+            for: "| A | B |\n|---|---|\n| **bold** and `code` | *it* ~~gone~~ |"
+        ) else { return XCTFail("no table") }
+
+        let markdown = table.markdownText()
+        XCTAssertTrue(markdown.contains("| **bold** and `code` | *it* ~~gone~~ |"))
+    }
+
+    func testCopyPlainTextReplacesTableCharacter() {
+        let rendered = MarkdownRenderer.render(
+            "before\n\n\(tableMarkdown)\n\nafter",
+            config: .baseline()
+        )
+        let plain = MarkdownTextView.plainText(
+            of: rendered,
+            in: NSRange(location: 0, length: rendered.length)
+        )
+
+        XCTAssertFalse(plain.contains("\u{FFFC}"))
+        XCTAssertTrue(plain.contains("Name\tScore\tNotes"))
+        XCTAssertTrue(plain.contains("before"))
+        XCTAssertTrue(plain.contains("after"))
+    }
+
+    // MARK: - Accessibility
+
+    func testTableRowsBecomeAccessibilityElements() {
+        let rendered = MarkdownRenderer.render(tableMarkdown, config: .baseline())
+        let specs = MarkdownAccessibilityElementBuilder.specs(for: rendered)
+
+        let rowSpecs = specs.filter {
+            if case .tableRow = $0.kind { return true }
+            return false
+        }
+        XCTAssertEqual(rowSpecs.count, 3)
+        XCTAssertTrue(rowSpecs[0].label.hasPrefix("Row 1: Name, Score, Notes"))
+        guard case .tableRow(let offset0, let height0, let isHeader0) = rowSpecs[0].kind,
+              case .tableRow(let offset1, _, let isHeader1) = rowSpecs[1].kind else {
+            return XCTFail("expected table row kinds")
+        }
+        XCTAssertTrue(isHeader0)
+        XCTAssertFalse(isHeader1)
+        XCTAssertEqual(offset0, 0)
+        XCTAssertEqual(offset1, height0)
+    }
+
+    // MARK: - Link hit test
+
+    func testLinkURLResolvesInsideLinkedCell() {
+        guard let table = attachment(for: tableMarkdown) else { return XCTFail("no table") }
+        let gridView = TableGridView(model: table.model, layout: table.layout, style: table.style)
+        gridView.frame = CGRect(x: 0, y: 0, width: table.layout.totalWidth, height: table.layout.totalHeight)
+
+        // The link sits in row 1 (first body row), column 2.
+        let xOffset = table.layout.columnWidths[0] + table.layout.columnWidths[1]
+        let yOffset = table.layout.rowHeights[0]
+        let point = CGPoint(
+            x: xOffset + table.style.cellPaddingHorizontal + 8,
+            y: yOffset + table.style.cellPaddingVertical + 8
+        )
+
+        XCTAssertEqual(gridView.linkURL(at: point), URL(string: "https://example.com"))
+        XCTAssertNil(gridView.linkURL(at: CGPoint(x: 5, y: 5)))
+    }
+
+    // MARK: - Align placement
+
+    func testCenterAlignPositionsGridWhenTableFits() {
+        var config = MarkdownStyleConfig.baseline()
+        config.table.align = .center
+        guard let table = attachment(for: "| A |\n|---|\n| x |", config: config) else {
+            return XCTFail("no table")
+        }
+
+        let view = TableAttachmentView(attachment: table)
+        view.frame = CGRect(x: 0, y: 0, width: 400, height: table.layout.totalHeight)
+        view.layoutIfNeeded()
+
+        guard let grid = findGridView(in: view) else { return XCTFail("no grid view") }
+        let expectedX = (400 - table.layout.totalWidth) / 2
+        XCTAssertEqual(grid.frame.minX, expectedX, accuracy: 0.5)
+    }
+
+    func testScrollOffsetPersistsOnAttachment() {
+        guard let table = attachment(
+            for: "| A | B | C | D | E | F | G |\n|---|---|---|---|---|---|---|\n| one | two | three | four | five | six | seven |"
+        ) else { return XCTFail("no table") }
+        XCTAssertGreaterThan(table.layout.totalWidth, 300)
+
+        let view = TableAttachmentView(attachment: table)
+        view.frame = CGRect(x: 0, y: 0, width: 300, height: table.layout.totalHeight)
+        view.layoutIfNeeded()
+
+        guard let scrollView = view.subviews.compactMap({ $0 as? UIScrollView }).first else {
+            return XCTFail("no scroll view")
+        }
+        scrollView.contentOffset = CGPoint(x: 42, y: 0)
+        XCTAssertEqual(table.preservedContentOffset.x, 42)
+
+        // A recreated view (viewport re-entry) restores the offset.
+        let recreated = TableAttachmentView(attachment: table)
+        recreated.frame = CGRect(x: 0, y: 0, width: 300, height: table.layout.totalHeight)
+        recreated.layoutIfNeeded()
+        let recreatedScroll = recreated.subviews.compactMap { $0 as? UIScrollView }.first
+        XCTAssertEqual(recreatedScroll?.contentOffset.x, 42)
+    }
+
+    private func findGridView(in view: UIView) -> TableGridView? {
+        if let grid = view as? TableGridView { return grid }
+        for subview in view.subviews {
+            if let found = findGridView(in: subview) { return found }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Tables now resolve their appearance from the theme: a Table element and TableStyle expose the RN keys (header colors, row striping, borders, corner radius, cell padding, margins, line height, whole-table align), with dark-mode-aware defaults built on dynamic system colors replacing the spike's fixed light palette. Cell fonts inherit the paragraph family at 14pt unless themed.

Interactions and integration:
- Links inside cells are tappable (grid hit test over the drawing geometry, routed to onLinkPress with a system-open fallback).
- Long-pressing a table offers Copy and Copy as Markdown; the markdown path rebuilds the pipe table with alignment separators and restores inline markers in cells via the extractor's inline formatting.
- Selection-based copies now include tables: the extractor emits the same pipe-table markdown for table attachments, plain-text copy replaces the attachment character with tab-separated cells, and the HTML flavor emits a semantic table. Whole-document selections return the original source verbatim even when they start after a leading margin spacer.
- VoiceOver exposes one element per row with the header trait on the header row, framed by slicing the attachment frame per row.
- A horizontally scrolled wide table keeps its position when TextKit recreates the provider view on viewport re-entry.

Deferred: horizontalOverflow bleed and headerFontFamily.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

