### PR TITLE
feat(ios): theme table header fonts and document GFM support

### DIFF
--- a/packages/enriched-markdown-ios/README.md
+++ b/packages/enriched-markdown-ios/README.md
@@ -148,6 +148,7 @@ The `MarkdownTheme` builder supports these elements:
 | `Blockquote()` | Block quotes |
 | `List()` | Ordered and unordered lists |
 | `TaskList()` | Task-list checkboxes (`- [x]`) |
+| `Table()` | GFM tables |
 | `BlockImage()` | Block images |
 | `InlineImage()` | Inline images |
 | `ThematicBreak()` | Horizontal rules |
@@ -163,6 +164,7 @@ Element-specific modifiers include:
 - **CodeBlock / Blockquote:** `.borderColor`, `.borderWidth`, `.padding` / `.gapWidth`, `.cornerRadius` / `.borderRadius`
 - **List:** `.bulletColor`, `.markerColor`, `.bulletSize`, `.markerMinWidth`, `.gapWidth`, `.marginLeft`
 - **TaskList:** `.checkedColor`, `.borderColor`, `.checkmarkColor`, `.checkboxSize`, `.checkboxBorderRadius`, `.checkedTextColor`, `.checkedStrikethrough`
+- **Table:** `.headerFontFamily(_:size:)`, `.headerTextColor`, `.headerBackground`, `.rowEvenBackground`, `.rowOddBackground`, `.borderColor`, `.borderWidth`, `.cornerRadius` / `.borderRadius`, `.cellPaddingHorizontal`, `.cellPaddingVertical`, `.align`
 - **BlockImage:** `.height`, `.borderRadius`
 - **InlineImage:** `.size`
 - **ThematicBreak:** `.color` / `.foregroundStyle`, `.height`
@@ -200,7 +202,7 @@ public struct Md4cFlags: Equatable, Sendable {
 }
 ```
 
-`underline`, `hardSoftBreaks`, and `permissiveAutolinks` affect rendering. The remaining flags gate parsing only — their content currently renders as plain text.
+`underline`, `hardSoftBreaks`, and `permissiveAutolinks` affect rendering. The remaining flags gate parsing only — their content currently renders as plain text. Tables, task lists, and strikethrough are always enabled and need no flags.
 
 ### `.markdownTheme`
 
@@ -320,6 +322,24 @@ VoiceOver walks the rendered markdown as individual elements rather than one tex
 
 Dynamic Type is supported throughout via text styles in the default theme.
 
+## Tables
+
+GFM tables render as live views inside the text: columns size to their
+content (wrapping long cells), and a table wider than the view scrolls
+horizontally in place. Cells support inline styling — bold, italic, code,
+strikethrough, and tappable links.
+
+Long-pressing a table offers **Copy** (tab-separated text) and **Copy as
+Markdown** (the pipe table rebuilt with alignment separators and inline
+markers). Text selection treats a table as a single character; copying a
+selection that spans one produces the table as tab-separated text, a
+semantic `<table>` in the HTML flavor, and the pipe table in
+markdown-based copies. VoiceOver reads one element per row.
+
+Styling comes from the `Table()` theme element (header colors, row
+striping, borders, cell padding, alignment); the defaults adapt to light
+and dark mode.
+
 ## Supported Markdown
 
 - Headings (`#`–`######`)
@@ -331,6 +351,7 @@ Dynamic Type is supported throughout via text styles in the default theme.
 - Block quotes
 - Ordered and unordered lists
 - Task lists (`- [x]` / `- [ ]`, display-only checkboxes)
