### PR TITLE
fix(android): add missing closing brace in setEnableImagePress

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -186,6 +186,7 @@ class EnrichedMarkdownManager :
     enableImagePress: Boolean,
   ) {
     view?.setEnableImagePress(enableImagePress)
+  }
 
   @ReactProp(name = "enableBlockContextMenu", defaultBoolean = true)
   override fun setEnableBlockContextMenu(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -188,6 +188,7 @@ class EnrichedMarkdownTextManager :
     enableImagePress: Boolean,
   ) {
     view?.setEnableImagePress(enableImagePress)
+  }
 
   @ReactProp(name = "enableBlockContextMenu", defaultBoolean = true)
   override fun setEnableBlockContextMenu(


### PR DESCRIPTION
## Summary

- Both `EnrichedMarkdownManager.kt` and `EnrichedMarkdownTextManager.kt` were missing the closing `}` for `setEnableImagePress`, causing every subsequent method to be parsed as a local function inside it.
- This broke the Android build with cascading errors: "override not applicable to local function", "unresolved reference NAME", and "class is not abstract and does not implement abstract members".

## Test plan

- [ ] Verify Android debug build succeeds (`./gradlew app:assembleDebug`)
- [ ] Verify the app launches and image press behavior works correctly on Android


Made with [Cursor](https://cursor.com)