+- Tables (GFM: column alignment, per-cell wrapping, horizontal scrolling)
 - Links and images (block and inline)
 - Autolinked bare URLs, `www.` links, and emails (`permissiveAutolinks`, on by default)
 - Thematic breaks (`---`)

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Attachments/TableAttachment.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Attachments/TableAttachment.swift
@@ -24,6 +24,7 @@ struct TableAttachmentStyle: Equatable {
     static let `default` = TableAttachmentStyle()
 
     var font: UIFont?
+    var headerFont: UIFont?
     var fontSize: CGFloat = 14
     var lineHeight: CGFloat = 20
     var textColor = UIColor.label
@@ -64,6 +65,7 @@ struct TableAttachmentStyle: Equatable {
             font = value
             fontSize = value.pointSize
         }
+        if let value = table.headerFont { headerFont = value }
         if let value = table.lineHeight { lineHeight = value }
         if let value = table.borderWidth { borderWidth = value }
         if let value = table.borderRadius { cornerRadius = value }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/TableRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/TableRenderer.swift
@@ -85,10 +85,11 @@ final class TableRenderer: NodeRenderer {
         let base = style.font
             ?? (config.paragraph.font ?? UIFont.preferredFont(forTextStyle: .body)).withSize(style.fontSize)
         guard isHeader else { return base }
-        guard let boldDescriptor = base.fontDescriptor.withSymbolicTraits(.traitBold) else {
-            return base
+        let headerBase = style.headerFont ?? base
+        guard let boldDescriptor = headerBase.fontDescriptor.withSymbolicTraits(.traitBold) else {
+            return headerBase
         }
-        return UIFont(descriptor: boldDescriptor, size: base.pointSize)
+        return UIFont(descriptor: boldDescriptor, size: headerBase.pointSize)
     }
 
     private func applyParagraphStyle(

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/Table.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/Table.swift
@@ -4,6 +4,7 @@ public struct Table: MarkdownThemeElement {
     public var fontSpec: ThemeFontSpec?
     public var fontWeight: Font.Weight?
     public var fontDesign: Font.Design?
+    public var headerFontSpec: ThemeFontSpec?
     public var foregroundColorSpec: ThemeColorSpec?
     public var headerTextColorSpec: ThemeColorSpec?
     public var headerBackgroundColorSpec: ThemeColorSpec?
@@ -21,6 +22,12 @@ public struct Table: MarkdownThemeElement {
     public var align: TableAlignment?
 
     public init() {}
+
+    public func headerFontFamily(_ name: String, size: CGFloat) -> Self {
+        var copy = self
+        copy.headerFontSpec = .custom(name: name, size: size)
+        return copy
+    }
 
     public func headerTextColor(_ color: Color) -> Self {
         var copy = self
@@ -149,6 +156,15 @@ public struct Table: MarkdownThemeElement {
                 weight: fontWeight,
                 design: fontDesign,
                 to: config.table.font,
+                traitCollection: traitCollection
+            )
+        }
+        if headerFontSpec != nil {
+            config.table.headerFont = ThemeResolver.applyFont(
+                spec: headerFontSpec,
+                weight: nil,
+                design: nil,
+                to: config.table.headerFont,
                 traitCollection: traitCollection
             )
         }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
@@ -304,6 +304,7 @@ public struct TableStyle: Equatable, Sendable {
     public var font: UIFont?
     public var foregroundColor: UIColor?
     public var lineHeight: CGFloat?
+    public var headerFont: UIFont?
     public var headerTextColor: UIColor?
     public var headerBackgroundColor: UIColor?
     public var rowEvenBackgroundColor: UIColor?
@@ -321,6 +322,7 @@ public struct TableStyle: Equatable, Sendable {
         font: UIFont? = nil,
         foregroundColor: UIColor? = nil,
         lineHeight: CGFloat? = nil,
+        headerFont: UIFont? = nil,
         headerTextColor: UIColor? = nil,
         headerBackgroundColor: UIColor? = nil,
         rowEvenBackgroundColor: UIColor? = nil,
@@ -337,6 +339,7 @@ public struct TableStyle: Equatable, Sendable {
         self.font = font
         self.foregroundColor = foregroundColor
         self.lineHeight = lineHeight
+        self.headerFont = headerFont
         self.headerTextColor = headerTextColor
         self.headerBackgroundColor = headerBackgroundColor
         self.rowEvenBackgroundColor = rowEvenBackgroundColor
@@ -355,6 +358,7 @@ public struct TableStyle: Equatable, Sendable {
         font = other.font ?? font
         foregroundColor = other.foregroundColor ?? foregroundColor
         lineHeight = other.lineHeight ?? lineHeight
+        headerFont = other.headerFont ?? headerFont
         headerTextColor = other.headerTextColor ?? headerTextColor
         headerBackgroundColor = other.headerBackgroundColor ?? headerBackgroundColor
         rowEvenBackgroundColor = other.rowEvenBackgroundColor ?? rowEvenBackgroundColor

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/TableThemingTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/TableThemingTests.swift
@@ -105,6 +105,27 @@ final class TableThemingTests: XCTestCase {
         XCTAssertEqual(centerStyle?.maximumLineHeight, 20)
     }
 
+    func testHeaderFontFamilyOverridesHeaderCellsOnly() {
+        var config = MarkdownStyleConfig.baseline()
+        Table()
+            .headerFontFamily("Helvetica", size: 13)
+            .apply(to: &config, traitCollection: .current)
+        XCTAssertEqual(config.table.headerFont?.familyName, "Helvetica")
+        XCTAssertEqual(config.table.headerFont?.pointSize, 13)
+
+        guard let table = attachment(for: tableMarkdown, config: config) else {
+            return XCTFail("no table")
+        }
+        let headerFont = table.model.rows[0][0].attributedText
+            .attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        let bodyFont = table.model.rows[1][0].attributedText
+            .attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+
+        XCTAssertEqual(headerFont?.familyName, "Helvetica")
+        XCTAssertEqual(headerFont?.fontDescriptor.symbolicTraits.contains(.traitBold), true)
+        XCTAssertNotEqual(bodyFont?.familyName, "Helvetica")
+    }
+
     func testHeaderCellsUseBoldFont() {
         guard let table = attachment(for: tableMarkdown) else { return XCTFail("no table") }
 


### PR DESCRIPTION
Adds the last easy TableStyle parity key from the React Native package: headerFont in the config and a headerFontFamily(_:size:) modifier on the Table element. Header cells render as the bold face of the header font, falling back to the cell font when unset.

README: tables join the supported-markdown list and the theme-element docs, a Tables section describes rendering, copying, selection, and VoiceOver behavior, and the Md4cFlags notes clarify that tables, task lists, and strikethrough are always enabled.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

